### PR TITLE
One liners to correct register designation in rvc-instr-table

### DIFF
--- a/src/rvc-instr-table.tex
+++ b/src/rvc-instr-table.tex
@@ -198,7 +198,7 @@
 &
 \multicolumn{3}{|c|}{010} &
 \multicolumn{1}{c|}{imm[5]} &
-\multicolumn{5}{c|}{rs1/rd$\neq$0} &
+\multicolumn{5}{c|}{rd$\neq$0} &
 \multicolumn{5}{c|}{imm[4:0]} &
 \multicolumn{2}{c|}{01} & C.LI {\em \tiny (HINT, rd=0)} \\
 \whline{2-17}
@@ -214,7 +214,7 @@
 &
 \multicolumn{3}{|c|}{011} &
 \multicolumn{1}{c|}{nzimm[17]} &
-\multicolumn{5}{c|}{rs1/rd$\neq$$\{0,2\}$} &
+\multicolumn{5}{c|}{rd$\neq$$\{0,2\}$} &
 \multicolumn{5}{c|}{nzimm[16:12]} &
 \multicolumn{2}{c|}{01} & C.LUI {\em \tiny (RES, nzimm=0; HINT, rd=0)}\\
 \whline{2-17}
@@ -489,7 +489,7 @@
 &
 \multicolumn{3}{|c|}{100} &
 \multicolumn{1}{c|}{1} &
-\multicolumn{5}{c|}{rd$\neq$0} &
+\multicolumn{5}{c|}{r1/rd$\neq$0} &
 \multicolumn{5}{c|}{rs2$\neq$0} &
 \multicolumn{2}{c|}{10} & C.ADD {\em \tiny (HINT, rd=0)} \\
 \whline{2-17}


### PR DESCRIPTION
No initial register value is not used by C.LI, so only rd is valid.

No initial register value is not used by C.LUI, so only rd is valid.

Both r1 and rd are set by the C.ADD expansion (to the same register id)