### PR TITLE
Make two's complement explicit early on (in introduction).

### DIFF
--- a/src/intro.tex
+++ b/src/intro.tex
@@ -217,8 +217,8 @@ systems (with additional supervisor-level operations), and so provides
 a convenient ISA and software toolchain ``skeleton'' around which more
 customized processor ISAs can be built.
 
-Each base integer instruction set is characterized by the width of the
-integer registers and the corresponding size of the user address
+Each base integer instruction set is characterized by the width of the two's
+complement integer registers and the corresponding size of the user address
 space.  There are two primary base integer variants, RV32I and RV64I,
 described in Chapters~\ref{rv32} and \ref{rv64}, which provide 32-bit
 or 64-bit user-level address spaces respectively.  Hardware


### PR DESCRIPTION
Two's complement is implicit elsewhere in the document;
Technically, operations define the encoding type,
and two's complement is almost universal,
but it still is valuable to make the sign encoding explicit (IMO).