### PR TITLE
Cimm

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -827,7 +827,7 @@ is always 16-byte aligned.
 \multicolumn{1}{c|}{op} \\
 \hline
 3 & 8 & 3 & 2 \\
-C.ADDI4SPN & zimm[5:4$\vert$9:6$\vert$2$\vert$3] & dest & C0 \\
+C.ADDI4SPN & nzuimm[5:4$\vert$9:6$\vert$2$\vert$3] & dest & C0 \\
 \end{tabular}
 \end{center}
 
@@ -835,7 +835,7 @@ C.ADDI4SPN is a CIW-format RV32C/RV64C-only instruction that adds a
 {\em zero}-extended non-zero immediate, scaled by 4, to the stack pointer,
 {\tt x2}, and writes the result to {\tt rd$'$}.  This instruction is used
 to generate pointers to stack-allocated variables, and expands to
-{\tt addi rd$'$, x2, zimm[9:2]}.
+{\tt addi rd$'$, x2, uimm[9:2]}.
 
 
 \vspace{-0.4in}
@@ -1163,4 +1163,11 @@ to register {\tt x0}, which will have no effect.
 \input{rvc-opcode-map}
 
 Tables~\ref{rvc-instr-table0}--\ref{rvc-instr-table2} list the RVC instructions.
+
+for the immediate values:
+\\    simm  - sign extended (instruction bit 12 is always the sign)
+\\    uimm  - unsigned zero extended
+\\    shamt - shift amount 
+\\    nzsimm, nzuimm and nzshamt are corresponding values that all bits must not be zero.
+
 \input{rvc-instr-table}

--- a/src/rvc-instr-table.tex
+++ b/src/rvc-instr-table.tex
@@ -33,52 +33,52 @@
 
 &
 \multicolumn{3}{|c|}{000} &
-\multicolumn{8}{c|}{nzimm[5:4$\vert$9:6$\vert$2$\vert$3]} &
+\multicolumn{8}{c|}{nzuimm[5:4$\vert$9:6$\vert$2$\vert$3]} &
 \multicolumn{3}{c|}{rd$'$} &
-\multicolumn{2}{c|}{00} & C.ADDI4SPN {\em \tiny (RES, nzimm=0)} \\
+\multicolumn{2}{c|}{00} & C.ADDI4SPN {\em \tiny (RES, nzuimm=0)} \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{001} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rd$'$} &
 \multicolumn{2}{c|}{00} & C.FLD {\em \tiny (RV32/64)}\\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{001} &
-\multicolumn{3}{c|}{imm[5:4$\vert$8]} &
+\multicolumn{3}{c|}{uimm[5:4$\vert$8]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rd$'$} &
 \multicolumn{2}{c|}{00} & C.LQ {\em \tiny (RV128)}\\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{010} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[2$\vert$6]} &
+\multicolumn{2}{c|}{uimm[2$\vert$6]} &
 \multicolumn{3}{c|}{rd$'$} &
 \multicolumn{2}{c|}{00} & C.LW \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[2$\vert$6]} &
+\multicolumn{2}{c|}{uimm[2$\vert$6]} &
 \multicolumn{3}{c|}{rd$'$} &
 \multicolumn{2}{c|}{00} & C.FLW {\em \tiny (RV32)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rd$'$} &
 \multicolumn{2}{c|}{00} & C.LD {\em \tiny (RV64/128)}\\
 \whline{2-17}
@@ -91,45 +91,45 @@
 
 &
 \multicolumn{3}{|c|}{101} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{00} & C.FSD {\em \tiny (RV32/64)}\\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{101} &
-\multicolumn{3}{c|}{imm[5:4$\vert$8]} &
+\multicolumn{3}{c|}{uimm[5:4$\vert$8]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{00} & C.SQ {\em \tiny (RV128)}\\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{110} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[2$\vert$6]} &
+\multicolumn{2}{c|}{uimm[2$\vert$6]} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{00} & C.SW \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{111} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[2$\vert$6]} &
+\multicolumn{2}{c|}{uimm[2$\vert$6]} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{00} & C.FSW {\em \tiny (RV32)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{111} &
-\multicolumn{3}{c|}{imm[5:3]} &
+\multicolumn{3}{c|}{uimm[5:3]} &
 \multicolumn{3}{c|}{rs1$'$} &
-\multicolumn{2}{c|}{imm[7:6]} &
+\multicolumn{2}{c|}{uimm[7:6]} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{00} & C.SD {\em \tiny (RV64/128)}\\
 \cline{2-17}
@@ -175,10 +175,10 @@
 
 &
 \multicolumn{3}{|c|}{000} &
-\multicolumn{1}{c|}{nzimm[5]} &
+\multicolumn{1}{c|}{nzsimm[5]} &
 \multicolumn{5}{c|}{rs1/rd$\neq$0} &
-\multicolumn{5}{c|}{nzimm[4:0]} &
-\multicolumn{2}{c|}{01} & C.ADDI {\em \tiny (HINT, nzimm=0)} \\
+\multicolumn{5}{c|}{nzsimm[4:0]} &
+\multicolumn{2}{c|}{01} & C.ADDI {\em \tiny (HINT, nzsimm=0)} \\
 \whline{2-17}
 
 &
@@ -189,43 +189,43 @@
 
 &
 \multicolumn{3}{|c|}{001} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{simm[5]} &
 \multicolumn{5}{c|}{rs1/rd$\neq$0} &
-\multicolumn{5}{c|}{imm[4:0]} &
+\multicolumn{5}{c|}{simm[4:0]} &
 \multicolumn{2}{c|}{01} & C.ADDIW {\em \tiny (RV64/128; RES, rd=0)} \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{010} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{simm[5]} &
 \multicolumn{5}{c|}{rd$\neq$0} &
-\multicolumn{5}{c|}{imm[4:0]} &
+\multicolumn{5}{c|}{simm[4:0]} &
 \multicolumn{2}{c|}{01} & C.LI {\em \tiny (HINT, rd=0)} \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{1}{c|}{nzimm[9]} &
+\multicolumn{1}{c|}{nzsimm[9]} &
 \multicolumn{5}{c|}{2} &
-\multicolumn{5}{c|}{nzimm[4$\vert$6$\vert$8:7$\vert$5]} &
-\multicolumn{2}{c|}{01} & C.ADDI16SP {\em \tiny (RES, nzimm=0)} \\
+\multicolumn{5}{c|}{nzsimm[4$\vert$6$\vert$8:7$\vert$5]} &
+\multicolumn{2}{c|}{01} & C.ADDI16SP {\em \tiny (RES, nzsimm=0)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{1}{c|}{nzimm[17]} &
+\multicolumn{1}{c|}{nzsimm[17]} &
 \multicolumn{5}{c|}{rd$\neq$$\{0,2\}$} &
-\multicolumn{5}{c|}{nzimm[16:12]} &
-\multicolumn{2}{c|}{01} & C.LUI {\em \tiny (RES, nzimm=0; HINT, rd=0)}\\
+\multicolumn{5}{c|}{nzsimm[16:12]} &
+\multicolumn{2}{c|}{01} & C.LUI {\em \tiny (RES, nzsimm=0; HINT, rd=0)}\\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{100} &
-\multicolumn{1}{c|}{nzimm[5]} &
+\multicolumn{1}{c|}{nzshamt[5]} &
 \multicolumn{2}{c|}{00} &
 \multicolumn{3}{c|}{rs1$'$/rd$'$} &
-\multicolumn{5}{c|}{nzimm[4:0]} &
-\multicolumn{2}{c|}{01} & C.SRLI {\em \tiny (RV32 NSE, nzimm[5]=1)} \\
+\multicolumn{5}{c|}{nzshamt[4:0]} &
+\multicolumn{2}{c|}{01} & C.SRLI {\em \tiny (RV32 NSE, nzshamt[5]=1)} \\
 \cline{2-17}
 
 &
@@ -239,11 +239,11 @@
 
 &
 \multicolumn{3}{|c|}{100} &
-\multicolumn{1}{c|}{nzimm[5]} &
+\multicolumn{1}{c|}{nzshamt[5]} &
 \multicolumn{2}{c|}{01} &
 \multicolumn{3}{c|}{rs1$'$/rd$'$} &
-\multicolumn{5}{c|}{nzimm[4:0]} &
-\multicolumn{2}{c|}{01} & C.SRAI {\em \tiny (RV32 NSE, nzimm[5]=1)} \\
+\multicolumn{5}{c|}{nzshamt[4:0]} &
+\multicolumn{2}{c|}{01} & C.SRAI {\em \tiny (RV32 NSE, nzshamt[5]=1)} \\
 \cline{2-17}
 
 &
@@ -257,10 +257,10 @@
 
 &
 \multicolumn{3}{|c|}{100} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{simm[5]} &
 \multicolumn{2}{c|}{10} &
 \multicolumn{3}{c|}{rs1$'$/rd$'$} &
-\multicolumn{5}{c|}{imm[4:0]} &
+\multicolumn{5}{c|}{simm[4:0]} &
 \multicolumn{2}{c|}{01} & C.ANDI \\
 \cline{2-17}
 
@@ -400,10 +400,10 @@
 
 &
 \multicolumn{3}{|c|}{000} &
-\multicolumn{1}{c|}{nzimm[5]} &
+\multicolumn{1}{c|}{nzshamt[5]} &
 \multicolumn{5}{c|}{rs1/rd$\neq$0} &
-\multicolumn{5}{c|}{nzimm[4:0]} &
-\multicolumn{2}{c|}{10} & C.SLLI {\em \tiny (HINT, rd=0; RV32 NSE, nzimm[5]=1)} \\
+\multicolumn{5}{c|}{nzshamt[4:0]} &
+\multicolumn{2}{c|}{10} & C.SLLI {\em \tiny (HINT, rd=0; RV32 NSE, nzshamt[5]=1)} \\
 \cline{2-17}
 
 &
@@ -416,41 +416,41 @@
 
 &
 \multicolumn{3}{|c|}{001} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{uimm[5]} &
 \multicolumn{5}{c|}{rd} &
-\multicolumn{5}{c|}{imm[4:3$\vert$8:6]} &
+\multicolumn{5}{c|}{uimm[4:3$\vert$8:6]} &
 \multicolumn{2}{c|}{10} & C.FLDSP {\em \tiny (RV32/64)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{001} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{uimm[5]} &
 \multicolumn{5}{c|}{rd$\neq$0} &
-\multicolumn{5}{c|}{imm[4$\vert$9:6]} &
+\multicolumn{5}{c|}{uimm[4$\vert$9:6]} &
 \multicolumn{2}{c|}{10} & C.LQSP {\em \tiny (RV128; RES, rd=0)} \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{010} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{uimm[5]} &
 \multicolumn{5}{c|}{rd$\neq$0} &
-\multicolumn{5}{c|}{imm[4:2$\vert$7:6]} &
+\multicolumn{5}{c|}{uimm[4:2$\vert$7:6]} &
 \multicolumn{2}{c|}{10} & C.LWSP {\em \tiny (RES, rd=0)} \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{uimm[5]} &
 \multicolumn{5}{c|}{rd} &
-\multicolumn{5}{c|}{imm[4:2$\vert$7:6]} &
+\multicolumn{5}{c|}{uimm[4:2$\vert$7:6]} &
 \multicolumn{2}{c|}{10} & C.FLWSP {\em \tiny (RV32)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{011} &
-\multicolumn{1}{c|}{imm[5]} &
+\multicolumn{1}{c|}{uimm[5]} &
 \multicolumn{5}{c|}{rd$\neq$0} &
-\multicolumn{5}{c|}{imm[4:3$\vert$8:6]} &
+\multicolumn{5}{c|}{uimm[4:3$\vert$8:6]} &
 \multicolumn{2}{c|}{10} & C.LDSP {\em \tiny (RV64/128; RES, rd=0)} \\
 \whline{2-17}
 
@@ -496,35 +496,35 @@
 
 &
 \multicolumn{3}{|c|}{101} &
-\multicolumn{6}{c|}{imm[5:3$\vert$8:6]} &
+\multicolumn{6}{c|}{uimm[5:3$\vert$8:6]} &
 \multicolumn{5}{c|}{rs2} &
 \multicolumn{2}{c|}{10} & C.FSDSP {\em \tiny (RV32/64)}\\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{101} &
-\multicolumn{6}{c|}{imm[5:4$\vert$9:6]} &
+\multicolumn{6}{c|}{uimm[5:4$\vert$9:6]} &
 \multicolumn{5}{c|}{rs2} &
 \multicolumn{2}{c|}{10} & C.SQSP {\em \tiny (RV128)}\\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{110} &
-\multicolumn{6}{c|}{imm[5:2$\vert$7:6]} &
+\multicolumn{6}{c|}{uimm[5:2$\vert$7:6]} &
 \multicolumn{5}{c|}{rs2} &
 \multicolumn{2}{c|}{10} & C.SWSP \\
 \whline{2-17}
 
 &
 \multicolumn{3}{|c|}{111} &
-\multicolumn{6}{c|}{imm[5:2$\vert$7:6]} &
+\multicolumn{6}{c|}{uimm[5:2$\vert$7:6]} &
 \multicolumn{5}{c|}{rs2} &
 \multicolumn{2}{c|}{10} & C.FSWSP {\em \tiny (RV32)} \\
 \cline{2-17}
 
 &
 \multicolumn{3}{|c|}{111} &
-\multicolumn{6}{c|}{imm[5:3$\vert$8:6]} &
+\multicolumn{6}{c|}{uimm[5:3$\vert$8:6]} &
 \multicolumn{5}{c|}{rs2} &
 \multicolumn{2}{c|}{10} & C.SDSP {\em \tiny (RV64/128)}\\
 \cline{2-17}


### PR DESCRIPTION
A preview of what the C instruction format table will look like (offset was not included - I think for consistency it should be. But your call)
for the immediate values:
simm - sign extended (instruction bit 12 is always the sign)
uimm - unsigned zero extended
shamt - shift amount
nzsimm, nzuimm and nzshamt are corresponding values that all bits must not be zero.

I have not revised any C instruction full description other than ADDI16SPN.

I believe there is value in making these codes consistent throughout the C extension document.
But is that scope creep?   
