### PR TITLE
Add ILEN to simplify descriptions of {m,s}tval CSRs

### DIFF
--- a/src/extensions.tex
+++ b/src/extensions.tex
@@ -52,6 +52,15 @@ example, the base ISA is defined within a 30-bit encoding space (bits
 31--2 of the 32-bit instruction), while the atomic extension ``A''
 fits within a 25-bit encoding space (bits 31--7).
 
+We use the term ILEN to refer to the maximum instruction length supported
+by an implementation, which is always a multiple of 16 bits.  For
+implementations supporting only the base instruction set, ILEN is 32 bits.
+Implementations supporting longer instructions have larger values of ILEN.
+ILEN is implied from the set of extensions implemented, or can be
+explicitly defined in the platform configuration if an implementation is
+designed to support an extension that uses longer instructions via software
+emulation but does not actually decode longer instructions in hardware.
+
 We use the term {\em prefix} to refer to the bits to the {\em right}
 of an instruction encoding space (since RISC-V is little-endian, the
 bits to the right are stored at earlier memory addresses, hence form a

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1757,14 +1757,13 @@ written with exception-specific information to assist software in handling the
 trap.  Otherwise, {\tt mtval} is never written by the implementation, though
 it may be explicitly written by software.
 
-When a hardware
-breakpoint is triggered, or an instruction-fetch, load, or store
-address-misaligned, access, or page-fault exception occurs, {\tt mtval} is
-written with the faulting effective address.  On an illegal instruction trap,
-{\tt mtval} is written with the first XLEN bits of the faulting
-instruction as described below.  For other exceptions, {\tt mtval} is
-set to zero, but a future standard may redefine {\tt mtval}'s setting for
-other exceptions.
+When a hardware breakpoint is triggered, or an instruction-fetch, load, or
+store address-misaligned, access, or page-fault exception occurs, {\tt
+  mtval} is written with the faulting effective address.  On an illegal
+instruction trap, {\tt mtval} may be written with the first XLEN or ILEN
+bits of the faulting instruction as described below.  For other exceptions,
+{\tt mtval} is set to zero, but a future standard may redefine {\tt
+  mtval}'s setting for other exceptions.
 
 \begin{commentary}
   The {\tt mtval} register replaces the {\tt mbadaddr} register in
@@ -1811,12 +1810,15 @@ faulting instruction bits on an illegal instruction exception ({\tt
 If this feature is not provided, then {\tt mtval} is set to zero on
 an illegal instruction fault.
 
-If the feature is provided, after an illegal instruction trap, {\tt
-  mtval} will contain the entire faulting instruction provided the
-instruction is no longer than XLEN bits.  If the instruction is less
-than XLEN bits long, the upper bits of {\tt mtval} are cleared to
-zero. If the instruction is more than XLEN bits long, {\tt mtval}
-will contain the first XLEN bits of the instruction.
+If this feature is provided, after an illegal instruction trap, {\tt mtval}
+will contain the shortest of:
+\begin{compactitem}
+\item the actual faulting instruction
+\item the first ILEN bits of the faulting instruction
+\item the first XLEN bits of the faulting instruction
+\end{compactitem}
+The value loaded into {\tt mtval} is right-justified and all unused upper
+bits are cleared to zero.
 
 \begin{commentary}
   Capturing the faulting instruction in {\tt mtval} reduces the

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -11,6 +11,8 @@
 \usepackage{multirow}
 \usepackage{float}
 
+\usepackage[olditem,oldenum]{paralist}
+
 % Setup margins
 
 \setlength{\topmargin}{-0.5in}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -631,13 +631,13 @@ written with exception-specific information to assist software in handling the
 trap.  Otherwise, {\tt stval} is never written by the implementation, though
 it may be explicitly written by software.
 
-When a hardware breakpoint is triggered, or
-an instruction-fetch, load, or store access or page-fault exception occurs,
-or an instruction-fetch or AMO address-misaligned exception occurs,
-{\tt stval} is written with the faulting address.
-For other exceptions, {\tt stval} is
-set to zero, but a future standard may redefine {\tt stval}'s setting for
-other exceptions.
+When a hardware breakpoint is triggered, or an instruction-fetch, load, or
+store access or page-fault exception occurs, or an instruction-fetch or AMO
+address-misaligned exception occurs, {\tt stval} is written with the
+faulting address.  On an illegal instruction trap, {\tt stval} may be
+written with the first XLEN or ILEN bits of the faulting instruction as
+described below.  For other exceptions, {\tt stval} is set to zero, but a
+future standard may redefine {\tt stval}'s setting for other exceptions.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -668,12 +668,15 @@ faulting instruction bits on an illegal instruction exception ({\tt
 If this feature is not provided, then {\tt stval} is set to zero on
 an illegal instruction fault.
 
-If the feature is provided, after an illegal instruction trap, {\tt
-  stval} will contain the entire faulting instruction provided the
-instruction is no longer than XLEN bits.  If the instruction is less
-than XLEN bits long, the upper bits of {\tt stval} are cleared to
-zero. If the instruction is more than XLEN bits long, {\tt stval}
-will contain the first XLEN bits of the instruction.
+If this feature is provided, after an illegal instruction trap, {\tt stval}
+will contain the shortest of:
+\begin{compactitem}
+\item the actual faulting instruction
+\item the first ILEN bits of the faulting instruction
+\item the first XLEN bits of the faulting instruction
+\end{compactitem}
+The value loaded into {\tt stval} is right-justified and all unused upper
+bits are cleared to zero.
 
 {\tt stval} is a \warl\ register that must be able to hold all valid physical
 and virtual addresses and the value 0.  It need not be capable of holding all


### PR DESCRIPTION
PR as requested on isa-dev.  (I finally made a GitHub account for this.)

I had enough difficulty getting the list spacing to look reasonable and ended up with sufficiently different "spacing magic" in machine.tex and supervsior.tex that I added the "paralist" package to get its "compactitem" environment and avoid the whole mess.

I also had to think about where to actually define ILEN, and eventually decided that it makes the most sense in "Extending RISC-V" since it is influenced by support for extensions.