### PR TITLE
Add nag package

### DIFF
--- a/src/riscv-spec.tex
+++ b/src/riscv-spec.tex
@@ -2,6 +2,7 @@
 % riscv-spec.tex
 %-----------------------------------------------------------------------
 
+\RequirePackage[l2tabu,orthodox]{nag}
 \documentclass[twoside,11pt]{book}
 
 \input{preamble}


### PR DESCRIPTION
Old habits die hard. All the same, there are commands, classes and packages which are outdated and superseded. The nag package provides routines to warn the user about the use of such ob­so­lete things.

The `l2tabu` packages warns you about obsolete commands and packages, and demonstrates the most severe mistakes most LaTeX users are prone to make. The orthodox option checks the LaTeX code for syntax that is technically correct, but most likely produces an unwanted result.

The `nag` package is a valuable resource to improving the quality of LaTeX documents.
