### PR TITLE
Fix typo

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -429,7 +429,7 @@ is only the software-writable UEIP bit, ignoring the interrupt value
 from the external interrupt controller.
 
 \begin{commentary}
-  Analogous to SEIP, the UIEP field behavior is designed to allow a
+  Analogous to SEIP, the UEIP field behavior is designed to allow a
   higher privilege layer to mimic external interrupts without losing
   any real external interrupts.
 \end{commentary}


### PR DESCRIPTION
Found this typo while writing a proposal for isa-dev.  A quick search of the PDF did not find any other instances of "IEP".