### PR TITLE
Fix typo in PMP address CSR bit field diagram

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2634,7 +2634,7 @@ space, so the RV64 PMP address registers impose the same limit.
 \multicolumn{1}{|c|}{\wiri} &
 \multicolumn{1}{c|}{address[55:2] (\warl)} \\
 \hline
-32 \\
+10 & 54 \\
 \end{tabular}
 \end{center}
 }


### PR DESCRIPTION
It looks like there was a copy and paste bug between the RV32 and RV64 version of the `pmpaddr` diagram. This changes the diagram to correctly display the bit widths of the fields in RV64.