### PR TITLE
Change remaining SCALL/SBREAK reference to ECALL/EBREAK

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -10,7 +10,7 @@ RV32I was designed to be sufficient to form a compiler target and to
 support modern operating system environments.  The ISA was also
 designed to reduce the hardware required in a minimal implementation.
 RV32I contains 47 unique instructions, though a simple implementation
-might cover the eight SCALL/SBREAK/CSRR* instructions with a single
+might cover the eight ECALL/EBREAK/CSRR* instructions with a single
 SYSTEM hardware instruction that always traps and might be able to
 implement the FENCE and FENCE.I instructions as NOPs, reducing
 hardware instruction count to 38 total.  RV32I can emulate almost any


### PR DESCRIPTION
in RV32I comment.

Signed-off-by: ds2horner <ds2horner@gmail.com>