### PR TITLE
 	Clarify Float Compare description 

### DIFF
--- a/src/f.tex
+++ b/src/f.tex
@@ -658,9 +658,11 @@ for common mixed-format code sequences.
 
 \section{Single-Precision Floating-Point Compare Instructions}
 
-Floating-point compare instructions perform the specified comparison (equal,
-less than, or less than or equal) between floating-point registers {\em rs1}
-and {\em rs2} and record the Boolean result in integer register {\em rd}.
+Floating-point compare instructions (FEQ.S, FLT.S, FLE.S) perform the specified 
+comparison between floating-point registers ($\mbox{\em rs1} = \mbox{\em rs2}$, 
+$\mbox{\em rs1} < \mbox{\em rs2}$, $\mbox{\em rs1} <= \mbox{\em rs2}$)
+writing 1 to the integer register {\em rd}
+if the condition is true, 0 otherwise.
 
 FLT.S and FLE.S perform what the IEEE 754-2008 standard refers to as {\em
 signaling} comparisons: that is, an Invalid Operation exception is raised if

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -10,7 +10,7 @@ RV32I was designed to be sufficient to form a compiler target and to
 support modern operating system environments.  The ISA was also
 designed to reduce the hardware required in a minimal implementation.
 RV32I contains 47 unique instructions, though a simple implementation
-might cover the eight SCALL/SBREAK/CSRR* instructions with a single
+might cover the eight ECALL/EBREAK/CSRR* instructions with a single
 SYSTEM hardware instruction that always traps and might be able to
 implement the FENCE and FENCE.I instructions as NOPs, reducing
 hardware instruction count to 38 total.  RV32I can emulate almost any


### PR DESCRIPTION
Modelled after SLT description:
Make register compare order explicit (rs1 to rs2)
Make Boolean result explicit (1 written if true, zero otherwise).

I considered mentioning that +0 and -0 compare equal, but decided IEEE 754-2008 compliance covers it.

I have no idea why the ECALL/EBREAK is included in the pull request when it exists in master already.