### PR TITLE
Document the 'DYN' mnemonic for dynamic rounding mode

### DIFF
--- a/src/f.tex
+++ b/src/f.tex
@@ -206,7 +206,7 @@ dynamic rounding mode register.
 \multicolumn{1}{l|}{\em Invalid.  Reserved for future use.}\\
 \hline
 \multicolumn{1}{|c|}{111} &
-\multicolumn{1}{l|}{} &
+\multicolumn{1}{l|}{DYN} &
 \multicolumn{1}{l|}{In instruction's {\em rm} field, selects dynamic rounding mode;}\\
 \multicolumn{1}{|c|}{} &
 \multicolumn{1}{l|}{} &


### PR DESCRIPTION
This mnemonic has been adopted by the GNU assembler in addition to the
RNE/RTZ/RDN/RUP/RMM mnemonics currently described here.