### PR TITLE
Fixes for two-level translation

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -206,11 +206,10 @@ Table~\ref{h-sprv} enumerates the cases.
 \label{h-sprv}
 \end{table*}
 
-When SPV=1, however, two-level translation swaps the usual meaning of
-{\tt satp} and {\tt bsatp}. {\tt bsatp} provides the virtual address to
-guest-physical address mapping, as well as the S-level ASID; {\tt satp}
-provides the guest-physical to machine-physical mapping and the HS-level
-ASID.
+When SPV=1, two-level translation uses the {\tt bsatp} register (instead
+of {\tt satp} to retrieve the virtual to guest-physical mapping, as
+well as the S-level ASID; as usual, {\tt hatp} provides the guest-physical
+to machine-physical mapping and the HS-level ASID.
 
 \begin{commentary}
 For simplicity, SPRV is in effect even when in S-mode or U-mode, but in normal
@@ -269,6 +268,71 @@ to U-mode by setting the corresponding bit in {\tt sedeleg} or {\tt sideleg}.
 When V=0 and the N extension for user-mode interrupts is implemented, any trap
 that has been delegated to HS-mode can be further delegated to U-mode by
 setting the corresponding bit in {\tt sedeleg} or {\tt sideleg}.
+
+\subsection{Hypervisor Address Translation and Protection Register ({\tt hatp})}
+
+The {\tt hatp} register is an XLEN-bit read/write register formatted as shown
+in Figure~\ref{rv32hatpreg} for RV32 and Figure~\ref{rv64hatpreg}  for RV64.
+The interpretation of the MODE, ASID, and PPN fields is the same as for
+{\tt satp}.
+
+\begin{figure}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{c@{}E@{}K}
+\instbit{31} &
+\instbitrange{30}{22} &
+\instbitrange{21}{0} \\
+\hline
+\multicolumn{1}{|c|}{{\tt MODE} (\warl)} &
+\multicolumn{1}{|c|}{{\tt ASID} (\warl)} &
+\multicolumn{1}{|c|}{{\tt PPN}  (\warl)} \\
+\hline
+1 & 9 & 22 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{RV32 hypervisor address translation and protection register {\tt hatp}.}
+\label{rv32hatpreg}
+\end{figure}
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}S@{}T@{}U}
+\instbitrange{63}{60} &
+\instbitrange{59}{44} &
+\instbitrange{43}{0} \\
+\hline
+\multicolumn{1}{|c|}{{\tt MODE} (\warl)} &
+\multicolumn{1}{|c|}{{\tt ASID} (\warl)} &
+\multicolumn{1}{|c|}{{\tt PPN}  (\warl)} \\
+\hline
+4 & 16 & 44 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{RV64 hypervisor address translation and protection register {\tt hatp}, for MODE
+values Bare, Sv39, and Sv48.}
+\label{rv64hatpreg}
+\end{figure*}
+
+The {\tt hatp} register is only active when second-level translation
+is in effect, namely when either V=1 or SPRV=1 and SPV=1.  The first
+level of translation comes from {\tt satp} when V=1, or from {\tt
+bsatp} when SPRV=1 and SPV=1.  Any physical address that is accessed
+by the hart to retrieve a page table entry, or that is specified in
+the leaf page table entry, is treated as a {\em guest physical address}
+and goes through a second stage of translation.  The second stage of
+translation uses paging structures described by {\tt hatp}.
+
+If MODE is 0 in {\tt hatp}, second-level translation uses an identity
+mapping from guest-physical to machine-physical addresses.  However,
+it is {\em not} entirely disabled.  In particular, when SPRV=1 and SPV=1,
+conversion of virtual addresses to guest physical addresses will use
+{\tt bsatp} rather than {\tt satp}.
 
 \subsection{Background Supervisor Status ({\tt bsstatus}) Register}
 
@@ -610,14 +674,10 @@ When V=0, the {\tt bsatp} register holds the S-mode guest's version of the
 V=1, or vice-versa), the implementation swaps the contents of {\tt bsatp} and
 {\tt satp}.
 
-{\tt bsatp} affects the behavior of the machine when two-level address
-translation is active.  When V=1, it controls the translation of guest
-physical addresses to machine physical addresses.  When V=0, but SPRV=1
-and SPV=1, it controls the translation of guest virtual addresses to
-guest physical addresses.
-
-The interpretation of the MODE, ASID, and PPN
-fields is the same as for {\tt satp}.
+{\tt bsatp} only affects the behavior of the machine when SPRV=1 and SPV=1.
+In that case, second-level translation uses {\tt bsatp} to translate
+guest virtual addresses to guest physical addresses, and {\tt hatp} to
+translate guest physical addresses to machine-physical addresses
 
 \begin{figure}[h!]
 {\footnotesize
@@ -845,19 +905,17 @@ and protection is in effect.  For any virtual memory access, the original
 virtual address is first converted
 by S-level address translation, as controlled by the {\tt satp} register, into
 a {\em guest physical address}.  The guest physical address is then
-converted by HS-level address translation, as controlled by the {\tt bsatp}
+converted by HS-level address translation, as controlled by the {\tt hatp}
 register, into a {\em machine physical address}.
 Although there is no option to disable two-level address translation when V=1,
 either level of translation can be effectively disabled by zeroing the
-corresponding {\tt satp} or {\tt bsatp} register.
+corresponding {\tt satp} or {\tt hatp} register.
 
 Two-level address translation and protection is also in effect if V=0 but
-SPRV=1 and SPV=1.  In that case, the process is the same but the roles
-of {\tt satp} and {\tt bsatp} are inverted.  The original virtual address
-is first converted by S-level address translation (now controlled by the
-{\tt bsatp} register) into a guest physical address.  The guest physical
-address is then converted by HS-level address translation (now controlled
-by the {\tt satp} register, into a {\em machine physical address}.
+SPRV=1 and SPV=1.  In that case, the process is the same except that
+S-level address translation is controlled by the {\tt bsatp} register.
+The guest physical address is then converted by HS-level address translation
+as usual, under control of of the {\tt hatp}.
 
 For the purposes of HS-level address translation and protection, all memory
 accesses made with V=1---including those made by the S-level
@@ -912,7 +970,8 @@ addresses and is in effect regardless of virtualization mode.
 
 When two-level address translation is in effect, there are separate
 HS-level and S-level ASIDs.  HS-level ASIDs share the ASID space with
-regular one-level page tables.
+regular one-level page tables.  The ASID field of {\tt hatp} provides the
+{\em active HS-level ASID}.
 
 \begin{commentary}
 	The processor may cache guest-physical to machine-physical
@@ -923,8 +982,7 @@ regular one-level page tables.
 	need to introduce an HFENCE.VMA instruction.  However, unless
 	there is a 1:1 correspondence between guest physical addresses
 	and host virtual addresses, the hypervisor must use different
-	ASIDs for virtualized guests and U-mode programs, even if
-	MODE is zero for the virtualized guest.
+	ASIDs in {\tt hatp} and {\tt satp}, even if MODE is zero.
 \end{commentary}
 
 While second-level translation is in effect, the ASID in {\tt satp}
@@ -933,7 +991,8 @@ or {\tt bsatp} (respectively when V=1, or when SPRV=1 and SPV=1) is a
 addresses to guest physical addresses.  S-level ASIDs are combined with
 the active HS-level ASID to form a {\em combined ASID}; combined ASIDs
 identify translations from guest virtual addresses to machine physical
-addresses.
+addresses.  As part of a combined ASID, the active HS-level ASID may be used
+to cache S-level translations even if MODE is zero in {\tt hatp}.
 
 \subsection{Memory-Management Fences}
 

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -908,20 +908,79 @@ entry must not have its U bit set, unless overridden by {\tt sstatus}.SUM.
 Machine-level physical memory protection applies to machine physical
 addresses and is in effect regardless of virtualization mode.
 
+\subsection{Address-space IDs}
+
+When two-level address translation is in effect, there are separate
+HS-level and S-level ASIDs.  HS-level ASIDs share the ASID space with
+regular one-level page tables.
+
+\begin{commentary}
+	The processor may cache guest-physical to machine-physical
+	translations in the TLB under the active HS-level ASID.
+
+	Sharing the ASID space between one-level translations and
+	guest-physical to machine-physical translations removes the
+	need to introduce an HFENCE.VMA instruction.  However, unless
+	there is a 1:1 correspondence between guest physical addresses
+	and host virtual addresses, the hypervisor must use different
+	ASIDs for virtualized guests and U-mode programs, even if
+	MODE is zero for the virtualized guest.
+\end{commentary}
+
+While second-level translation is in effect, the ASID in {\tt satp}
+or {\tt bsatp} (respectively when V=1, or when SPRV=1 and SPV=1) is a
+{\em S-level ASID}.  S-level ASIDs identify translations from guest virtual
+addresses to guest physical addresses.  S-level ASIDs are combined with
+the active HS-level ASID to form a {\em combined ASID}; combined ASIDs
+identify translations from guest virtual addresses to machine physical
+addresses.
+
 \subsection{Memory-Management Fences}
 
 The behavior of the SFENCE.VMA instruction is affected by the current
 virtualization mode V.  When V=0, the virtual-address argument is an HS-level
 virtual address, and the ASID argument is an HS-level ASID.  If either argument
 is provided, the instruction orders stores only to HS-level address-translation
-structures with subsequent address translations.  If neither argument is
-provided, the instruction orders stores to all HS-level and S-level address-translation structures
-with subsequent address translations.
+structures with subsequent address translations; in addition, if the HS-level
+ASID is provided, SFENCE.VMA will only order reads and writes for the
+combined ASIDs formed by the provided HS-level ASID and any S-level ASID.
+If neither argument is provided, the instruction orders stores to all
+HS-level and S-level address-translation structures with subsequent
+address translations.
 
 When V=1, the virtual-address argument to SFENCE.VMA is a guest virtual
 address, and the ASID argument is an S-level ASID.  The instruction
 orders stores only to the S-level address-translation structures within the
-HS-level address-space specified by the {\tt bsatp} register.
+HS-level address-space specified by the {\tt bsatp} register.  More precisely,
+SFENCE.VMA will only order reads and writes for:
+\begin{itemize}
+	\item if {\em rs2}={\tt x0}, the combined ASIDs formed by
+		the active HS-level ASID and any S-level ASID;
+	\item if {\em rs2}$\neq${\tt x0}, the combined ASID formed by
+		the active HS-level ASID and the S-level ASID
+		specified in {\em rs2}.
+\end{itemize}
+
+\begin{commentary}
+	Simplified implementations are possible where the processor doesn't
+	store combined ASIDs in the TLB.  For example:
+	\begin{itemize}
+		\item The processor may cache guest-virtual to
+			machine-physical translations in the TLB under
+			the active HS-level ASID.  In this case,
+			every write to {\tt satp} while V=1 acts
+			as a fence for the active HS-level ASID, and
+			SFENCE.VMA while V=1 must behave as if {\em
+			rs2} specified the active HS-level ASID.
+		\item The processor may cache guest-virtual to
+			machine-physical translations in the TLB under
+			the active S-level ASID; in this case, the
+			implementation must flush the TLB completely
+			every time V changes.
+	\end{itemize}
+	In either case, the processor must not use cached translations
+	while SPRV=1 and SPV=1.
+\end{commentary}
 
 When V=0, attempts to execute SFENCE.VMA in U-mode or when {\tt mstatus}.TSR=1
 raise an illegal instruction exception.  When V=1, attempts to execute

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -206,6 +206,12 @@ Table~\ref{h-sprv} enumerates the cases.
 \label{h-sprv}
 \end{table*}
 
+When SPV=1, however, two-level translation swaps the usual meaning of
+{\tt satp} and {\tt bsatp}. {\tt bsatp} provides the virtual address to
+guest-physical address mapping, as well as the S-level ASID; {\tt satp}
+provides the guest-physical to machine-physical mapping and the HS-level
+ASID.
+
 \begin{commentary}
 For simplicity, SPRV is in effect even when in S-mode or U-mode, but in normal
 use will only be enabled for short sequences in HS-mode.
@@ -604,9 +610,13 @@ When V=0, the {\tt bsatp} register holds the S-mode guest's version of the
 V=1, or vice-versa), the implementation swaps the contents of {\tt bsatp} and
 {\tt satp}.
 
-When V=0, {\tt bsatp} does not directly affect the behavior of the machine.  When V=1,
-it controls the translation of guest physical addresses to
-machine physical addresses.  The interpretation of the MODE, ASID, and PPN
+{\tt bsatp} affects the behavior of the machine when two-level address
+translation is active.  When V=1, it controls the translation of guest
+physical addresses to machine physical addresses.  When V=0, but SPRV=1
+and SPV=1, it controls the translation of guest virtual addresses to
+guest physical addresses.
+
+The interpretation of the MODE, ASID, and PPN
 fields is the same as for {\tt satp}.
 
 \begin{figure}[h!]
@@ -840,6 +850,14 @@ register, into a {\em machine physical address}.
 Although there is no option to disable two-level address translation when V=1,
 either level of translation can be effectively disabled by zeroing the
 corresponding {\tt satp} or {\tt bsatp} register.
+
+Two-level address translation and protection is also in effect if V=0 but
+SPRV=1 and SPV=1.  In that case, the process is the same but the roles
+of {\tt satp} and {\tt bsatp} are inverted.  The original virtual address
+is first converted by S-level address translation (now controlled by the
+{\tt bsatp} register) into a guest physical address.  The guest physical
+address is then converted by HS-level address translation (now controlled
+by the {\tt satp} register, into a {\em machine physical address}.
 
 For the purposes of HS-level address translation and protection, all memory
 accesses made with V=1---including those made by the S-level


### PR DESCRIPTION
Hi,

this is at last the result of my review of two-level translation in the hypervisor draft.

The first commit is, I believe, an actual bug in the specification: SPRV=1/SPV=1 is using the "S-mode meanings" of `satp` and `bsatp`, but those are reversed when running in HS-mode. Therefore, we must reverse them when HS-mode is doing accesses "as if" in S-mode.

The second commit clarifies the meaning of HS-level and S-level ASIDs. It also defines a combined HS-level + S-level ASID, and allows the TLB to store combined translations (from virtual address to machine-physical address) under the combined ASID.

The third commit introduces a new base register for paging, `hatp`, which makes the SPRV=1/SPV=1 mode much easier to use.