### PR TITLE
Maintain symmetry between traps and MRET with respect to MPV

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -783,10 +783,11 @@ hypervisor extension is provided.
 \end{figure*}
 
 The MPV bit (Machine Previous Virtualization Mode) is written by the implementation
-whenever a trap is taken into M-mode.  Just as the MPP bit is set to the privilege
-mode at the time of the trap, the MPV bit is set to the value of the virtualization
-mode V at the time of the trap.  When an MRET instruction is executed, the
-virtualization mode V is set to MPV, unless MPP=3, in which case V remains 0.
+whenever a vertical trap is taken into M-mode from a less-privileged mode.  The MPV bit is
+set to the value of the virtualization mode V at the time the trap is taken, unless the
+trap is taken from M-mode.  MPV is unchanged when a horizontal trap is taken within
+M-mode.  When an MRET instruction is executed, the virtualization mode V is set to MPV,
+unless MPP=3, in which case V remains 0.
 
 The MTL bit (Machine Translation Level), which indicates which address-translation level
 caused a page-fault exception, is also written by the implementation whenever a trap


### PR DESCRIPTION
If MPP is M, then V can only have been zero.  The outer frame must have
its own copy of the previous value of MPP somewhere, but that is no reason
to destroy MPV.

This change allows monitor trap handlers to recognize when the monitor was
initially entered from a guest virtual machine, even when handling traps
within the monitor.