### PR TITLE
early intra-hart --> early inter-hart

### DIFF
--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1079,7 +1079,7 @@ Microarchitectures are free to use any pipeline design, any coherent or non-cohe
 That said, to help people understand the actual implementations of the memory model, in this section we provide some guidelines below on how architects and programmers should interpret the models' rules.
 
 Both RVWMO and RVTSO are multi-copy atomic (or ``other-multi-copy-atomic''): any store value which is visible to a hart other than the one that originally issued it must also be conceptually visible to all other harts in the system.
-In other words, harts may forward from their own previous stores before those stores have become globally visible to all harts, but no other early intra-hart forwarding is permitted.
+In other words, harts may forward from their own previous stores before those stores have become globally visible to all harts, but no other early inter-hart forwarding is permitted.
 Multi-copy atomicity may be enforced in a number of ways.
 It might hold inherently due to the physical design of the caches and store buffers, it may be enforced via a single-writer/multiple-reader cache coherence protocol, or it might hold due to some other mechanism.
 

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1079,7 +1079,7 @@ Microarchitectures are free to use any pipeline design, any coherent or non-cohe
 That said, to help people understand the actual implementations of the memory model, in this section we provide some guidelines below on how architects and programmers should interpret the models' rules.
 
 Both RVWMO and RVTSO are multi-copy atomic (or ``other-multi-copy-atomic''): any store value which is visible to a hart other than the one that originally issued it must also be conceptually visible to all other harts in the system.
-In other words, harts may forward from their own previous stores before those stores have become globally visible to all harts, but no other early inter-hart forwarding is permitted.
+In other words, harts may forward from their own previous stores before those stores have become globally visible to all harts, but no early inter-hart forwarding is permitted.
 Multi-copy atomicity may be enforced in a number of ways.
 It might hold inherently due to the physical design of the caches and store buffers, it may be enforced via a single-writer/multiple-reader cache coherence protocol, or it might hold due to some other mechanism.
 


### PR DESCRIPTION
perhaps this was a typo?