### PR TITLE
Make it explicit that the page-fault exceptions from address translation correspond to the original access type, as is done for access exceptions.

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1212,8 +1212,10 @@ must be cleared by software for forward compatibility.
 \subsection{Virtual Address Translation Process}
 \label{sv32algorithm}
 
-A virtual address $va$ is translated into a physical address $pa$ as
-follows:
+A virtual address $va$ used for a memory access is translated into a
+physical address $pa$ as follows, where any access exception or
+page-fault exception raised corresponds to the one for the type of
+that memory access:
 
 \begin{enumerate}
 
@@ -1222,34 +1224,32 @@ follows:
 \item Let $pte$ be the value of the PTE at address
   $a+va.vpn[i]\times \textrm{PTESIZE}$. (For Sv32, PTESIZE=4.)
   If accessing $pte$ violates a PMA or PMP check, raise an
-  access exception corresponding to the original access type.
+  access exception.
 
 \item If $pte.v=0$, or if $pte.r=0$ and $pte.w=1$, stop and raise a
-  page-fault exception corresponding to the original access type.
+  page-fault exception.
 
 \item Otherwise, the PTE is valid.
   If $pte.r=1$ or $pte.x=1$, go to step 5.
   Otherwise, this PTE is a pointer to the next level of the page table.  Let
-  $i=i-1$.  If $i<0$, stop and raise a page-fault exception
-  corresponding to the original access type.  Otherwise, let
-  $a=pte.ppn \times \textrm{PAGESIZE}$ and go to step 2.
+  $i=i-1$.  If $i<0$, stop and raise a page-fault exception.
+  Otherwise, let $a=pte.ppn \times \textrm{PAGESIZE}$ and go to step 2.
 
 \item A leaf PTE has been found.  Determine if the requested memory access is
   allowed by the $pte.r$, $pte.w$, $pte.x$, and $pte.u$ bits, given the
   current privilege mode and the value of the SUM and MXR fields of
   the {\tt mstatus} register.  If not, stop and raise a page-fault
-  exception corresponding to the original access type.
+  exception.
 
 \item If $i>0$ and $pa.ppn[i-1:0]\neq 0$, this is a misaligned superpage;
-  stop and raise a page-fault exception corresponding to the original access type.
+  stop and raise a page-fault exception.
 
 \item If $pte.a=0$, or if the memory access is a store and $pte.d=0$, either
-  raise a page-fault exception corresponding to the original access type, or:
+  raise a page-fault exception, or:
   \begin{itemize}
   \item Set $pte.a$ to 1 and, if the memory access is a store, also set
     $pte.d$ to 1.
-  \item If this access violates a PMA or PMP check, raise an access exception
-    corresponding to the original access type.
+  \item If this access violates a PMA or PMP check, raise an access exception.
   \item This update and the loading of $pte$ in step 2 must be atomic; in
     particular, no intervening store to the PTE may be perceived to have
     occurred in-between.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1224,24 +1224,27 @@ follows:
   If accessing $pte$ violates a PMA or PMP check, raise an
   access exception corresponding to the original access type.
 
-\item If $pte.v=0$, or if $pte.r=0$ and $pte.w=1$, stop and raise a page-fault exception.
+\item If $pte.v=0$, or if $pte.r=0$ and $pte.w=1$, stop and raise a
+  page-fault exception corresponding to the original access type.
 
 \item Otherwise, the PTE is valid.
   If $pte.r=1$ or $pte.x=1$, go to step 5.
   Otherwise, this PTE is a pointer to the next level of the page table.  Let
-  $i=i-1$.  If $i<0$, stop and raise a page-fault exception.  Otherwise, let
+  $i=i-1$.  If $i<0$, stop and raise a page-fault exception
+  corresponding to the original access type.  Otherwise, let
   $a=pte.ppn \times \textrm{PAGESIZE}$ and go to step 2.
 
 \item A leaf PTE has been found.  Determine if the requested memory access is
   allowed by the $pte.r$, $pte.w$, $pte.x$, and $pte.u$ bits, given the
   current privilege mode and the value of the SUM and MXR fields of
-  the {\tt mstatus} register.  If not, stop and raise a page-fault exception.
+  the {\tt mstatus} register.  If not, stop and raise a page-fault
+  exception corresponding to the original access type.
 
 \item If $i>0$ and $pa.ppn[i-1:0]\neq 0$, this is a misaligned superpage;
-      stop and raise a page-fault exception.
+  stop and raise a page-fault exception corresponding to the original access type.
 
 \item If $pte.a=0$, or if the memory access is a store and $pte.d=0$, either
-  raise a page-fault exception or:
+  raise a page-fault exception corresponding to the original access type, or:
   \begin{itemize}
   \item Set $pte.a$ to 1 and, if the memory access is a store, also set
     $pte.d$ to 1.


### PR DESCRIPTION
It is implicit, but being more explicit seemed better.
