### PR TITLE
Misaligned superpage exception occurs if pte.ppn[i−1:0]!=0

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1241,7 +1241,7 @@ follows:
   the {\tt mstatus} register.  If not, stop and raise a page-fault
   exception corresponding to the original access type.
 
-\item If $i>0$ and $pa.ppn[i-1:0]\neq 0$, this is a misaligned superpage;
+\item If $i>0$ and $pte.ppn[i-1:0]\neq 0$, this is a misaligned superpage;
   stop and raise a page-fault exception corresponding to the original access type.
 
 \item If $pte.a=0$, or if the memory access is a store and $pte.d=0$, either


### PR DESCRIPTION
Misaligned superpage exception occurs if **pte.ppn[i−1:0]!=0**. In the current specification instead of pte.ppn it given as pa.ppn.