### PR TITLE
Clarify URET with no user-mode traps support

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1996,9 +1996,10 @@ MRET/SRET/URET & 0 & PRIV & 0 & SYSTEM \\
 
 To return after handling a trap, there are separate trap return
 instructions per privilege level: MRET, SRET, and URET.  MRET is
-always provided, while SRET must be provided if supervisor mode is
-supported.  When user mode is supported, URET is provided if user-mode
-traps are also supported, and should raise an illegal instruction otherwise.
+always provided. SRET must be provided if supervisor mode is
+supported, and should raise an illegal instruction otherwise.
+URET is only provided if user-mode traps are supported, and
+should raise an illegal instruction otherwise.
 An {\em x}\,RET instruction can be executed in privilege mode {\em x}
 or higher, where executing a lower-privilege {\em x}\,RET instruction
 will pop the relevant lower-privilege interrupt enable and privilege

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1997,7 +1997,8 @@ MRET/SRET/URET & 0 & PRIV & 0 & SYSTEM \\
 To return after handling a trap, there are separate trap return
 instructions per privilege level: MRET, SRET, and URET.  MRET is
 always provided, while SRET must be provided if supervisor mode is
-supported.  URET is only provided if user-mode traps are supported.
+supported.  When user mode is supported, URET is provided if user-mode
+traps are also supported, and should raise an illegal instruction otherwise.
 An {\em x}\,RET instruction can be executed in privilege mode {\em x}
 or higher, where executing a lower-privilege {\em x}\,RET instruction
 will pop the relevant lower-privilege interrupt enable and privilege


### PR DESCRIPTION
Following up on [issue 163](https://github.com/riscv/riscv-isa-manual/issues/163)...