### PR TITLE
Specify operand order for sub instruction

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -590,9 +590,10 @@ write the result into register {\em rd}.  The {\em funct7} and {\em
 \end{tabular}
 \end{center}
 
-ADD and SUB perform addition and subtraction respectively.  Overflows
-are ignored and the low XLEN bits of results are written to the
-destination.  SLT and SLTU perform signed and unsigned compares
+ADD performs the addition of {\em rs1} and {\em rs2}. SUB performs the
+subtraction of {\em rs2} from {\em rs1}.  Overflows are ignored and the low XLEN
+bits of results are written to the destination {\em rd}.
+SLT and SLTU perform signed and unsigned compares
 respectively, writing 1 to {\em rd} if $\mbox{\em rs1} < \mbox{\em
   rs2}$, 0 otherwise.  Note, SLTU {\em rd}, {\em x0}, {\em rs2} sets
 {\em rd} to 1 if {\em rs2} is not equal to zero, otherwise sets {\em


### PR DESCRIPTION
The current text does not actually specify whether `sub` puts `rs1 - rs2` or `rs2 - rs1` into `rd` (same for `add` but that one doesn't matter...).