### PR TITLE
Clarify pseudoinstruction sign extension neglected

### DIFF
--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -50,16 +50,17 @@ RISC-V pseudoinstructions.
 \begin{tabular}{l l l}
 pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 
-\multirow{2}{*}{\tt la rd, symbol} & {\tt auipc rd, symbol[31:12]} & \multirow{2}{*}{Load address} \\
-                                   & {\tt addi rd, rd, symbol[11:0]} \\
-\multirow{2}{*}{\tt l\{b|h|w|d\} rd, symbol} & {\tt auipc rd, symbol[31:12]} & \multirow{2}{*}{Load global} \\
-                                           & {\tt l\{b|h|w|d\} rd, symbol[11:0](rd)} \\
-\multirow{2}{*}{\tt s\{b|h|w|d\} rd, symbol, rt} & {\tt auipc rt, symbol[31:12]} & \multirow{2}{*}{Store global} \\
-                                               & {\tt s\{b|h|w|d\} rd, symbol[11:0](rt)} \\
-\multirow{2}{*}{\tt fl\{w|d\} rd, symbol, rt} & {\tt auipc rt, symbol[31:12]} & \multirow{2}{*}{Floating-point load global} \\
-                                            & {\tt fl\{w|d\} rd, symbol[11:0](rt)} \\
-\multirow{2}{*}{\tt fs\{w|d\} rd, symbol, rt} & {\tt auipc rt, symbol[31:12]} & \multirow{2}{*}{Floating-point store global} \\
-                                            & {\tt fs\{w|d\} rd, symbol[11:0](rt)} \\
+\multirow{2}{*}{\tt la rd, symbol} & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load (absolute) address \\
+                                   & {\tt addi rd, rd, delta[11:0]}                         & Where ${\tt delta} = {\tt symbol} - {\tt pc}$\\
+\multirow{2}{*}{\tt l\{b|h|w|d\} rd, symbol} & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Load global} \\
+                                             & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)} \\
+\multirow{2}{*}{\tt s\{b|h|w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Store global} \\
+                                                 & {\tt s\{b|h|w|d\} rd, delta[11:0](rt)} \\
+\multirow{2}{*}{\tt fl\{w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Floating-point load global} \\
+                                              & {\tt fl\{w|d\} rd, delta[11:0](rt)} \\
+\multirow{2}{*}{\tt fs\{w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Floating-point store global} \\
+                                              & {\tt fs\{w|d\} rd, delta[11:0](rt)} \\
+\multicolumn{3}{p{.99\textwidth}}{Note: Due to {\tt pc}-relativity, the compiler translates the absolute {\tt symbol} to a relative {\tt delta}, where {\tt pc} is the memory location of the first base instruction. Due to sign extension, the compiler adds {\tt delta[11]}, which is a no-op if {\tt delta[11]} is {\tt 0}.} \\
 \hline
 {\tt nop} & {\tt addi x0, x0, 0} & No operation \\
 {\tt li rd, immediate} & {\em Myriad sequences} & Load immediate \\
@@ -97,9 +98,9 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 {\tt jr rs} & {\tt jalr x0, rs, 0} & Jump register \\
 {\tt jalr rs} & {\tt jalr x1, rs, 0} & Jump and link register \\
 {\tt ret} & {\tt jalr x0, x1, 0} & Return from subroutine \\
-\multirow{2}{*}{\tt call offset} & {\tt auipc x1, offset[31:12]} & \multirow{2}{*}{Call far-away subroutine} \\
+\multirow{2}{*}{\tt call offset} & {\tt auipc x1, ${\tt offset[31:12]} + {\tt offset[11]}$} & \multirow{2}{*}{Call far-away subroutine} \\
                                  & {\tt jalr x1, x1, offset[11:0]} \\
-\multirow{2}{*}{\tt tail offset} & {\tt auipc x6, offset[31:12]} & \multirow{2}{*}{Tail call far-away subroutine} \\
+\multirow{2}{*}{\tt tail offset} & {\tt auipc x6, ${\tt offset[31:12]} + {\tt offset[11]}$} & \multirow{2}{*}{Tail call far-away subroutine} \\
                                  & {\tt jalr x0, x6, offset[11:0]} & \\
 \hline
 {\tt fence} & {\tt fence iorw, iorw} & Fence on all memory and I/O \\

--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -50,16 +50,16 @@ RISC-V pseudoinstructions.
 \begin{tabular}{l l l}
 pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 
-\multirow{2}{*}{\tt la rd, symbol} & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load (absolute) address \\
-                                   & {\tt addi rd, rd, delta[11:0]}                         & Where ${\tt delta} = {\tt symbol} - {\tt pc}$\\
-\multirow{2}{*}{\tt l\{b|h|w|d\} rd, symbol} & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Load global} \\
-                                             & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)} \\
-\multirow{2}{*}{\tt s\{b|h|w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Store global} \\
-                                                 & {\tt s\{b|h|w|d\} rd, delta[11:0](rt)} \\
-\multirow{2}{*}{\tt fl\{w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Floating-point load global} \\
-                                              & {\tt fl\{w|d\} rd, delta[11:0](rt)} \\
-\multirow{2}{*}{\tt fs\{w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Floating-point store global} \\
-                                              & {\tt fs\{w|d\} rd, delta[11:0](rt)} \\
+\tt la rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load (absolute) address \\
+                  & {\tt addi rd, rd, delta[11:0]}                         & Where ${\tt delta} = {\tt symbol} - {\tt pc}$ \\[1ex]
+\tt l\{b|h|w|d\} rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load global \\
+                            & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)}                 & \\[1ex]
+\tt s\{b|h|w|d\ rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Store global \\
+                               & {\tt s\{b|h|w|d\} rd, delta[11:0](rt)}                 & \\[1ex]
+\tt fl\{w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Floating-point load global \\
+                             & {\tt fl\{w|d\} rd, delta[11:0](rt)}                    & \\[1ex]
+\tt fs\{w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Floating-point store global \\
+                             & {\tt fs\{w|d\} rd, delta[11:0](rt)}                    & \\[1ex]
 \multicolumn{3}{p{.99\textwidth}}{\small \em Due to {\tt pc}-relativity, the compiler translates the absolute {\tt symbol} to a relative {\tt delta}, where {\tt pc} is the memory location of the first base instruction. Due to sign extension, the compiler adds {\tt delta[11]}, which is a no-op if {\tt delta[11]} is {\tt 0}.} \\
 \hline
 {\tt nop} & {\tt addi x0, x0, 0} & No operation \\
@@ -98,10 +98,10 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 {\tt jr rs} & {\tt jalr x0, rs, 0} & Jump register \\
 {\tt jalr rs} & {\tt jalr x1, rs, 0} & Jump and link register \\
 {\tt ret} & {\tt jalr x0, x1, 0} & Return from subroutine \\
-\multirow{2}{*}{\tt call offset} & {\tt auipc x1, ${\tt offset[31:12]} + {\tt offset[11]}$} & \multirow{2}{*}{Call far-away subroutine} \\
-                                 & {\tt jalr x1, x1, offset[11:0]} \\
-\multirow{2}{*}{\tt tail offset} & {\tt auipc x6, ${\tt offset[31:12]} + {\tt offset[11]}$} & \multirow{2}{*}{Tail call far-away subroutine} \\
-                                 & {\tt jalr x0, x6, offset[11:0]} & \\
+\tt call offset & {\tt auipc x1, ${\tt offset[31:12]} + {\tt offset[11]}$} & Call far-away subroutine \\
+                & {\tt jalr x1, x1, offset[11:0]}                          & \\
+\tt tail offset & {\tt auipc x6, ${\tt offset[31:12]} + {\tt offset[11]}$} & Tail call far-away subroutine \\
+                & {\tt jalr x0, x6, offset[11:0]}                          & \\
 \hline
 {\tt fence} & {\tt fence iorw, iorw} & Fence on all memory and I/O \\
 {\tt fence.tso} & {\tt fence.tso rw, rw} & TSO Fence \\

--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -60,7 +60,7 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
                                               & {\tt fl\{w|d\} rd, delta[11:0](rt)} \\
 \multirow{2}{*}{\tt fs\{w|d\} rd, symbol, rt} & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & \multirow{2}{*}{Floating-point store global} \\
                                               & {\tt fs\{w|d\} rd, delta[11:0](rt)} \\
-\multicolumn{3}{p{.99\textwidth}}{Note: Due to {\tt pc}-relativity, the compiler translates the absolute {\tt symbol} to a relative {\tt delta}, where {\tt pc} is the memory location of the first base instruction. Due to sign extension, the compiler adds {\tt delta[11]}, which is a no-op if {\tt delta[11]} is {\tt 0}.} \\
+\multicolumn{3}{p{.99\textwidth}}{\small \em Due to {\tt pc}-relativity, the compiler translates the absolute {\tt symbol} to a relative {\tt delta}, where {\tt pc} is the memory location of the first base instruction. Due to sign extension, the compiler adds {\tt delta[11]}, which is a no-op if {\tt delta[11]} is {\tt 0}.} \\
 \hline
 {\tt nop} & {\tt addi x0, x0, 0} & No operation \\
 {\tt li rd, immediate} & {\em Myriad sequences} & Load immediate \\

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -691,8 +691,8 @@ with {\em rd}={\tt x0}.
 \end{center}
 
 The indirect jump instruction JALR (jump and link register) uses the
-I-type encoding.  The target address is obtained by adding the 12-bit
-signed I-immediate to the register {\em rs1}, then setting the
+I-type encoding.  The target address is obtained by adding the sign-extended
+12-bit I-immediate to the register {\em rs1}, then setting the
 least-significant bit of the result to zero.  The address of
 the instruction following the jump ({\tt pc}+4) is written to register
 {\em rd}.  Register {\tt x0} can be used as the destination if the


### PR DESCRIPTION
As discussed in issue 144, the table "RISC-V pseudoinstructions" in the
placeholder "RISC-V Assembly Programmer's Handbook" chapter neglects
sign extension for brevity. This commit adds this assumption explicitly
to the table.

I was lying on the beach (no Internet, no laptop), reading a printout of the RISC V manual. Nice read, thanks! But I spent a long time staring at the pseudoinstruction table and reading the parts about sign extension again and again, because I thought my understanding of sign extension was wrong. I was so desperate that left the beach to find a computer. Fortunately, @andrewt0301 already raised the same question in issue #144. Though the whole assembly programming chapter will be replaced, please accept this little commit to make the risc v manual a better reading material for the upcoming holiday season :smile: 