### PR TITLE
Nit: no hyphen in instruction-set

### DIFF
--- a/src/d.tex
+++ b/src/d.tex
@@ -2,7 +2,7 @@
 Version 2.0}
 
 This chapter describes the standard double-precision floating-point
-instruction-set extension, which is named ``D'' and adds
+instruction set extension, which is named ``D'' and adds
 double-precision floating-point computational instructions compliant
 with the IEEE 754-2008 arithmetic standard.  The D extension depends on
 the base single-precision instruction subset F.

--- a/src/extensions.tex
+++ b/src/extensions.tex
@@ -3,17 +3,17 @@
 
 In addition to supporting standard general-purpose software
 development, another goal of RISC-V is to provide a basis for more
-specialized instruction-set extensions or more customized
+specialized instruction set extensions or more customized
 accelerators.  The instruction encoding spaces and optional
 variable-length instruction encoding are designed to make it easier to
 leverage software development effort for the standard ISA toolchain
 when building more customized processors.  For example, the intent is
 to continue to provide full software support for implementations that
 only use the standard I base, perhaps together with many non-standard
-instruction-set extensions.
+instruction set extensions.
 
 This chapter describes various ways in which the base RISC-V ISA can
-be extended, together with the scheme for managing instruction-set
+be extended, together with the scheme for managing instruction set
 extensions developed by independent groups.  This volume only deals
 with the user-level ISA, although the same approach and terminology is
 used for supervisor-level extensions described in the second volume.
@@ -133,7 +133,7 @@ Brownfield & F(I), D(F), Q(D) & M(I) \\
 \end{tabular}
 \end{center}
 }
-\caption{Two-dimensional characterization of standard instruction-set
+\caption{Two-dimensional characterization of standard instruction set
   extensions.}
 \label{exttax}
 \end{table}
@@ -206,7 +206,7 @@ implementation, and has been encoded to use only a small fraction of a
 32-bit instruction encoding space.
 
 Another use-case is to build a research prototype for a new type of
-instruction-set extension.  The researchers might not want to expend
+instruction set extension.  The researchers might not want to expend
 the effort to implement a variable-length instruction-fetch unit, and
 so would like to prototype their extension using a simple 32-bit
 fixed-width instruction encoding.  However, this new extension might
@@ -217,13 +217,13 @@ unused standard extensions and reuse their prefixes to place the
 proposed extension in a non-standard location to simplify engineering
 of the research prototype.  Standard tools will still be able to
 target the base and any standard extensions that are present to reduce
-development time.  Once the instruction-set extension has been
+development time.  Once the instruction set extension has been
 evaluated and refined, it could then be made available for packing
 into a larger variable-length encoding space to avoid conflicts with
 all standard extensions.
 
 The following sections describe increasingly sophisticated strategies
-for developing implementations with new instruction-set extensions.
+for developing implementations with new instruction set extensions.
 These are mostly intended for use in highly customized, educational,
 or experimental architectures rather than for the main line of RISC-V
 ISA development.
@@ -244,7 +244,7 @@ many restricted accelerators and research prototypes.
 In the standard encoding, three of the available 30-bit instruction
 encoding spaces (those with 2-bit prefixes 00, 01, and 10) are used to
 enable the optional compressed instruction extension.  However, if the
-compressed instruction-set extension is not required, then these three
+compressed instruction set extension is not required, then these three
 further 30-bit encoding spaces become available.  This quadruples the
 available encoding space within the 32-bit format.
 

--- a/src/f.tex
+++ b/src/f.tex
@@ -2,7 +2,7 @@
 Version 2.0}
 \label{sec:single-float}
 
-This chapter describes the standard instruction-set extension for
+This chapter describes the standard instruction set extension for
 single-precision floating-point, which is named ``F'' and adds
 single-precision floating-point computational instructions compliant
 with the IEEE 754-2008 arithmetic standard~\cite{ieee754-2008}.

--- a/src/gmaps.tex
+++ b/src/gmaps.tex
@@ -4,8 +4,8 @@ One goal of the RISC-V project is that it be used as a stable software
 development target.  For this purpose, we define a combination of a
 base ISA (RV32I or RV64I) plus selected standard extensions (IMAFD) as
 a ``general-purpose'' ISA, and we use the abbreviation G for the IMAFD
-combination of instruction-set extensions.    This chapter presents
-opcode maps and instruction-set listings for RV32G and RV64G.
+combination of instruction set extensions.    This chapter presents
+opcode maps and instruction set listings for RV32G and RV64G.
 
 \input{opcode-map}
 
@@ -15,11 +15,11 @@ lengths greater than 32 bits.  Opcodes marked as {\em reserved} should
 be avoided for custom instruction set extensions as they might be used
 by future standard extensions.  Major opcodes marked as {\em custom-0}
 and {\em custom-1} will be avoided by future standard extensions and
-are recommended for use by custom instruction-set extensions within
+are recommended for use by custom instruction set extensions within
 the base 32-bit instruction format.  The opcodes marked {\em
   custom-2/rv128} and {\em custom-3/rv128} are reserved for future use
 by RV128, but will otherwise be avoided for standard extensions and so
-can also be used for custom instruction-set extensions in RV32 and
+can also be used for custom instruction set extensions in RV32 and
 RV64.
 
 We believe RV32G and RV64G provide simple but complete instruction

--- a/src/intro.tex
+++ b/src/intro.tex
@@ -87,7 +87,7 @@ A RISC-V core might have additional specialized instruction set
 extensions or an added {\em coprocessor}.  We use the term {\em
   coprocessor} to refer to a unit that is attached to a RISC-V core
 and is mostly sequenced by a RISC-V instruction stream, but which
-contains additional architectural state and instruction-set
+contains additional architectural state and instruction set
 extensions, and possibly some limited autonomy relative to the
 primary RISC-V instruction stream.
 
@@ -95,7 +95,7 @@ We use the term {\em accelerator} to refer to either a
 non-programmable fixed-function unit or a core that can operate
 autonomously but is specialized for certain tasks.  In RISC-V systems,
 we expect many programmable accelerators will be RISC-V-based cores
-with specialized instruction-set extensions and/or customized
+with specialized instruction set extensions and/or customized
 coprocessors.  An important class of RISC-V accelerators are I/O
 accelerators, which offload I/O processing tasks from the main
 application cores.
@@ -200,8 +200,8 @@ could be accommodated within the RISC-V ISA framework.
 
 RISC-V has been designed to support extensive customization and
 specialization.  Each base integer ISA can be extended with one or
-more optional instruction-set extensions, and we divide each RISC-V
-instruction-set encoding space (and related encoding spaces such as
+more optional instruction set extensions, and we divide each RISC-V
+instruction set encoding space (and related encoding spaces such as
 the CSRs) into three disjoint categories: {\em standard}, {\em
   reserved}, and {\em custom}.  Standard encodings are defined by the
 Foundation, and shall not conflict with other standard extensions for
@@ -213,11 +213,11 @@ extensions and are made available for vendor-specific non-standard
 extensions.  We use the term {\em non-conforming} to describe a
 non-standard extension that uses either a standard or a reserved
 encoding (i.e., custom extensions are {\em not} non-conforming).
-Instruction-set extensions may provide slightly different
+Instruction set extensions may provide slightly different
 functionality depending on the width of the base integer instruction
 set.  Chapter~\ref{extensions} describes various ways of extending the
 RISC-V ISA.  We have also developed a naming convention for RISC-V
-base instructions and instruction-set extensions, described in detail
+base instructions and instruction set extensions, described in detail
 in Chapter~\ref{naming}.
 
 To support more general software development, a set of standard
@@ -283,9 +283,9 @@ instructions have larger values of ILEN.
 Figure~\ref{instlengthcode} illustrates the standard RISC-V
 instruction-length encoding convention.  All the 32-bit instructions
 in the base ISA have their lowest two bits set to {\tt 11}.  The
-optional compressed 16-bit instruction-set extensions have their
+optional compressed 16-bit instruction set extensions have their
 lowest two bits equal to {\tt 00}, {\tt 01}, or {\tt 10}.  Standard
-instruction-set extensions encoded with more than 32 bits have
+instruction set extensions encoded with more than 32 bits have
 additional low-order bits set to {\tt 1}, with the conventions for
 48-bit and 64-bit lengths shown in Figure~\ref{instlengthcode}.
 Instruction lengths between 80 bits and 176 bits are encoded using a
@@ -295,7 +295,7 @@ addition to the first 5$\times$16-bit words.  The encoding with bits
 encodings.
 
 The encodings with bits [15:0] all zeros are illegal.  These instructions are
-considered to be of minimal length: 16 bits if any 16-bit instruction-set
+considered to be of minimal length: 16 bits if any 16-bit instruction set
 extension is present, otherwise 32 bits.  The encoding with bits [ILEN-1:0]
 all ones is also illegal; this instruction is considered to be ILEN bits long.
 
@@ -357,7 +357,7 @@ wanted to build in support for a compressed format to the ISA encoding
 scheme rather than adding this as an afterthought, but to allow
 simpler implementations we didn't want to make the compressed format
 mandatory. We also wanted to optionally allow longer instructions to
-support experimentation and larger instruction-set extensions.
+support experimentation and larger instruction set extensions.
 Although our encoding convention required a tighter encoding of the
 core RISC-V ISA, this has several beneficial effects.
 
@@ -376,7 +376,7 @@ Chapter~\ref{extensions}, an implementation that does not require
 support for the standard compressed instruction extension can map 3
 additional 30-bit instruction spaces into the 32-bit fixed-width
 format, while preserving support for standard $>=$32-bit
-instruction-set extensions.  Further, if the implementation also does
+instruction set extensions.  Further, if the implementation also does
 not need instructions $>$32-bits in length, it can recover a further
 four major opcodes.
 \end{samepage-commentary}
@@ -411,7 +411,7 @@ to memory correctly regardless of memory system endianness.
 \caption{Recommended code sequence to store 32-bit instruction from register to
   memory.  Operates correctly on both big- and little-endian
   memory systems and avoids misaligned accesses when used with variable-length
-  instruction-set extensions.}
+  instruction set extensions.}
 \label{fig:storeinstruction}
 \end{figure}
 

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -8,7 +8,7 @@ application binary interface (ABI).
 
 \begin{commentary}
 The RISC-V ISA is designed to support a wide variety of
-implementations with various experimental instruction-set extensions.
+implementations with various experimental instruction set extensions.
 We have found that an organized naming scheme simplifies software
 tools and documentation.
 \end{commentary}

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -61,7 +61,7 @@ implementations can be optimized to reduce access energy for the
 frequently accessed registers~\cite{jtseng:sbbci}.  The optional
 compressed 16-bit instruction format mostly only accesses 8 registers
 and hence can provide a dense instruction encoding, while additional
-instruction-set extensions could support a much larger register space
+instruction set extensions could support a much larger register space
 (either flat or hierarchical) if desired.
 
 For resource-constrained embedded applications, we have defined the
@@ -1406,7 +1406,7 @@ load and store instructions might be treated and ordered as device
 input and device output operations respectively rather than memory
 reads and writes.  For example, memory-mapped I/O devices will
 typically be accessed with uncached loads and stores that are ordered
-using the I and O bits rather than the R and W bits.  Instruction-set
+using the I and O bits rather than the R and W bits.  Instruction set
 extensions might also describe new coprocessor I/O instructions that
 will also be ordered using the I and O bits in a FENCE.
 

--- a/src/sbi.tex
+++ b/src/sbi.tex
@@ -23,7 +23,7 @@ RISC-V, including:
 \item Some device drivers may be handled by the SEE, and managed via
   virtual device calls over the SBI.
 
-\item The presence and version of supported instruction-set extensions
+\item The presence and version of supported instruction set extensions
   is obtained via an SBI call to return the configuration string
   rather than a machine register.  This allows for an arbitrarily
   large definition of instruction set extensions, and simplifies


### PR DESCRIPTION
Unify the writing of "instruction set".