### PR TITLE
Specify operand order for div instructions

### DIFF
--- a/src/m.tex
+++ b/src/m.tex
@@ -90,8 +90,8 @@ MULDIV & divisor & dividend & DIV[U]W/REM[U]W & dest & OP-32 \\
 \end{tabular}
 \end{center}
 
-DIV and DIVU perform signed and unsigned integer division of XLEN
-bits by XLEN bits, rounding towards zero.
+DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned integer
+division of {\em rs1} by {\em rs2}, rounding towards zero.
 REM and REMU provide the remainder of the
 corresponding division operation.  If both the quotient and remainder
 are required from the same division, the recommended code sequence is:


### PR DESCRIPTION
Same as [#172](https://github.com/riscv/riscv-isa-manual/pull/172), bu for `div` (is it `rs1/rs2` or `rs2/rs1`?). `rem` seems to be defined in terms of `div` in the text, so that one is no longer ambiguous either. I wonder whether there are more noncommutative operations that would have also a similar ambiguity...