### PR TITLE
FDIV.S and FSUB.S disambiguation

### DIFF
--- a/src/f.tex
+++ b/src/f.tex
@@ -367,12 +367,13 @@ is naturally aligned.
 \label{sec:single-float-compute}
 
 Floating-point arithmetic instructions with one or two source operands use the
-R-type format with the OP-FP major opcode.  FADD.S, FSUB.S,
-FMUL.S, and FDIV.S perform single-precision floating-point addition,
-subtraction, multiplication, and division, respectively, between {\em rs1} and
-{\em rs2}, writing the result to {\em rd}.
-FSQRT.S computes the square root of {\em rs1} and writes the
-result to {\em rd}.
+R-type format with the OP-FP major opcode.  FADD.S and FMUL.S perform
+single-precision floating-point addition and multiplication respectively,
+between {\em rs1} and {\em rs2}. FSUB.S performs the single-precision
+floating-point subtraction of {\em rs2} from {\em rs1}.  FDIV.S performs the
+single-precision floating-point division of {\em rs1} by {\em rs2}. FSQRT.S
+computes the square root of {\em rs1}.  In each case, the result is written to
+{\em rd}.
 
 The 2-bit floating-point format field {\em fmt} is encoded as shown in
 Table~\ref{tab:fmt}.  It is set to {\em S} (00) for all instructions in


### PR DESCRIPTION
Following up on [#179](https://github.com/riscv/riscv-isa-manual/pull/179). `FDIV` and `FSQRT` are actually defined in terms of the single precision instructions. `FSQRT.S` looked fine to me. I just rephrased the paragraph to be explicit about `FSUB.S` and `FDIV.S`.