### PR TITLE
Disambiguation of MULHSU + explicit rd as a destination for DIV,DIVU, REM,REMU

### DIFF
--- a/src/m.tex
+++ b/src/m.tex
@@ -40,11 +40,13 @@ MULDIV & multiplier & multiplicand & MULW           & dest & OP-32 \\
 \end{center}
 
 MUL performs an XLEN-bit$\times$XLEN-bit multiplication and places the
-lower XLEN bits in the destination register.  MULH, MULHU, and MULHSU
-perform the same multiplication but return the upper XLEN bits of the
-full 2$\times$XLEN-bit product, for signed$\times$signed,
-unsigned$\times$unsigned, and signed$\times$unsigned multiplication
-respectively.  If both the high and low bits of the same product are
+lower XLEN bits in the destination register {\em rd}.  MULH and MULHU perform
+the same multiplication but return the upper XLEN bits of the full
+2$\times$XLEN-bit product, for signed$\times$signed and unsigned$\times$unsigned
+respectively. MULHSU performs the same multiplication and returns the upper XLEN
+bits of the full 2$\times$XLEN-bit product for signed {\em rs1} $\times$ unsigned
+{\em rs2}.
+If both the high and low bits of the same product are
 required, then the recommended code sequence is: MULH[[S]U] {\em rdh,
   rs1, rs2}; MUL {\em rdl, rs1, rs2} (source register specifiers must
 be in same order and {\em rdh} cannot be the same as {\em rs1} or {\em
@@ -91,8 +93,8 @@ MULDIV & divisor & dividend & DIV[U]W/REM[U]W & dest & OP-32 \\
 \end{center}
 
 DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned integer
-division of {\em rs1} by {\em rs2}, rounding towards zero.
-REM and REMU provide the remainder of the
+division of {\em rs1} by {\em rs2}, rounding towards zero, and place the
+result in {\em rd}.  REM and REMU provide the remainder of the
 corresponding division operation.  If both the quotient and remainder
 are required from the same division, the recommended code sequence is:
 DIV[U] {\em rdq, rs1, rs2}; REM[U] {\em rdr, rs1, rs2} ({\em rdq}


### PR DESCRIPTION
Same idea as [#180](https://github.com/riscv/riscv-isa-manual/pull/180).
This time `MULHSU` as I understand it is non-commutative, but I am not sure I fully understand this instruction. I guess more than a pull request, this is me asking for someone to help me understand this bit:

> *MULHSU is used in multi-word signed multiplication to multiply the most-significant word of the multiplier (which contains the sign bit) with the less-significant words of the multiplicand (which are unsigned).*

Should I understand "word" in the text above as being XLEN-bit chuncks? I think it makes sence if I do that... Could someone give me an example to make sure I got it? 

Also there is a more trivial change to explicitly mention a destination register `rd` for `DIV` & co.