### PR TITLE
Specify division by zero for DIVW, DIVUW, REMW, REMUW

### DIFF
--- a/src/m.tex
+++ b/src/m.tex
@@ -101,25 +101,33 @@ cannot be the same as {\em rs1} or {\em rs2}).  Microarchitectures can
 then fuse these into a single divide operation instead of performing
 two separate divides.
 
-The semantics for division by zero and division overflow are
-summarized in Table~\ref{tab:divby0}.  The quotient of division by
-zero has all bits set, i.e. $2^{XLEN}-1$ for unsigned division or $-1$
-for signed division.  The remainder of division by zero equals the
-dividend.  Signed division overflow occurs only when the most-negative
-integer, $-2^{XLEN-1}$, is divided by $-1$.  The quotient of signed
-division overflow is equal to the dividend, and the remainder is zero.
-Unsigned division overflow cannot occur.
+DIVW and DIVUW instructions are only valid for RV64, and divide the
+lower 32 bits of {\em rs1} by the lower 32 bits of {\em rs2}, treating
+them as signed and unsigned integers respectively, placing the 32-bit
+quotient in {\em rd}, sign-extended to 64 bits.  REMW and REMUW
+instructions are only valid for RV64, and provide the corresponding
+signed and unsigned remainder operations respectively. Both REMW and
+REMUW always sign-extend the 32-bit result to 64 bits, including on a
+divide by zero.
+
+The semantics for division by zero and division overflow are summarized in
+Table~\ref{tab:divby0}.  The quotient of division by zero has all bits set, and
+the remainder of division by zero equals the dividend.  Signed division overflow
+occurs only when the most-negative integer is divided by $-1$.  The quotient of
+a signed division with overflow is equal to the dividend, and the remainder is
+zero. Unsigned division overflow cannot occur.
 
 \vspace{0.1in}
 \begin{table}[h]
 \center
 \begin{tabular}{|l|c|c||c|c|c|c|}
 \hline
-Condition              & Dividend      & Divisor & DIVU         & REMU & DIV           & REM  \\ \hline
-Division by zero       & $x$           & 0       & $2^{XLEN}-1$ & $x$  & $-1$          & $x$  \\
-Overflow (signed only) & $-2^{XLEN-1}$ & $-1$    & --           & --   & $-2^{XLEN-1}$ & 0    \\
+Condition              & Dividend   & Divisor & DIVU[W]   & REMU[W] & DIV[W]     & REM[W] \\ \hline
+Division by zero       & $x$        & 0       & $2^{y}-1$ & $x$     & $-1$       & $x$    \\
+Overflow (signed only) & $-2^{y-1}$ & $-1$    & --        & --      & $-2^{y-1}$ & 0      \\
 \hline
 \end{tabular}
+where $y$ is equal to XLEN, or 32 for the W intructions.
 \caption{Semantics for division by zero and division overflow.}
 \label{tab:divby0}
 \end{table}
@@ -146,13 +154,3 @@ unsigned divider implementations.  Signed division is often
 implemented using an unsigned division circuit and specifying the same
 overflow result simplifies the hardware.
 \end{commentary}
-
-DIVW and DIVUW instructions are only valid for RV64, and divide the
-lower 32 bits of {\em rs1} by the lower 32 bits of {\em rs2}, treating
-them as signed and unsigned integers respectively, placing the 32-bit
-quotient in {\em rd}, sign-extended to 64 bits.  REMW and REMUW
-instructions are only valid for RV64, and provide the corresponding
-signed and unsigned remainder operations respectively. Both REMW and
-REMUW always sign-extend the 32-bit result to 64 bits, including on a
-divide by zero.
-


### PR DESCRIPTION
Follow up on #181.
I lifted the paragraph defining the `W`-version of the instructions above the table, and tried to make the table generic in that the 32-bit values for the "all ones" and "most negative int" are different for the `W`-version (for example, XLEN can be 64, but the most negative 32-bit int is not -2^{XLEN-1} but rather -2^{32-1}).
This PR simplifies the text a bit, but does make the table harder to read. Another way to specify it without adding an extra table would be to simply add a note in the `W`-instruction paragraph as...