### PR TITLE
 Be more explicit about allow less precise FS and XS transitions

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -831,10 +831,16 @@ register state.  In particular, setting FS=Off does not destroy the state, nor
 does setting FS=Initial clear the contents.  Other extensions might not
 preserve state when set to Off.
 
-Table~\ref{fsxsstates} shows all the possible state transitions for
-the FS or XS status bits.  Note that the standard floating-point
-extensions do not support user-mode unconfigure or disable/enable
-instructions.
+Table~\ref{fsxsstates} shows the most precise possible state transitions
+for the FS or XS status bits.  Implementations are allowed to be less
+precise than the state transitions listed in Table~\ref{fxsstates}, as
+long as the implemented state transitions have a larger number as
+defined by Table~\ref{fsxencoding}.  The platform may further restrict
+the degree to which less precise FS and/or XS state transitions are
+allowed.
+
+Note that the standard floating-point extensions do not support
+user-mode unconfigure or disable/enable instructions.
 
 \begin{table*}[h!]
 \begin{center}
@@ -887,7 +893,7 @@ Next state     & Initial   & Initial & Initial & Initial   \\
 \hline
 \end{tabular}
 \end{center}
-\caption{FS and XS state transitions.}
+\caption{The most precise FS and XS state transitions.}
 \label{fsxsstates}
 \end{table*}
 

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -847,7 +847,7 @@ Action & & & &\\
 \multicolumn{5}{|c|}{At context save in privileged code}\\
 \hline	 
 Save state?    & No         & No        & No     & Yes \\
-Next state       & Off        & Initial   & Clean  & Clean \\
+Next state     & Off        & Initial   & Clean  & Clean \\
 \hline
 \hline
 \multicolumn{5}{|c|}{At context restore in privileged code}\\


### PR DESCRIPTION
The goal here is to explicitly allow for implementations that use two
states to track FS.  The previous wording was ambiguous here, as it
seemed to allow that in the text but then specify a set of state
transitions.  This new wording makes it explicit that the listed state
transitions are just the most precise possible, and defines how
implementations are allowed to be less precise.

There's also one commit that has no output changes, it just re-aligns a table.

Fixes: https://github.com/riscv/riscv-isa-manual/issues/147