### PR TITLE
Don't describe fence.tso as a pseudoinstruction

### DIFF
--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -105,7 +105,6 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
                 & {\tt jalr x0, x6, offset[11:0]}                          & \\
 \hline
 {\tt fence} & {\tt fence iorw, iorw} & Fence on all memory and I/O \\
-{\tt fence.tso} & {\tt fence.tso rw, rw} & TSO Fence \\
 \hline
 
 \end{tabular}


### PR DESCRIPTION
As discussed in #186, it makes no sense for RISC-V assemblers to accept
`fence.tso rw, rw`. Removing this expansion from the pseudoinstruction
table (23.2) seems consistent with the description of fence.tso
elsewhere in the document.

If different pred/succ for fence.tso are made legal in a future spec, at
that point it would make sense to list fence.tso as a pseudoinstruction.