### PR TITLE
Disambiguation of accesses to SSIP/USIP bits through mip/sip/uip

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1268,9 +1268,10 @@ UTIE for M-mode, S-mode, and U-mode timer interrupts respectively.
 
 Each lower privilege level has a separate software interrupt-pending
 bit (SSIP, USIP), which can be both read and written by CSR accesses
-from code running on the local hart at the associated or any higher
-privilege level. The machine-level MSIP bits are written by accesses
-to memory-mapped control registers, which are used by remote harts to
+from code running on the local hart. SSIP and USIP can also be read and
+written through {\tt sip}, and USIP through {\tt uip} on systems where
+those registers are defined. The machine-level MSIP bits are written by
+accesses to memory-mapped control registers, which are used by remote harts to
 provide machine-mode interprocessor interrupts.  Interprocessor
 interrupts for lower privilege levels are implemented through ABI and
 SBI calls to the AEE or SEE respectively, which might ultimately


### PR DESCRIPTION
The bold section in the initial text

> Each lower privilege level has a separate software interrupt-pending bit (SSIP, USIP), which can
be both read and written by CSR accesses from code running on the local hart **at the associated
or any higher privilege level**.

suggests that `mip` could be accessed from other privilege modes than `M`. According to the CSR Address Mapping Conventions chapter, if I understand correctly, any access to `mip` from another mode than `M` should raise an illegal instruction exception. I presume that what is really being refered to here is the access to those bits through the `sip`/`uip` views of the `mip` register, so I am suggesting to make this explicit...