### PR TITLE
Switch to active voice

### DIFF
--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -50,7 +50,7 @@ RISC-V pseudoinstructions.
 \begin{tabular}{l l l}
 pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 
-\tt la rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load (absolute) address, \\
+\tt la rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load absolute address, \\
                   & {\tt addi rd, rd, delta[11:0]}                         & where ${\tt delta} = {\tt symbol} - {\tt pc}$ \\[1ex]
 \tt l\{b|h|w|d\} rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load global \\
                             & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)}                 & \\[1ex]
@@ -60,7 +60,7 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
                              & {\tt fl\{w|d\} rd, delta[11:0](rt)}                    & \\[1ex]
 \tt fs\{w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Floating-point store global \\
                              & {\tt fs\{w|d\} rd, delta[11:0](rt)}                    & \\[1ex]
-\multicolumn{3}{p{.99\textwidth}}{\small \em These pseudoinstructions use {\tt pc}-relative addressing, so the encoded address {\tt delta} subtracts the {\tt pc} from {\tt symbol}.  {\tt delta[11]} is added to the 20-bit high part counteract sign extension of the 12-bit low part.} \\
+\multicolumn{3}{p{.99\textwidth}}{\small \em The base instructions use {\tt pc}-relative addressing, so the linker subtracts {\tt pc} from {\tt symbol} to get {\tt delta}.  The linker adds {\tt delta[11]} to the 20-bit high part, counteracting sign extension of the 12-bit low part.} \\
 ~\\
 \hline
 {\tt nop} & {\tt addi x0, x0, 0} & No operation \\


### PR DESCRIPTION
Active voice, discussed in #177.

Also fix: the pseudoinstructions use absolute addressing, the base instructions are pc-relative. `symbol` is an absolute value and `auipc` is pc-relative.

If I understand correctly, `la rd, symbol` just puts `symbol` into `rd`. For 32 bit systems, it is essentially equivalent to `li rd, symbol`.