### PR TITLE
Help the reader by pointing at TVM, TW and TSR in the relevant sections

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2011,9 +2011,10 @@ MRET/SRET/URET & 0 & PRIV & 0 & SYSTEM \\
 To return after handling a trap, there are separate trap return
 instructions per privilege level: MRET, SRET, and URET.  MRET is
 always provided. SRET must be provided if supervisor mode is
-supported, and should raise an illegal instruction otherwise.
-URET is only provided if user-mode traps are supported, and
-should raise an illegal instruction otherwise.
+supported, and should raise an illegal instruction exception otherwise. SRET
+should also raise an illegal instruction exception when TSR=1 in {\tt mstatus},
+as described in Section~\ref{virt-control}. URET is only provided if user-mode
+traps are supported, and should raise an illegal instruction otherwise.
 An {\em x}\,RET instruction can be executed in privilege mode {\em x}
 or higher, where executing a lower-privilege {\em x}\,RET instruction
 will pop the relevant lower-privilege interrupt enable and privilege

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2924,6 +2924,7 @@ than XLEN bits (e.g., the FSD instruction in RV32D), even when the store
 address is naturally aligned.
 
 \subsection{Physical Memory Protection and Paging}
+\label{pmp-vmem}
 
 The Physical Memory Protection mechanism is designed to compose with the
 page-based virtual memory systems described in Chapter~\ref{supervisor}.  When

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -661,6 +661,7 @@ Note that, while SUM is ordinarily ignored when not executing in S-mode, it
 not supported.
 
 \subsection{Virtualization Support in {\tt mstatus} Register}
+\label{virt-control}
 
 The TVM (Trap Virtual Memory) bit supports intercepting
 supervisor virtual-memory management operations.  When TVM=1,
@@ -2038,7 +2039,9 @@ might need servicing.  Execution of the WFI instruction can also be
 used to inform the hardware platform that suitable interrupts should
 preferentially be routed to this hart.  WFI is available in all of the
 supported S and M privilege modes, and optionally available to
-U-mode for implementations that support U-mode interrupts.
+U-mode for implementations that support U-mode interrupts. This instruction may
+raise an illegal instruction exception when TW=1 in {\tt mstatus}, as described
+in Section~\ref{virt-control}.
 
 \vspace{-0.2in}
 \begin{center}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -726,7 +726,9 @@ This register holds the physical page number (PPN) of the root page
 table, i.e., its supervisor physical address divided by \wunits{4}{KiB};
 an address space identifier (ASID), which facilitates address-translation
 fences on a per-address-space basis; and the MODE field, which selects the
-current address-translation scheme.
+current address-translation scheme. Attempts to access this register should
+raise an illegal instruction exception when TVM=1 in {\tt mstatus}, as
+described in Section~\ref{virt-control}.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -912,7 +914,9 @@ these data structures; however, these implicit references are ordinarily not
 ordered with respect to loads and stores in the instruction stream.  Executing
 an SFENCE.VMA instruction guarantees that any stores in the instruction stream
 prior to the SFENCE.VMA are ordered before all implicit references subsequent
-to the SFENCE.VMA.
+to the SFENCE.VMA. This instruction should raise an illegal instruction
+exception when TVM=1 in {\tt mstatus}, as described in
+Section~\ref{virt-control}.
 
 \begin{commentary}
 The SFENCE.VMA is used to flush any local hardware caches related to

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -726,9 +726,8 @@ This register holds the physical page number (PPN) of the root page
 table, i.e., its supervisor physical address divided by \wunits{4}{KiB};
 an address space identifier (ASID), which facilitates address-translation
 fences on a per-address-space basis; and the MODE field, which selects the
-current address-translation scheme. Attempts to access this register should
-raise an illegal instruction exception when TVM=1 in {\tt mstatus}, as
-described in Section~\ref{virt-control}.
+current address-translation scheme. Further details on the access to this
+register are described in Section~\ref{virt-control}.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -914,9 +913,8 @@ these data structures; however, these implicit references are ordinarily not
 ordered with respect to loads and stores in the instruction stream.  Executing
 an SFENCE.VMA instruction guarantees that any stores in the instruction stream
 prior to the SFENCE.VMA are ordered before all implicit references subsequent
-to the SFENCE.VMA. This instruction should raise an illegal instruction
-exception when TVM=1 in {\tt mstatus}, as described in
-Section~\ref{virt-control}.
+to the SFENCE.VMA. Further details on the behaviour of this instruction are
+described in Section~\ref{virt-control}.
 
 \begin{commentary}
 The SFENCE.VMA is used to flush any local hardware caches related to

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -914,7 +914,7 @@ ordered with respect to loads and stores in the instruction stream.  Executing
 an SFENCE.VMA instruction guarantees that any stores in the instruction stream
 prior to the SFENCE.VMA are ordered before all implicit references subsequent
 to the SFENCE.VMA. Further details on the behaviour of this instruction are
-described in Section~\ref{virt-control}.
+described in Section~\ref{virt-control} and Section~\ref{pmp-vmem}.
 
 \begin{commentary}
 The SFENCE.VMA is used to flush any local hardware caches related to


### PR DESCRIPTION
Sections that are possibly distant in the document from the `mstatus` section are often affected by bits in the `mstatus` register.
I suggest helping the reader by mentioning that specific instructions/csrs are influenced by `mstatus` where those instructions/csrs are defined as opposed to exclusively in the `mstatus` section.

EDIT: Added a mention of TSR when describing SRET as well.

Additionally, when describing the `mstatus` TW field, shoud U-mode be mentioned in the case that user interrupts are enabled?