### PR TITLE
Strengthen guidance on the need to clear a reservation using SC

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -215,8 +215,9 @@ any address) between the LR and the SC in program order.  In other
 words, multiple outstanding reservations are not permitted.
 
 \begin{commentary}
-A store-conditional instruction to a scratch word of memory can be used
-by context-switch code to forcibly yield any existing load reservation.
+A store-conditional instruction to a scratch word of memory should be used
+during a preemptive context switch to forcibly yield any existing load
+reservation.
 \end{commentary}
 
 \begin{commentary}


### PR DESCRIPTION
Commit 170f3c5 clarified that reservations can be cleared with an SC to
a dummy memory location. As discussed
<https://github.com/riscv/riscv-isa-manual/commit/170f3c52bd134ac90c3467f77925fdaa68e9b8f6#commitcomment-29386537>,
this patch makes it clear that the reservation "should" be cleared in
this way during a preemptive context switch.

Anyone writing preemptive context switch code should be forcibly
clearing load reservations. Although other mechanisms might be used,
this is the standard way of doing it (hence "should" rather than
"must").