### PR TITLE
Correct an instance of lr{w|d}.aq.rl to lr{w|d}.aqrl

### DIFF
--- a/src/memory.tex
+++ b/src/memory.tex
@@ -937,7 +937,7 @@ Power ISYNC maps on RISC-V to a FENCE.I followed by a FENCE~R,R; the latter fenc
     \hline
     Load-Exclusive            & \tt lr.\{w|d\}  \\
     \hline
-    Load-Acquire-Exclusive    & \tt lr.\{w|d\}.aq.rl \\
+    Load-Acquire-Exclusive    & \tt lr.\{w|d\}.aqrl \\
     \hline
     Store                     & \tt s\{b|h|w|d\}  \\
     \hline


### PR DESCRIPTION
Although purely a spelling issue, CCing @daniellustig as it touches memory.tex.