### PR TITLE
Clarify that AMOs are always stores, and clarify fence.tso configs

### DIFF
--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1213,7 +1213,7 @@ That said, these mappings are subject to change as the Linux Kernel Memory Model
 \end{table}
 
 Table~\ref{tab:c11mappings} provides a mapping of C11/C++11 atomic operations onto RISC-V memory instructions.
-If load and store opcodes with {\em aq} and {\em rl} modifiers are introduced, then the mappings in Figure~\ref{tab:c11mappings_hypothetical} will suffice.
+If load and store opcodes with {\em aq} and {\em rl} modifiers are introduced, then the mappings in Table~\ref{tab:c11mappings_hypothetical} will suffice.
 Note however that the two mappings only interoperate correctly if {\tt atomic\_<op>(memory\_order\_seq\_cst)} is mapped using an LR that has both {\em aq} and {\em rl} set.
 
 Any AMO can be emulated by an LR/SC pair, but care must be taken to ensure that any PPO orderings that originate from the LR are also made to originate from the SC, and that any PPO orderings that terminate at the SC are also made to terminate at the LR.

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1275,7 +1275,7 @@ Architectures that implement RVTSO can safely do the following:
 Other general notes:
 
 \begin{itemize}
-  \item Silent stores (i.e., stores that write the same value that already exists at a memory location) behave like any other store from a memory model point of view.  Microarchitectures that attempt to implement silent stores must take care to ensure that the memory model is still obeyed, particularly in cases such as RSW (Section~\ref{sec:memory:overlap}) which tend to be incompatible with silent stores.
+  \item Silent stores (i.e., stores that write the same value that already exists at a memory location) behave like any other store from a memory model point of view.  Likewise, AMOs which do not actually change the value in memory (e.g., an AMOMAX for which the value in {\em rs2} is smaller than the value currently in memory) are still semantically considered store operations.  Microarchitectures that attempt to implement silent stores must take care to ensure that the memory model is still obeyed, particularly in cases such as RSW (Section~\ref{sec:memory:overlap}) which tend to be incompatible with silent stores.
   \item Writes may be merged (i.e., two consecutive writes to the same address may be merged) or subsumed (i.e., the earlier of two back-to-back writes to the same address may be elided) as long as the resulting behavior does not otherwise violate the memory model semantics.
 \end{itemize}
 

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -536,7 +536,7 @@ Note, however, that in this case, the fence also enforces additional orderings: 
 In this way, fence-enforced orderings are slightly coarser than orderings enforced by {\em .aq}.
 
 Release orderings work exactly the same as acquire orderings, just in the opposite direction.  Release semantics require all loads and stores preceding the release operation in program order to also precede the release operation in the global memory order.
-This ensures, for example, that memory accesses in a critical section appear before the lock-releasing store in the global memory order.  Just as for acquire semantics, release semantics can be enforced using release annotations or with a FENCE~R,RW operations.  Using the same examples, the ordering between the loads and stores in the critical section and the ``Arbitrary unrelated store'' at the end of the code snippet is enforced only by the FENCE~R,RW in Figure~\ref{fig:litmus:spinlock_fences}, not by the {\em rl} in Figure~\ref{fig:litmus:spinlock_fences}.
+This ensures, for example, that memory accesses in a critical section appear before the lock-releasing store in the global memory order.  Just as for acquire semantics, release semantics can be enforced using release annotations or with a FENCE~R,RW operations.  Using the same examples, the ordering between the loads and stores in the critical section and the ``Arbitrary unrelated store'' at the end of the code snippet is enforced only by the FENCE~R,RW in Figure~\ref{fig:litmus:spinlock_fences}, not by the {\em rl} in Figure~\ref{fig:litmus:spinlock_atomics}.
 
 With RCpc annotations alone, store-release-to-load-acquire ordering is not enforced.  This facilitates the porting of code written under the TSO and/or RCpc memory models.  
 To enforce store-release-to-load-acquire ordering, the code must use store-release-RCsc and load-acquire-RCsc operations so that PPO rule \ref{ppo:rcsc} applies.
@@ -757,7 +757,7 @@ Therefore, (f) will never perform before (d) has performed.
   \label{fig:litmus:addrdatarfi_no}
 \end{figure}
 
-If there were another store to the same address in between (b) and (c), as in Figure~\ref{fig:litmus:addrdatarfi_no}, then (c) would no longer be dependent on the data of (b) being resolved, and hence the dependency of (c) on (a), which produces the data for (b), would be broken.
+If there were another store to the same address in between (e) and (f), as in Figure~\ref{fig:litmus:addrdatarfi_no}, then (f) would no longer be dependent on the data of (e) being resolved, and hence the dependency of (f) on (d), which produces the data for (e), would be broken.
 
 Rule~\ref{ppo:addrpo} makes a similar observation to the previous rule: a store cannot be performed at memory until all previous loads that might access the same address have themselves been performed.
 Such a load must appear to execute before the store, but it cannot do so if the store were to overwrite the value in memory before the load had a chance to read the old value.
@@ -785,7 +785,7 @@ Likewise, a store generally cannot be performed until it is known that preceding
 \end{figure}
 
 Consider Figure~\ref{fig:litmus:addrpo}:
-(f) cannot be executed until the address for (e) is resolved, because it may turn out that the addresses match; i.e., that {\tt a0=s1}.  Therefore, (f) cannot be sent to memory before (d) has executed and confirmed whether the addresses do indeed overlap.
+(f) cannot be executed until the address for (e) is resolved, because it may turn out that the addresses match; i.e., that {\tt a1=s0}.  Therefore, (f) cannot be sent to memory before (d) has executed and confirmed whether the addresses do indeed overlap.
 
 
 \section{Beyond Main Memory}

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1420,9 +1420,9 @@ will also be ordered using the I and O bits in a FENCE.
 0000 & \em none & Normal Fence \\
 \hline
 \multirow{2}{*}{1000} & \multirow{2}{*}{TSO} & With FENCE RW,RW: exclude write-to-read ordering \\
-                      &                      & Otherwise: \em Invalid.  Reserved for future use. \\
+                      &                      & Otherwise: \em Reserved for future use. \\
 \hline
-\multicolumn{2}{|c|}{\em other} & \em Invalid.  Reserved for future use. \\
+\multicolumn{2}{|c|}{\em other} & \em Reserved for future use. \\
 \hline
 \end{tabular}
 \end{center}
@@ -1439,8 +1439,11 @@ This leaves non-AMO store operations in the FENCE.TSO's predecessor set unordere
 The unused fields in the FENCE instructions---{\em rs1} and {\em rd}---are
 reserved for finer-grain fences in future extensions.  For forward
 compatibility, base implementations shall ignore these fields, and standard
-software shall zero these fields.
-Likewise, all combinations of {\em fm} and predecessor/successor set not listed in Table~\ref{fm} are also reserved for future use.
+software shall zero these fields.  Likewise, many {\em fm} and
+predecessor/successor set settings in Table~\ref{fm} are also reserved
+for future use.  Base implementations shall treat all such reserved
+configurations as normal fences with {\em fm}=0000, and standard
+software shall use only non-reserved configurations.
 
 \begin{commentary}
 We chose a relaxed memory model to allow high performance from simple


### PR DESCRIPTION
Two small updates to the memory model text

1) Clarify that AMOs are always semantically considered stores
2) Attempt to clarify #186