### PR TITLE
Clarifications on the virtual memory translation mechanism

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -638,15 +638,20 @@ widest supported width not wider than the new MXLEN.
 
 \subsection{Memory Privilege in {\tt mstatus} Register}
 
-The MPRV (Modify PRiVilege) bit modifies the privilege level at which
-loads and stores execute in all privilege modes.  When MPRV=0,
-translation and protection behave as normal, that is, M-mode accesses only go
-through the PMP mechanism (Section~\ref{sec:pmp}), and S-mode and U-mode
-accesses may also go through the address translation mechanism
-(Section~\ref{sv32algorithm}).  When MPRV=1, load and store memory addresses
-are translated and protected as though the current privilege mode were set to
-MPP.  Instruction address-translation and protection are unaffected.  MPRV is
-hardwired to 0 if U-mode is not supported.
+The MPRV (Modify PRiVilege) bit modifies the privilege level at which loads
+and stores execute in all privilege modes. When MPRV=1, load and store memory
+addresses are translated and protected as though the current privilege mode
+were set to MPP. When MPRV=0, loads and stores are unaffected. Instruction
+address-translation and protection are unaffected. MPRV is hardwired to 0 if
+U-mode is not supported.
+
+\begin{commentary}
+MPRV enables M-mode software to use the translation and protection mechanisms
+active in S-mode and U-mode, typically the one described in
+Section~\ref{sv32algorithm}. When MPRV=0, M-mode accesses do not go through
+these mechanisms, but still undergo checks active in M-mode, such as the PMP
+mechanism described in Section~\ref{sec:pmp}.
+\end{commentary}
 
 The MXR (Make eXecutable Readable) bit modifies the privilege with which loads
 access virtual memory.  When MXR=0, only loads from pages marked readable (R=1

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -640,11 +640,13 @@ widest supported width not wider than the new MXLEN.
 
 The MPRV (Modify PRiVilege) bit modifies the privilege level at which
 loads and stores execute in all privilege modes.  When MPRV=0,
-translation and protection behave as normal.  When MPRV=1, load and
-store memory addresses are translated and protected as though the
-current privilege mode were set to MPP.  Instruction
-address-translation and protection are unaffected.  MPRV is hardwired
-to 0 if U-mode is not supported.
+translation and protection behave as normal, that is, M-mode accesses only go
+through the PMP mechanism (Section~\ref{sec:pmp}), and S-mode and U-mode
+accesses may also go through the address translation mechanism
+(Section~\ref{sv32algorithm}).  When MPRV=1, load and store memory addresses
+are translated and protected as though the current privilege mode were set to
+MPP.  Instruction address-translation and protection are unaffected.  MPRV is
+hardwired to 0 if U-mode is not supported.
 
 The MXR (Make eXecutable Readable) bit modifies the privilege with which loads
 access virtual memory.  When MXR=0, only loads from pages marked readable (R=1

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -290,7 +290,7 @@ Number    & Privilege & Name & Description \\
 \tt 0x343 & MRW  &\tt mtval      & Machine bad address or instruction. \\
 \tt 0x344 & MRW  &\tt mip        & Machine interrupt pending. \\
 \hline
-\multicolumn{4}{|c|}{Machine Protection and Translation} \\
+\multicolumn{4}{|c|}{Machine Memory Protection} \\
 \hline
 %\tt 0x380 & MRW  &\tt mbase      & Base register. \\
 %\tt 0x381 & MRW  &\tt mbound     & Bound register. \\

--- a/src/priv-intro.tex
+++ b/src/priv-intro.tex
@@ -146,7 +146,7 @@ possibly additional secure execution modes.
 
 Each privilege level has a core set of privileged ISA extensions with
 optional extensions and variants.  For example, machine-mode supports
-an optional standard variant for memory protection.  Also, supervisor-mode
+an optional standard extension for memory protection.  Also, supervisor-mode
 can be extended to support Type-2 hypervisor execution as described in
 Chapter~\ref{hypervisor}.
 

--- a/src/priv-intro.tex
+++ b/src/priv-intro.tex
@@ -146,9 +146,9 @@ possibly additional secure execution modes.
 
 Each privilege level has a core set of privileged ISA extensions with
 optional extensions and variants.  For example, machine-mode supports
-several optional standard variants for address translation and memory
-protection.  Also, supervisor-mode can be extended to support Type-2
-hypervisor execution as described in Chapter~\ref{hypervisor}.
+an optional standard variant for memory protection.  Also, supervisor-mode
+can be extended to support Type-2 hypervisor execution as described in
+Chapter~\ref{hypervisor}.
 
 Implementations might provide anywhere from 1 to 3 privilege modes
 trading off reduced isolation for lower implementation cost, as shown

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -812,6 +812,10 @@ Implementations are not required to support all MODE settings,
 and if {\tt satp} is written with an unsupported MODE, the entire write has
 no effect; no fields in {\tt satp} are modified.
 
+When memory translation is active, instruction fetches and memory loads and stores
+from S-mode and U-mode go through the translation mechanism described in
+Section~\ref{sv32algorithm}.
+
 \begin{table}[h]
 \begin{center}
 \begin{tabular}{|c|c|l|}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -812,10 +812,6 @@ Implementations are not required to support all MODE settings,
 and if {\tt satp} is written with an unsupported MODE, the entire write has
 no effect; no fields in {\tt satp} are modified.
 
-When memory translation is active, instruction fetches and memory loads and stores
-from S-mode and U-mode go through the translation mechanism described in
-Section~\ref{sv32algorithm}.
-
 \begin{table}[h]
 \begin{center}
 \begin{tabular}{|c|c|l|}
@@ -825,7 +821,7 @@ Section~\ref{sv32algorithm}.
 Value  & Name & Description \\
 \hline
 0       & Bare  & No translation or protection. \\
-1       & Sv32  & Page-based 32-bit virtual addressing. \\
+1       & Sv32  & Page-based 32-bit virtual addressing (see Section~\ref{sec:sv32}). \\
 \hline \hline
 \multicolumn{3}{|c|}{RV64} \\
 \hline
@@ -833,8 +829,8 @@ Value  & Name & Description \\
 \hline  
 0       & Bare  & No translation or protection. \\
 1--7    & ---   & {\em Reserved} \\
-8       & Sv39  & Page-based 39-bit virtual addressing. \\
-9       & Sv48  & Page-based 48-bit virtual addressing. \\
+8       & Sv39  & Page-based 39-bit virtual addressing (see Section~\ref{sec:sv39}). \\
+9       & Sv48  & Page-based 48-bit virtual addressing (see Section~\ref{sec:sv48}). \\
 10      & {\em Sv57} & {\em Reserved for page-based 57-bit virtual addressing.} \\
 11      & {\em Sv64} & {\em Reserved for page-based 64-bit virtual addressing.} \\
 12--15  & ---   & {\em Reserved} \\
@@ -992,8 +988,10 @@ the ASID value in {\em rs2} and always perform a global fence.
 
 When Sv32 is written to the MODE field in the {\tt satp} register
 (see Section~\ref{sec:satp}),
-the supervisor operates in a 32-bit paged virtual-memory system.  Sv32
-is supported on RV32 systems and is designed to include mechanisms
+the supervisor operates in a 32-bit paged virtual-memory system.
+Instruction fetches and memory loads and stores from S-mode and U-mode
+go through the translation mechanism described in Section~\ref{sv32algorithm}.
+Sv32 is supported on RV32 systems and is designed to include mechanisms
 sufficient for supporting modern Unix-based operating systems.
 
 \begin{commentary}


### PR DESCRIPTION
This is based on a confusion I had that memory translation should always take place when enabled, that is even for memory accesses in M-mode. After chatting with a colleague, I understand now that it should only be the case for S-mode and U-mode (although memory translation with an effective current privilege of M-mode can take place when writing S-mode or U-mode to MPP and 1 to MPRV).

Is this correct?
If so, this set of changes tries to make it more explicit that M-mode virtual translation are not a thing.