### PR TITLE
Fix Typo: Recover a lost brace in assembly.tex

### DIFF
--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -54,7 +54,7 @@ pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
                   & {\tt addi rd, rd, delta[11:0]}                         & where ${\tt delta} = {\tt symbol} - {\tt pc}$ \\[1ex]
 \tt l\{b|h|w|d\} rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load global \\
                             & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)}                 & \\[1ex]
-\tt s\{b|h|w|d\ rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Store global \\
+\tt s\{b|h|w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Store global \\
                                & {\tt s\{b|h|w|d\} rd, delta[11:0](rt)}                 & \\[1ex]
 \tt fl\{w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Floating-point load global \\
                              & {\tt fl\{w|d\} rd, delta[11:0](rt)}                    & \\[1ex]


### PR DESCRIPTION
The commit 3f05dd6ef3c7965f0d9c375c19bf4a4a76c331be from 2018-06-02 lost a closing brace.
This patch restores it.