### PR TITLE
Remove text stating C.ADDI4SPN is RV32C/RV64C-only

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -829,9 +829,9 @@ C.ADDI4SPN & nzuimm[5:4$\vert$9:6$\vert$2$\vert$3] & dest & C0 \\
 \end{tabular}
 \end{center}
 
-C.ADDI4SPN is a CIW-format RV32C/RV64C-only instruction that adds a
-{\em zero}-extended non-zero immediate, scaled by 4, to the stack pointer,
-{\tt x2}, and writes the result to {\tt rd$'$}.  This instruction is used
+C.ADDI4SPN is a CIW-format instruction that adds a {\em zero}-extended
+non-zero immediate, scaled by 4, to the stack pointer, {\tt x2}, and
+writes the result to {\tt rd$'$}.  This instruction is used
 to generate pointers to stack-allocated variables, and expands to
 {\tt addi rd$'$, x2, nzuimm[9:2]}.
 


### PR DESCRIPTION
The paragraph of text describing C.ADDI4SPN states the instruction is
RV32C/RV64C-only, but the opcode map indicates the instruction is
available for RV128C too.  This change updates the descriptive text,
assuming that the opcode map is correct.