### PR TITLE
Clarification on the meaning of the annotations

### DIFF
--- a/src/rvwmo.tex
+++ b/src/rvwmo.tex
@@ -72,7 +72,7 @@ An ``RCsc annotation'' refers to an acquire-RCsc annotation or a release-RCsc an
 \begin{commentary}
   In the memory model literature, the term ``RCpc'' stands for release consistency with processor-consistent synchronization operations, and the term ``RCsc'' stands for release consistency with sequentially-consistent synchronization operations~\cite{Gharachorloo90memoryconsistency}.
   
-While there are many different informal defintions of these annotations, in the context of the RISC-V RVWMO (and by extension RVTSO) these terms are concisely and completely defined axiomatixally by Preserved Program Order rules 4, 5 and 6 on page ##.
+While there are many different informal definitions of these annotations, in the context of the RISC-V RVWMO (and by extension RVTSO) these terms are concisely and completely defined axiomatixally by Preserved Program Order rules \ref{ppo:acquire}--\ref{ppo:rcsc}.
 
   ``RCpc'' annotations are currently only used when implicitly assigned to every memory access per the standard extension ``Ztso'' (Chapter~\ref{sec:ztso}).  Furthermore, although the ISA does not currently contain native load-acquire or store-release instructions, nor RCpc variants thereof, the RVWMO model itself is designed to be forwards-compatible with the potential addition of any or all of the above into the ISA in a future extension.
 \end{commentary}

--- a/src/rvwmo.tex
+++ b/src/rvwmo.tex
@@ -72,7 +72,7 @@ An ``RCsc annotation'' refers to an acquire-RCsc annotation or a release-RCsc an
 \begin{commentary}
   In the memory model literature, the term ``RCpc'' stands for release consistency with processor-consistent synchronization operations, and the term ``RCsc'' stands for release consistency with sequentially-consistent synchronization operations~\cite{Gharachorloo90memoryconsistency}.
   
-While there are many different definitions of acquire and release annotations, in the context of the RVWMO these terms are concisely and completely defined by Preserved Program Order rules \ref{ppo:acquire}--\ref{ppo:rcsc}.
+While there are many different definitions for acquire and release annotations in the literature, in the context of the RVWMO these terms are concisely and completely defined by Preserved Program Order rules \ref{ppo:acquire}--\ref{ppo:rcsc}.
 
   ``RCpc'' annotations are currently only used when implicitly assigned to every memory access per the standard extension ``Ztso'' (Chapter~\ref{sec:ztso}).  Furthermore, although the ISA does not currently contain native load-acquire or store-release instructions, nor RCpc variants thereof, the RVWMO model itself is designed to be forwards-compatible with the potential addition of any or all of the above into the ISA in a future extension.
 \end{commentary}

--- a/src/rvwmo.tex
+++ b/src/rvwmo.tex
@@ -72,7 +72,7 @@ An ``RCsc annotation'' refers to an acquire-RCsc annotation or a release-RCsc an
 \begin{commentary}
   In the memory model literature, the term ``RCpc'' stands for release consistency with processor-consistent synchronization operations, and the term ``RCsc'' stands for release consistency with sequentially-consistent synchronization operations~\cite{Gharachorloo90memoryconsistency}.
   
-While there are many different informal definitions of these annotations, in the context of the RISC-V RVWMO (and by extension RVTSO) these terms are concisely and completely defined axiomatixally by Preserved Program Order rules \ref{ppo:acquire}--\ref{ppo:rcsc}.
+While there are many different definitions of acquire and release annotations, in the context of the RVWMO these terms are concisely and completely defined by Preserved Program Order rules \ref{ppo:acquire}--\ref{ppo:rcsc}.
 
   ``RCpc'' annotations are currently only used when implicitly assigned to every memory access per the standard extension ``Ztso'' (Chapter~\ref{sec:ztso}).  Furthermore, although the ISA does not currently contain native load-acquire or store-release instructions, nor RCpc variants thereof, the RVWMO model itself is designed to be forwards-compatible with the potential addition of any or all of the above into the ISA in a future extension.
 \end{commentary}

--- a/src/rvwmo.tex
+++ b/src/rvwmo.tex
@@ -71,6 +71,8 @@ An ``RCsc annotation'' refers to an acquire-RCsc annotation or a release-RCsc an
 
 \begin{commentary}
   In the memory model literature, the term ``RCpc'' stands for release consistency with processor-consistent synchronization operations, and the term ``RCsc'' stands for release consistency with sequentially-consistent synchronization operations~\cite{Gharachorloo90memoryconsistency}.
+  
+While there are many different informal defintions of these annotations, in the context of the RISC-V RVWMO (and by extension RVTSO) these terms are concisely and completely defined axiomatixally by Preserved Program Order rules 4, 5 and 6 on page ##.
 
   ``RCpc'' annotations are currently only used when implicitly assigned to every memory access per the standard extension ``Ztso'' (Chapter~\ref{sec:ztso}).  Furthermore, although the ISA does not currently contain native load-acquire or store-release instructions, nor RCpc variants thereof, the RVWMO model itself is designed to be forwards-compatible with the potential addition of any or all of the above into the ISA in a future extension.
 \end{commentary}


### PR DESCRIPTION
As discussed in the weekly memory model meeting, this text clarifies that it is not necessary (and perhaps not desirable) to research the common definitions of these memory ordering annotation terms - in the context of RISC-V their semantics are  fully defined in this chapter.