### PR TITLE
A pair of somewhat pedantic changes to the wording of C.NOP

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -1099,7 +1099,8 @@ C.NOP & 0 & 0 & 0 & C1 \\
 \end{center}
 
 C.NOP is a CI-format instruction that does not change any user-visible state,
-except for advancing the {\tt pc}.  C.NOP expands to {\tt nop}.
+except for advancing the {\tt pc} and incrementing any applicable performance
+counters.  C.NOP expands to {\tt nop}.
 
 \subsection*{Breakpoint Instruction}
 \vspace{-0.4in}

--- a/src/c.tex
+++ b/src/c.tex
@@ -1099,8 +1099,7 @@ C.NOP & 0 & 0 & 0 & C1 \\
 \end{center}
 
 C.NOP is a CI-format instruction that does not change any user-visible state,
-except for advancing the {\tt pc}.  C.NOP is encoded as {\tt c.addi x0, 0} and
-so expands to {\tt addi x0, x0, 0}.
+except for advancing the {\tt pc}.  C.NOP expands to {\tt nop}.
 
 \subsection*{Breakpoint Instruction}
 \vspace{-0.4in}


### PR DESCRIPTION
I was recently reading the instruction manual and noticed that the text describing the C.NOP instruction resulted in a self-inconsistency in the ISA manual.  This is all a bit pedantic, as I don't think any reasonable implementator would run the risk of getting confused here.  That said, I still couldn't stop myself from fixing it :).