### PR TITLE
Describe the AMOs as "bitwise", not "logical"

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -326,8 +326,8 @@ emulated.  The ``Zam'' extension, described in Chapter~\ref{sec:zam},
 relaxes this requirement and specifies the semantics of misaligned
 AMOs.
 
-The operations supported are swap, integer add, logical AND, logical
-OR, logical XOR, and signed and unsigned integer maximum and minimum.
+The operations supported are swap, integer add, bitwise AND, bitwise
+OR, bitwise XOR, and signed and unsigned integer maximum and minimum.
 Without ordering constraints, these AMOs can be used to implement
 parallel reduction operations, where typically the return value would
 be discarded by writing to {\tt x0}.


### PR DESCRIPTION
"logical AND" usually means C's "&&" operator, not "&" operator.  Thanks
to Bodhisattva Debnath for pointing out the issue!