### PR TITLE
Change funct to funct2 in the CA format

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -309,7 +309,7 @@ CS & Store &
 CA & Arithmetic &
 \multicolumn{6}{|c|}{funct6} &
 \multicolumn{3}{c|}{rd$'$/rs1$'$} &
-\multicolumn{2}{c|}{funct} &
+\multicolumn{2}{c|}{funct2} &
 \multicolumn{3}{c|}{rs2$'$} &
 \multicolumn{2}{c|}{op} \\
 \cline{3-18}
@@ -1001,7 +1001,7 @@ result to register {\em rd}.  C.ADD expands into {\tt add rd, rd, rs2}.
 \hline
 \multicolumn{1}{|c|}{funct6} &
 \multicolumn{1}{c|}{rd$'$/rs1$'$} &
-\multicolumn{1}{c|}{funct} &
+\multicolumn{1}{c|}{funct2} &
 \multicolumn{1}{c|}{rs2$'$} &
 \multicolumn{1}{c|}{op} \\
 \hline


### PR DESCRIPTION
In the RVC instruction formats figure and the respective subsection, the CA format row is changed such that the funct field is renamed to funct2, for consistency with the base ISA (which distinguishes between funct7 and funct3).

In the RVC instruction listings, the instructions with the CA format have the table formatting updated to match the new CA format, which was introduced in the commit 00557c314bd288c6eb511a201ce90bbdd4450d19.