### PR TITLE
Fix colliding latex labels.

### DIFF
--- a/src/instr-table.tex
+++ b/src/instr-table.tex
@@ -462,7 +462,7 @@
 \end{center}
 \end{small}
 
-\label{instr-table}
+\label{instr-table0}
 \end{table}
   
 
@@ -895,7 +895,7 @@
 \end{center}
 \end{small}
 
-\label{instr-table}
+\label{instr-table1}
 \end{table}
   
 
@@ -1212,7 +1212,7 @@
 \end{center}
 \end{small}
 
-\label{instr-table}
+\label{instr-table2}
 \end{table}
   
 
@@ -1598,7 +1598,7 @@
 \end{center}
 \end{small}
 
-\label{instr-table}
+\label{instr-table3}
 \end{table}
   
 

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -134,7 +134,7 @@ illegal instruction exceptions on machine-mode access to these registers.
 
 \section{CSR Listing}
 
-Tables~\ref{ucsrnames}--\ref{mcsrnames} list the CSRs that have
+Tables~\ref{ucsrnames}--\ref{mcsrnames1} list the CSRs that have
 currently been allocated CSR addresses.  The timers, counters, and
 floating-point CSRs are standard user-level CSRs, as well as the
 additional user trap registers added by the N extension.  The other
@@ -310,7 +310,7 @@ Number    & Privilege & Name & Description \\
 \end{tabular}
 \end{center}
 \caption{Currently allocated RISC-V machine-level CSR addresses.}
-\label{mcsrnames}
+\label{mcsrnames0}
 \end{table}
 
 \begin{table}[htb!]
@@ -357,7 +357,7 @@ Number    & Privilege & Name & Description \\
 \end{tabular}
 \end{center}
 \caption{Currently allocated RISC-V machine-level CSR addresses.}
-\label{mcsrnames}
+\label{mcsrnames1}
 \end{table}
 
 \clearpage

--- a/src/priv-instr-table.tex
+++ b/src/priv-instr-table.tex
@@ -114,6 +114,6 @@
 \end{center}
 \end{small}
 \caption{RISC-V Privileged Instructions}
-\label{instr-table}
+\label{priv-instr-table}
 \end{table}
   

--- a/src/v-instr-table.tex
+++ b/src/v-instr-table.tex
@@ -539,7 +539,7 @@
 \end{center}
 \end{small}
 
-\label{instr-table}
+\label{v-instr-table0}
 \end{table}
   
 
@@ -730,6 +730,6 @@
 \end{center}
 \end{small}
 \caption{Instruction listing for RISC-V}
-\label{instr-table}
+\label{v-instr-table1}
 \end{table}
   

--- a/src/v.tex
+++ b/src/v.tex
@@ -1,5 +1,5 @@
 \chapter{``V'' Standard Extension for Vector Operations, Version 0.4-DRAFT}
-\label{sec:bits}
+\label{sec:vector}
 
 {\bf This version is out-of-date with respect to the current working
   group draft, which is now hosted on {\tt https://github.com/riscv/riscv-v-spec}.}


### PR DESCRIPTION
needed to fix only one label reference to mcsrnames.
