### PR TITLE
Add commentary on combining RV32E with extensions, mention Zfinx

### DIFF
--- a/src/rv32e.tex
+++ b/src/rv32e.tex
@@ -47,3 +47,11 @@ extensions will not make use of the instruction bits freed up by the
 reduced register-specifier fields and so these are available for
 custom extensions.
 
+\begin{commentary}
+RV32E can be combined with all current standard extensions. Defining the F, D,
+and Q extensions as having a 16-entry floating point register file when
+combined with RV32E was considered but decided against. Instead, we intend to
+define a ``Zfinx'' extension that makes floating-point computations use the
+integer registers, removing the floating-point loads, stores, and moves between
+floating point and integer registers.
+\end{commentary}


### PR DESCRIPTION
Following on from #265, I think it would be worth documenting the decision to leave F and D extensions as introducing 32 FP registers when combined with RV32E. It's an obvious question/concern and the ISA manual tends to do a great job of anticipating these with commentary paragraphs - so let's add a new one.

I drafted something for the sake of moving the discussion forwards, but obviously you may wish to discard and put in your own words.