### PR TITLE
Double-Precision Floating-Point Move Instructions proposal for XLEN=32.

### DIFF
--- a/src/d.tex
+++ b/src/d.tex
@@ -354,27 +354,79 @@ FMV.D.X & D & 0    & src  & 000  & dest & OP-FP  \\
 \end{tabular}
 \end{center}
 
-\begin{commentary}
-  Early versions of the RISC-V ISA had additional instructions to
-  allow RV32 systems to transfer between the upper and lower portions
-  of a 64-bit floating-point register and an integer register.
-  However, these would be the only instructions with partial register
-  writes and would add complexity in implementations with recoded
-  floating-point or register renaming, requiring a pipeline read-modify-write
-  sequence.  Scaling up to handling quad-precision for RV32 and RV64
-  would also require additional instructions if they were to follow
-  this pattern.  The ISA was defined to reduce the number of explicit
-  int-float register moves, by having conversions and comparisons
-  write results to the appropriate register file, so we expect the
-  benefit of these instructions to be lower than for other ISAs.
+For XLEN$=$32 there are the following instructions to move bit patterns
+between the floating-point and integer registers.
 
-  We note that for systems that implement a 64-bit floating-point unit
-  including fused multiply-add support and 64-bit floating-point loads
-  and stores, the marginal hardware cost of moving from a 32-bit to
-  a 64-bit integer datapath is low, and a software ABI supporting 32-bit
-  wide address-space and pointers can be used to avoid growth of
-  static data and dynamic memory traffic.
-\end{commentary}
+The FMVH.X.W instruction (binary alias of the FMV.X.D)
+copies the bits of the upper half of the double-precision
+floating-point source register
+into the integer destination register.
+
+\begin{samepage-commentary}
+The "F" Standard Extension instruction FMV.X.W
+copies the bits of the lower half
+of the double-precision floating-point source register
+into the integer destination register in the regular way
+(similar to the single-precision floating-point instruction,
+without checking that the source operand is correctly NaN-boxed).
+
+If both the FMVH.X.W and FMV.X.W are required
+for the same double-precision floating-point register,
+the following code sequence is recommended:
+FMVH.X.W {\em rdh, fs1}; FMV.X.W {\em rdl, fs1}
+(where {\em fs1} is the same, but {\em rdh} cannot be the same as {\em rdl}).
+Microarchitectures can then fuse these into a single
+operation with single access to a floating-point register
+instead of performing two separate accesses.
+This order of instructions distinguishes
+the reading of parts of a double-precision floating-point register
+from reading a register as a single-precision value only.
+\end{samepage-commentary}
+
+For XLEN$=$32 the FMV.D.X instruction have additional
+source register operand
+encoded in the instruction field {\em rs2}.
+The {\em rs2} operand is optional in assembler
+(and by default is hardwired to zero {\em x0}/{\em zero} register).
+This instruction concatenates the bits of the two registers {\em rs1}
+(the upper half of the double-precision floating point value, 
+including the sign bit,
+exponent bits,
+and the most significant mantissa bits
+according to IEEE~754-2008)
+and {\em rs2} 
+(the lower half of the double-precision floating point value,
+including the least significant mantissa bits
+according to IEEE~754-2008)
+into the single 64 bits value and then copies these bits
+into the double-precision floating-point destination register {\em rd}
+as is.
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{R@{}F@{}R@{}R@{}F@{}R@{}O}
+\\
+\instbitrange{31}{27} &
+\instbitrange{26}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct5} &
+\multicolumn{1}{c|}{fmt} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{rm} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+5 & 2 & 5 & 5 & 3 & 5 & 7 \\
+FMVH.X.W & D & 0    & src  & 000  & dest & OP-FP  \\
+FMV.D.X  & D & src2 & src1 & 000  & dest & OP-FP  \\
+\end{tabular}
+\end{center}
 
 \section{Double-Precision Floating-Point Compare Instructions}
 


### PR DESCRIPTION
We would like to propose to define the FMVH.X.W instruction (binary alias of the FMV.X.D) and FMV.D.X instructions for RV32IMFD architectures