### PR TITLE
added passage explaining conditional branches and misaligned accesses

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -946,6 +946,19 @@ allowing the branch and following instructions to be executed
 speculatively and out-of-order with respect to other code~\cite{ibmpower7}.
 \end{commentary}
 
+All conditional branch instructions will generate an
+instruction-address-misaligned exception if the target address is not
+aligned to a four-byte boundary, whenever the result of executing the
+instruction would be to take the jump (i.e. if the branch condition is
+true). If the branch condition is false, a misaligned address
+exception will not be raised.
+
+\begin{commentary}
+Instruction-address-misaligned exceptions are not possible on machines
+that support extensions with 16-bit aligned instructions, such as the
+compressed instruction-set extension, C.
+\end{commentary}
+
 \section{Load and Store Instructions}
 
 RV32I is a load-store architecture, where only load and store


### PR DESCRIPTION
There is currently no explanation, within the Conditional Branches section, of how branches to misaligned addresses work in the absence of C. My understanding is that if the branch is taken, a misaligned exception should be raised, but if it is not taken, then an exception is not raised.

I have added two brief paragraphs explaining this; it could be merged now if it is deemed correct. If it is not correct, can someone correct it and add the correct explanation?