### PR TITLE
Clarify that PTE updates aren't atomic w.r.t. the ultimate access

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1189,8 +1189,11 @@ since the last time the D bit was cleared.
 Two schemes to manage the A and D bits are permitted:
 \begin{itemize}
 \item When a virtual page is accessed and the A bit is clear, or is
+      written and the D bit is clear, a page-fault exception is raised.
+
+\item When a virtual page is accessed and the A bit is clear, or is
       written and the D bit is clear, the implementation sets the
-      corresponding bit in the PTE.  The PTE update must be atomic with
+      corresponding bit(s) in the PTE.  The PTE update must be atomic with
       respect to other accesses to the PTE, and must atomically check
       that the PTE is valid and grants sufficient permissions.  The
       PTE update must be exact (i.e., not speculative), and observed
@@ -1198,8 +1201,11 @@ Two schemes to manage the A and D bits are permitted:
       provided by FENCE instructions and the acquire/release bits on atomic
       instructions also orders the PTE updates associated with those loads
       and stores as observed by remote harts.
-\item When a virtual page is accessed and the A bit is clear, or is
-      written and the D bit is clear, a page-fault exception is raised.
+
+      The PTE update is not required to be atomic with respect to the explicit
+      memory access that caused the update, and the sequence is interruptible.
+      However, the hart must not perform the explicit memory access before the
+      PTE update.
 \end{itemize}
 All harts in a system must employ the same PTE-update scheme as each other.
 


### PR DESCRIPTION
I claim that this follows from the text in the following section, but it is clearly deserving of clarification.

https://groups.google.com/a/groups.riscv.org/forum/?utm_medium=email&utm_source=footer#!msg/isa-dev/EQQGObY1bQM/xm6imw-aCwAJ