### PR TITLE
Suggest gp as the base for a millicode library

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -769,7 +769,9 @@ address will usually quickly raise an exception.
 When used with a base {\em rs1}$=${\tt x0}, JALR can be used to implement
 a single instruction subroutine call to the lowest \wunits{2}{KiB} or highest
 \wunits{2}{KiB} address region from anywhere in the address space, which could
-be used to implement fast calls to a small runtime library.
+be used to implement fast calls to a small runtime library. If the ABI in use
+has a Global Pointer register ({\em rs1}$=${\tt x3} in the standard calling
+convention) this could also be used.
 \end{commentary}
 
 The JAL and JALR instructions will generate an


### PR DESCRIPTION
This is likely to be available on more systems. For example HiFive1 :-)

On Linux you could potentially put an execute-only page at address 0, but I think it's better to put an execute-only page with millicode routines (.stext?) at the TOP of the page (the -msave-restore routines are currently 96 bytes), followed by R/W page(s) with .sdata, then .data and point GP at 2048 bytes above the start of the millicode.
