### PR TITLE
Clean up description of x registers. Add commentary about ABI

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -32,17 +32,33 @@ Most of the commentary for RV32I also applies to the RV64I base.
 \section{Programmers' Model for Base Integer ISA}
 
 Figure~\ref{gprs} shows the unprivileged state for the base integer
-ISA.  There are 31 general-purpose registers {\tt x1}--{\tt x31},
-which hold integer values.  Register {\tt x0} is hardwired to the
-constant 0.  There is no hardwired subroutine return address link
-register, but the standard software calling convention uses register
-{\tt x1} to hold the return address on a call.  For RV32I, the {\tt x}
-registers are 32 bits wide, i.e., XLEN=32.
+ISA.  For RV32I, the 32 {\tt x} registers are each 32 bits wide, i.e.,
+XLEN=32.  Register {\tt x0} is hardwired with all bits equal to 0.
+General purpose registers {\tt x1}--{\tt x31} hold values that various
+instructions interpret as a collection of Boolean values, or as two's
+complement signed binary integers or unsigned binary integers.
 
 There is one additional unprivileged register: the program counter {\tt pc}
 holds the address of the current instruction.
 
 \begin{commentary}
+There is no dedicated stack pointer or subroutine return address link
+register in the Base Integer ISA, the instruction encoding allows any
+{\tt x} register to be used for these purposes. However the standard
+software calling convention uses register {\tt x1} to hold the return
+address for a call, with register {\tt x5} available as an alternate.
+The standard calling convention uses register {\tt x2} as the stack
+pointer.
+
+Hardware might choose to accelerate function calls and returns that
+use {\tt x1} or {\tt x5}. See the descriptions of the JAL and JALR
+instructions.
+
+The optional compressed 16-bit instruction format is designed around
+the assumption that {\tt x1} is the return address register and {\tt
+ x2} is the stack pointer. Software using other conventions will
+operate correctly but may not gain as much code compression.
+
 The number of available architectural registers can have large impacts
 on code size, performance, and energy consumption.  Although 16
 registers would arguably be sufficient for an integer ISA running


### PR DESCRIPTION
I moved the stuff about ABI to commentary and greatly expanded it with details about what advanced hardware and the C extension assumes about usage of x registers.

Also arbitrary and capricious rewording of the description of x registers that might or might not make things more clear for people not already familiar with machine code and registers/instructions.
