### PR TITLE
Add commentary on sufficiency of rv128

### DIFF
--- a/src/rv128.tex
+++ b/src/rv128.tex
@@ -33,6 +33,10 @@ segmentation, 96-bit address spaces, and software workarounds, until,
 finally, flat 128-bit address spaces will be adopted as the simplest
 and best solution.
 
+If you could somehow store one bit of information in every atom of a
+diamond, storing $2^{128}$ bytes would require a diamond almost exactly
+two miles in diameter --- 128 bits ought to be enough for anybody.
+
 We have not frozen the RV128 spec at this time, as there might be need
 to evolve the design based on actual usage of 128-bit address spaces.
 \end{commentary}


### PR DESCRIPTION
A little bit whimsical :-)

Could add comment that even quite sparse usage will not exhaust it quickly.

Calculation (Python):

    ((2**128 # bytes
    *8 # bits
    /6.022e23 # moles
    *12 # grams
    /3.51 # CCs
    /(4.0/3*3.1416*0.5**3) # volume of a sphere inscribed in a unit cube
    )**(1.0/3) # cm
    /100 # m
    /1609.344) #miles
