### PR TITLE
Clarify use of C instructions between LR and SC

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -149,7 +149,8 @@ sequence plus the code to retry the sequence in case of failure must
 comprise at most 16 integer instructions placed sequentially in
 memory.  For the sequence to be guaranteed to eventually succeed, the
 dynamic code executed between the LR and SC instructions can only
-contain other instructions from the base ``I'' instruction set, excluding
+contain other instructions from the base ``I'' instruction set (or
+their ``C'' extension counterparts), excluding
 loads, stores, backward jumps or taken backward branches, FENCE,
 FENCE.I, and SYSTEM instructions.  The code to retry a failing LR/SC
 sequence can contain backward jumps and/or branches to repeat the


### PR DESCRIPTION
Is it true? If not then substitute "but not" for "or"