### PR TITLE
Fix a couple of typos and inconsistencies.

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -517,7 +517,7 @@ privilege mode.  These bits are primarily used to guarantee atomicity
 with respect to interrupt handlers in the current privilege mode.
 
 \begin{commentary}
-The global {\em x}IE bits are located in the low-order bits of {\tt mstatus},
+The global {\em x}\,IE bits are located in the low-order bits of {\tt mstatus},
 allowing them to be atomically set or cleared with a single CSR
 instruction.
 \end{commentary}
@@ -561,7 +561,7 @@ interrupts, so only one entry per stack is required.
 
 The MRET, SRET, or URET instructions are used to return from
 traps in M-mode, S-mode, or U-mode respectively.  When
-executing an {\em x}RET instruction, supposing {\em x}\,PP holds the
+executing an {\em x}\,RET instruction, supposing {\em x}\,PP holds the
 value {\em y}, {\em x}\,IE is set to {\em x}\,PIE; the privilege mode
 is changed to {\em y}; {\em x}\,PIE is set to 1; and {\em x}\,PP is
 set to U (or M if user-mode is not supported).
@@ -2150,17 +2150,17 @@ Previously, there was only a single ERET instruction (which was also
 earlier known as SRET).  To support the addition of user-level
 interrupts, we needed to add a separate URET instruction to continue
 to allow classic virtualization of OS code using the ERET instruction.
-It then became more orthogonal to support a different {\em x}RET
+It then became more orthogonal to support a different {\em x}\,RET
 instruction per privilege level.
 \end{commentary}
 
-If the A extension is supported, the {\em x},RET instruction is
+If the A extension is supported, the {\em x}\,RET instruction is
 allowed to clear any outstanding LR address reservation but is not
 required to.  Trap handlers should explicitly clear the reservation if
-required (e.g., by using a dummy SC) before executing the {\em x}RET.
+required (e.g., by using a dummy SC) before executing the {\em x}\,RET.
 
 \begin{commentary}
-  If {\em x},RET instructions always cleared LR reservations, it would
+  If {\em x}\,RET instructions always cleared LR reservations, it would
   be impossible to single-step through LR/SC sequences using a
   debugger.
 \end{commentary}


### PR DESCRIPTION
Perhaps its time to use \newcommand to avoid this fragility.