### PR TITLE
Operational memory model and litmus tests are in GitHub

### DIFF
--- a/src/memory-model-operational.tex
+++ b/src/memory-model-operational.tex
@@ -26,11 +26,32 @@ The operational presentation covers mixed-size execution, with
 potentially overlapping memory accesses of different power-of-two byte
 sizes.  Misaligned accesses are broken up into single-byte accesses.
 
-An interactive version of the model, together with a library of litmus tests,
-is provided online: \url{http://www.cl.cam.ac.uk/~pes20/rmem}.
-This is integrated with a fragment of the RISC-V ISA semantics
-(RV64I and A) expressed explicitly in Sail
-(\url{https://github.com/rems-project/sail}).
+The operational model, together with a fragment of the RISC-V ISA
+semantics (RV64I and A), are integrated into the {\tt rmem} exploration
+tool (\url{https://github.com/rems-project/rmem}).  {\tt rmem} can
+explore litmus tests (see \ref{sec:litmustests}) and small ELF
+binaries exhaustively,
+pseudo-randomly and interactively.  In {\tt rmem}, the ISA semantics
+is expressed explicitly in Sail (see
+\url{https://github.com/rems-project/sail} for the Sail language, and
+\url{https://github.com/rems-project/sail-riscv} for the RISC-V ISA
+model), and the concurrency semantics is expressed in Lem (see
+\url{https://github.com/rems-project/lem} for the Lem language).
+
+{\tt rmem} has a command-line interface and a web-interface.
+The web-interface runs entirely on the client side, and is provided
+online together with a library of litmus tests:
+\url{http://www.cl.cam.ac.uk/~pes20/rmem}.  The command-line interface
+is faster than the web-interface, specially in exhaustive mode.
+
+% A library of RISC-V litmus tests can be downloaded from
+% \url{https://github.com/litmus-tests/litmus-tests-riscv}.
+% This repository also provides instructions on how to run the litmus
+% tests on RISC-V hardware and how to compare the results with the
+% operational and axiomatic models.  The library is also available
+% through the web-interface.
+
+
 % TODO: compare with the herd and alloy versions
 
 

--- a/src/memory.tex
+++ b/src/memory.tex
@@ -36,7 +36,7 @@ Each implementation must therefore choose whether to prioritize compatibility wi
 Some fences and/or memory ordering annotations in code written for RVWMO may become redundant under RVTSO; the cost that the default of RVWMO imposes on Ztso implementations is the incremental overhead of fetching those fences (e.g., FENCE~R,RW and FENCE~RW,W) which become no-ops on that implementation.
 However, these fences must remain present in the code if compatibility with non-Ztso implementations is desired.
 
-\section{Litmus Tests}
+\section{Litmus Tests}\label{sec:litmustests}
 The explanations in this chapter make use of {\em litmus tests}, or small programs designed to test or highlight one particular aspect of a memory model.
 Figure~\ref{fig:litmus:sample} shows an example of a litmus test with two harts.
 As a convention for this figure and for all figures that follow in this chapter, we assume that {\tt s0}--{\tt s2} are pre-set to the same value in all harts and that {\tt s0} holds the address labeled {\tt x}, {\tt s1} holds {\tt y}, and {\tt s2} holds {\tt z}, where {\tt x}, {\tt y}, and {\tt z} are disjoint memory locations aligned to 8 byte boundaries.
@@ -115,7 +115,13 @@ For example, in Figure~\ref{fig:litmus:sample}, {\tt a0=1} could occur only if o
 \end{itemize}
 Since neither of these scenarios satisfies the RVWMO axioms, the outcome {\tt a0=1} is forbidden.
 
-Beyond what is described in this appendix, a suite of more than seven thousand litmus tests is available at \url{http://diy.inria.fr/cats7/riscv/}.
+Beyond what is described in this appendix, a suite of more than seven thousand litmus tests is available at \url{https://github.com/litmus-tests/litmus-tests-riscv}.
+
+\begin{commentary}
+  The litmus tests repository also provides instructions on how to run
+  the litmus tests on RISC-V hardware and how to compare the results
+  with the operational and axiomatic models.
+\end{commentary}
 
 \begin{commentary}
   In the future, we expect to adapt these memory model litmus tests for use as part of the RISC-V compliance test suite as well.


### PR DESCRIPTION
The operational memory model (rmem) and the litmus tests are now publicly available in GitHub.