### PR TITLE
Make the mcause table easier to find.

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1044,7 +1044,7 @@ address in the BASE field.  When MODE=Vectored, all synchronous exceptions
 into machine mode cause the {\tt pc} to be set to the address in the BASE
 field, whereas interrupts cause the {\tt pc} to be set to the address in
 the BASE field plus four times the interrupt cause number.  For example,
-a machine-mode timer interrupt (see Table~\ref{mcauses}) causes the {\tt pc}
+a machine-mode timer interrupt (see Table~\ref{mcauses} on page~\pageref{mcauses}) causes the {\tt pc}
 to be set to BASE+{\tt 0x1c}.
 
 \begin{commentary}
@@ -1155,7 +1155,7 @@ MXLEN \\
 \end{figure}
 
 {\tt medeleg} has a bit position allocated for every synchronous exception
-shown in Table~\ref{mcauses}, with the index of the bit position equal to the
+shown in Table~\ref{mcauses} on page~\pageref{mcauses}, with the index of the bit position equal to the
 value returned in the {\tt mcause} register (i.e., setting bit 8 allows
 user-mode environment calls to be delegated to a lower-privilege trap
 handler).

--- a/src/riscv-privileged.tex
+++ b/src/riscv-privileged.tex
@@ -64,6 +64,8 @@ Andrew Waterman and Krste Asanovi\'{c}, RISC-V Foundation, \privmonthyear.
 
 {\hypersetup{linktoc=all,hidelinks}
 \tableofcontents
+\listoftables
+\listoffigures
 }
 
 \mainmatter


### PR DESCRIPTION
It is forward referenced a couple of times around 10 pages before it actually appears.  Added a pageref for specifically this table, and add figures and tables to ToC for other cases.