### PR TITLE
Fix typos.

### DIFF
--- a/src/csr.tex
+++ b/src/csr.tex
@@ -54,7 +54,7 @@ in the CSRs and integer registers. CSRRW reads the old value of the
 CSR, zero-extends the value to XLEN bits, then writes it to integer
 register {\em rd}.  The initial value in {\em rs1} is written to the
 CSR.  If {\em rd}={\tt x0}, then the instruction shall not read the CSR
-and shall not cause any of the side-effects that might occur on a CSR
+and shall not cause any of the side effects that might occur on a CSR
 read.
 
 The CSRRS (Atomic Read and Set Bits in CSR) instruction reads the
@@ -94,9 +94,9 @@ register.  For CSRRSI and CSRRCI, if the uimm[4:0] field is zero, then
 these instructions will not write to the CSR, and shall not cause any
 of the side effects that might otherwise occur on a CSR write.  For
 CSRRWI, if {\em rd}={\tt x0}, then the instruction shall not read the
-CSR and shall not cause any of the side-effects that might occur on a
+CSR and shall not cause any of the side effects that might occur on a
 CSR read.  Both CSRRSI and CSRRCI will always read the CSR and cause
-any read side-effects regardless of {\em rd} and {\em rs1} fields.
+any read side effects regardless of {\em rd} and {\em rs1} fields.
 
 \begin{table}
   \centering

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -987,7 +987,7 @@ byte-addressed and little-endian.  The EEI will
 define what portions of the address space are legal to access with
 which instructions (e.g., some addresses might be read only, or
 support word access only).  Loads with a destination of {\tt x0} must
-still raise any exceptions and action any other side effects even
+still raise any exceptions and cause any other side effects even
 though the load value is discarded.
 
 \vspace{-0.4in}


### PR DESCRIPTION
Use non-hyphenated "side effects".
Use verb "cause" wrt "side effects".