### PR TITLE
Privileged Spec: Add dscratch0/1 to CSR listing

### DIFF
--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -352,7 +352,8 @@ Number    & Privilege & Name & Description \\
 \hline
 \tt 0x7B0 & DRW &\tt dcsr & Debug control and status register. \\
 \tt 0x7B1 & DRW &\tt dpc & Debug PC. \\
-\tt 0x7B2 & DRW &\tt dscratch & Debug scratch register. \\
+\tt 0x7B2 & DRW &\tt dscratch0 & Debug scratch register 0. \\
+\tt 0x7B3 & DRW &\tt dscratch1 & Debug scratch register 1. \\
 \hline
 \end{tabular}
 \end{center}


### PR DESCRIPTION
dscratch1 was missing from the listing, dscratch0 was named only dscratch.