### PR TITLE
Don't reference the SBI in normative privileged spec sections

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -968,14 +968,6 @@ restored using standard instructions (F, D, and/or Q), and privileged
 code must be aware of FLEN to determine the appropriate space to
 reserve for each {\tt f} register.
 
-In a supervisor-level OS, any additional user-mode state should be
-initialized, saved, and restored using SBI calls that treats the
-additional context as an opaque object of a fixed maximum size.  The
-implementation of the SBI initialize, save, and restore calls might
-require additional implementation-dependent privileged instructions to
-initialize, save, and restore microarchitectural state inside a
-coprocessor.
-
 All privileged modes share a single copy of the FS and XS bits.  In a
 system with more than one privileged mode, supervisor mode would
 normally use the FS and XS bits directly to record the status with
@@ -1327,11 +1319,11 @@ from code running on the local hart at the associated or any higher
 privilege level. The machine-level MSIP bits are written by accesses
 to memory-mapped control registers, which are used by remote harts to
 provide machine-mode interprocessor interrupts.  Interprocessor
-interrupts for lower privilege levels are implemented through ABI and
-SBI calls to the AEE or SEE respectively, which might ultimately
-result in a machine-mode write to the receiving hart's MSIP bit.  A
-hart can write its own MSIP bit using the same memory-mapped control
-register.
+interrupts for lower privilege levels are implemented through
+implementation-specific mechanisms, e.g., via calls to an AEE or SEE,
+which might ultimately result in
+a machine-mode write to the receiving hart's MSIP bit.  A hart can write its
+own MSIP bit using the same memory-mapped control register.
 
 The MSIE, SSIE, and USIE fields in the {\tt mie} CSR enable M-mode software
 interrupts, S-mode software interrupts, and U-mode software interrupts,
@@ -1341,7 +1333,7 @@ respectively.
 We only allow a hart to directly write its own SSIP or USIP
 bits when running in the appropriate mode, as other harts might be
 virtualized and possibly descheduled by higher privilege levels.  We
-rely on ABI and SBI calls to provide interprocessor interrupts
+rely on calls to the AEE and SEE to provide interprocessor interrupts
 for this reason.  Machine-mode harts are not virtualized and can
 directly interrupt other harts by setting their MSIP bits, typically
 using uncached I/O writes to memory-mapped control registers depending

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -4,16 +4,17 @@
 This chapter describes the RISC-V supervisor-level architecture, which
 contains a common core that is used with various supervisor-level
 address translation and protection schemes.
-Supervisor-level code relies on a supervisor execution environment to
-initialize the environment and enter the supervisor code at an entry
-point defined by the supervisor binary interface (SBI).  The SBI also
-defines function entry points that provide supervisor environment
-services for supervisor-level code.
 
 \begin{commentary}
 Supervisor mode is deliberately restricted in terms of interactions
 with underlying physical hardware, such as physical memory and device
 interrupts, to support clean virtualization.
+In this spirit, certain supervisor-level facilities, including requests for
+timer and interprocessor interrupts, are provided by implementation-specific
+mechanisms.  In some systems, a supervisor execution environment (SEE)
+provides these facilities in a manner specified by a superivsor binary
+interface (SBI).  Other systems supply these facilities directly, through some
+other implementation-defined mechanism.
 \end{commentary}
 
 \section{Supervisor CSRs}
@@ -388,9 +389,9 @@ interrupt can be cleared by writing 0 to the SSIP bit in {\tt sip}.
 Supervisor-level software interrupts are disabled when the SSIE bit in the
 {\tt sie} register is clear.
 
-Interprocessor interrupts are sent to other harts by means of SBI
-calls, which will ultimately cause the SSIP bit to be set in the
-recipient hart's {\tt sip} register.
+Interprocessor interrupts are sent to other harts by implementation-specific
+means, which will ultimately cause the SSIP bit to be set in the recipient
+hart's {\tt sip} register.
 
 A user-level software interrupt is triggered on the current hart by writing
 1 to its user software interrupt-pending (USIP) bit in the {\tt sip} register.
@@ -403,8 +404,8 @@ All bits besides SSIP, USIP, and UEIP in the {\tt sip} register are read-only.
 
 A supervisor-level timer interrupt is pending if the STIP bit in the {\tt sip}
 register is set.  Supervisor-level timer interrupts are disabled when the STIE
-bit in the {\tt sie} register is clear.  An SBI call to the SEE may be used to
-clear the pending timer interrupt.
+bit in the {\tt sie} register is clear.  The implementation must provide a
+mechanism to clear a pending timer interrupt.
 
 A user-level timer interrupt is pending if the UTIP bit in the {\tt sip}
 register is set.  User-level timer interrupts are disabled when the UTIE bit
@@ -415,8 +416,9 @@ and UTIE are hardwired to zero.
 
 A supervisor-level external interrupt is pending if the SEIP bit in the
 {\tt sip} register is set.  Supervisor-level external interrupts are disabled
-when the SEIE bit in the {\tt sie} register is clear.  The SBI should provide
-facilities to mask, unmask, and query the cause of external interrupts.
+when the SEIE bit in the {\tt sie} register is clear.  The implementation
+should provide facilities to mask, unmask, and query the cause of external
+interrupts.
 
 The UEIP field in {\tt sip} contains a single read-write bit.  UEIP
 may be written by S-mode software to indicate to U-mode that an
@@ -458,11 +460,11 @@ they are marked \wpri\ in Figures~\ref{sipreg} and \ref{siereg}.
 
 Supervisor software uses the same hardware performance monitoring facility
 as user-mode software, including the {\tt time}, {\tt cycle}, and {\tt instret}
-CSRs.  The SBI should provide a mechanism to modify the
+CSRs.  The implementation should provide a mechanism to modify the
 counter values.
 
-The SBI must provide a facility for scheduling timer interrupts in terms
-of the real-time counter, {\tt time}.
+The implementation must provide a facility for scheduling timer interrupts in
+terms of the real-time counter, {\tt time}.
 
 \subsection{Counter-Enable Register ({\tt scounteren})}
 
@@ -954,10 +956,7 @@ a local data fence to ensure local writes are visible globally, then
 2) an interprocessor interrupt to the other thread, then 3) a local
 SFENCE.VMA in the interrupt handler of the remote thread, and finally
 4) signal back to originating thread that operation is complete.  This
-is, of course, the RISC-V analog to a TLB shootdown.  Alternatively,
-implementations might provide direct hardware support for remote TLB
-invalidation.  TLB shootdowns are handled by an SBI call to hide
-implementation details.
+is, of course, the RISC-V analog to a TLB shootdown.
 \end{commentary}
 
 For the common case that the translation data structures have only been


### PR DESCRIPTION
Submitted on behalf of Christoph Hellwig

For context, see https://groups.google.com/a/groups.riscv.org/d/msg/isa-dev/kL-2LhgUmcE/xxySlYT0CQAJ