### PR TITLE
Add coherency bit in PTE attributes

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1153,10 +1153,11 @@ before being directly converted to machine-level physical addresses.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{@{}E@{}O@{}Fcccccccc}
+\begin{tabular}{@{}E@{}O@{}cFcccccccc}
 \instbitrange{31}{20} &
 \instbitrange{19}{10} &
-\instbitrange{9}{8} &
+\instbit{9} &
+\instbit{8} &
 \instbit{7} &
 \instbit{6} &
 \instbit{5} &
@@ -1168,6 +1169,7 @@ before being directly converted to machine-level physical addresses.
 \hline
 \multicolumn{1}{|c|}{PPN[1]} &
 \multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{C} &
 \multicolumn{1}{c|}{RSW} &
 \multicolumn{1}{c|}{D} &
 \multicolumn{1}{c|}{A} &
@@ -1178,7 +1180,7 @@ before being directly converted to machine-level physical addresses.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-12 & 10 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+12 & 10 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1309,6 +1311,14 @@ supervisor software does not rely on accessed and/or dirty bits,
 e.g. if it does not swap memory pages to secondary storage or if the
 pages are being used to map I/O space, it should always set them to 1
 in the PTE to improve performance.
+\end{commentary}
+
+The C bit designates a coherent memory model for this page mapping. Software set
+the bit to tell the hardware that the region of the page's memory area must be
+coherency with IOs and dma devices in SOC system by PMA settings.
+
+\begin{commentary}
+If IOs and memorys are already coherency in SOC system, CPU just ignore this bit.
 \end{commentary}
 
 Any level of PTE may be a leaf PTE, so in addition to 4 KiB pages, Sv32
@@ -1463,12 +1473,13 @@ quickly distinguish user and supervisor address regions.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}cFcccccccc}
 \instbitrange{63}{54} &
 \instbitrange{53}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
-\instbitrange{9}{8} &
+\instbit{9} &
+\instbit{8} &
 \instbit{7} &
 \instbit{6} &
 \instbit{5} &
@@ -1482,6 +1493,7 @@ quickly distinguish user and supervisor address regions.
 \multicolumn{1}{c|}{PPN[2]} &
 \multicolumn{1}{c|}{PPN[1]} &
 \multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{C} &
 \multicolumn{1}{c|}{RSW} &
 \multicolumn{1}{c|}{D} &
 \multicolumn{1}{c|}{A} &
@@ -1492,7 +1504,7 @@ quickly distinguish user and supervisor address regions.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-10 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+10 & 26 & 9 & 9 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1613,13 +1625,14 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Y@{}cFcccccccc}
 \instbitrange{63}{54} &
 \instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
-\instbitrange{9}{8} &
+\instbit{9} &
+\instbit{8} &
 \instbit{7} &
 \instbit{6} &
 \instbit{5} &
@@ -1634,6 +1647,7 @@ is untranslated.
 \multicolumn{1}{c|}{PPN[2]} &
 \multicolumn{1}{c|}{PPN[1]} &
 \multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{C} &
 \multicolumn{1}{c|}{RSW} &
 \multicolumn{1}{c|}{D} &
 \multicolumn{1}{c|}{A} &
@@ -1644,7 +1658,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-10 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+10 & 17 & 9 & 9 & 9 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }


### PR DESCRIPTION
The bit designates a coherent memory model for this page mapping.
Software set the bit to tell the hardware that the region of the
page's memory area must be coherency with IOs and dma devices in
SOC system by PMA settings.

Signed-off-by: Guo Ren <ren_guo@c-sky.com>