### PR TITLE
Two separate changes

### DIFF
--- a/src/m.tex
+++ b/src/m.tex
@@ -99,7 +99,20 @@ MULDIV & divisor & dividend & DIV[U]W/REM[U]W & dest & OP-32 \\
 DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned integer
 division of {\em rs1} by {\em rs2}, rounding towards zero.
 REM and REMU provide the remainder of the
-corresponding division operation.  If both the quotient and remainder
+corresponding division operation.
+For signed division, the sign of the remainder and the value of the quotient
+follow the usual conventions: the sign of the remainder is the sign of the
+dividend and the absolute value of the quotient is the same as the quotient for
+the unsigned division of the absolute value of dividend by the absolute value
+of the divisor.
+
+\begin{commentary}
+This ensures that $\textrm{dividend} = \textrm{divisor} \times
+\textrm{quotient} + \textrm{remainder}$, where the quotient can be obtained by
+dividing the absolute values of the inputs and setting the sign appropriately.
+\end{commentary}
+
+If both the quotient and remainder
 are required from the same division, the recommended code sequence is:
 DIV[U] {\em rdq, rs1, rs2}; REM[U] {\em rdr, rs1, rs2} ({\em rdq}
 cannot be the same as {\em rs1} or {\em rs2}).  Microarchitectures can

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -88,6 +88,19 @@ at a time.  If zero after one shift, then the machine is RV32.  If
 zero after two shifts, then the machine is RV64, else RV128.
 \end{commentary}
 
+\begin{commentary}
+When MXLEN is reduced by changing MXL, the hardware still contains wider
+architectural registers but it has to logically present narrower registers.
+For integer registers, including PC, the values stored by instructions
+operating under narrower MXLEN must be sign-extended and for CSRs, it must
+follow the rules of Section~\ref{sec:csrwidthmodulation}. It is important to
+perform the appropriate sign or zero extension because, if the MXLEN is
+increased later, the values that future instructions operate on must be
+correct. One interesting side-effect is that when MXLEN is reduced, the higher
+order bits of the PC will be logically truncated, potentially leading to an
+implicit jump for fetching the next instruction.
+\end{commentary}
+
 The Extensions field encodes the presence of the standard extensions,
 with a single bit per letter of the alphabet (bit 0 encodes presence
 of extension ``A'' , bit 1 encodes presence of extension ``B'',


### PR DESCRIPTION
1) Specifiying the sign of the remainder in signed division
2) Explaining the effect of reducing MXLEN on integer register values, PC and CSRs.