### PR TITLE
Adding FENCE to the table of RV64 HINT instructions

### DIFF
--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -286,7 +286,8 @@ will ever be defined in this subspace.
   SUBW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   SLLW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   SRLW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
-  SRAW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \hline \hline
+  SRAW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
+  FENCE                 & {\em pred}=0 or {\em succ}=0                & $2^{5}-1$                   & \\ \hline \hline
   SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{10}{*}{\em Reserved for custom use} \\ \cline{1-3}
   SLTIU                 & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   SLLI                  & {\em rd}={\tt x0}                           & $2^{11}$                    & \\ \cline{1-3}


### PR DESCRIPTION
Adds the missing FENCE instructions to the table of RV64 HINT instructions.