### PR TITLE
Clarify behavior on taking delegated interrupts

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1397,10 +1397,12 @@ An interrupt {\em i} will be taken if bit {\em i} is set in both {\tt
 default, M-mode interrupts are globally enabled if the hart's current
 privilege mode is less than M, or if the current privilege mode is M
 and the MIE bit in the {\tt mstatus} register is set.  If bit {\em i}
-in {\tt mideleg} is set, however, interrupts are considered to be
-globally enabled if the hart's current privilege mode equals the
-delegated privilege mode (S or U) and that mode's interrupt enable
-bit (SIE or UIE in {\tt mstatus}) is set, or if the current
+in {\tt mideleg} is set, however, an interrupt {\em i} delegated to mode {\em x}
+(S or U) will be taken if bit {\em i} is set in {\em x}\,{\tt ip},
+and if interrupts are globally enabled. In this context, interrupts are
+considered to be globally enabled if the hart's current privilege mode equals
+the delegated privilege mode and that mode's interrupt enable
+bit ({\em x}\,{\tt IE} in {\tt mstatus}) is set, or if the current
 privilege mode is less than the delegated privilege mode.
 
 Multiple simultaneous interrupts destined for different privilege modes are


### PR DESCRIPTION
I found this paragraph to be confusing as I wasn't sure whether `sie`/`uie` play any role when taking delegated interrupts that originally targeted machine-mode. I came to the conclusion that they do because in the manual in 3.1.9 it is said:

> Restricted views of the `mip` and `mie` registers appear as the `sip`/`sie`, and `uip`/`uie` registers in S-mode and U-mode respectively. If an interrupt is delegated to privilege mode x by setting a bit in the `mideleg` register, it becomes visible in the `xip` register and is maskable using the `xie` register. Otherwise, the corresponding bits in `xip` and `xie` appear to be hardwired to zero.

Without my addition you could think that when an interrupt `i` is pending and `mideleg` is set accordingly, it will be taken if `i` is set in both `mip` and `mie` and either `xIE` in `mstatus` is set or the current privilege mode is less than the delegated privilege mode.

This come from the fact that the second half of the paragraph concerning delegated interrupts only talks about what changes about interrupts being *globally enabled*.