### PR TITLE
Allow mcycle to be shared between harts

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1922,7 +1922,7 @@ desirable to conditionally inhibit them to reduce energy consumption.
 Providing a single CSR to inhibit all counters also allows the counters to be
 atomically sampled.
 
-As all the harts on a processor core share a {\tt cycle} counter,
+As all the harts on a processor core may share a {\tt cycle} counter,
 so they share an {\tt mcountinhibit}.CY bit.
 
 Because the {\tt time} counter can be shared between multiple cores, it

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1698,7 +1698,9 @@ precision on all RV32 and RV64 systems.
 
 The counter registers have an arbitrary value after system reset, and
 can be written with a given value. Any CSR write takes effect after
-the writing instruction has otherwise completed.
+the writing instruction has otherwise completed. Writes to {\tt mcycle} on one
+hart may change the value of {\tt mcycle} on other harts, the platform must
+provide a mechanism to indicate when this behavior will occur.
 
 The hardware performance monitor includes 29 additional 64-bit event counters, {\tt
 mhpmcounter3}--{\tt mhpmcounter31}.  The event selector CSRs, {\tt
@@ -1907,7 +1909,9 @@ their accessibility is not affected by the setting of this register.
 When the CY, IR, or HPM{\em n} bit in the {\tt mcountinhibit} register is
 clear, the {\tt cycle}, {\tt instret}, or {\tt hpmcounter{\em n}} register
 increments as usual.  When the CY, IR, or HPM{\em n} bit is set, the
-corresponding counter does not increment.
+corresponding counter does not increment.  Writes to {\tt mcountinhibit}.CY may
+change the value of {\tt mcountintihib}.CY on other harts, the platform must
+provide a mechanism to indicate when this behavior will occur.
 
 If the {\tt mcountinhibit} register is not implemented, the implementation
 behaves as though the register were set to zero.


### PR DESCRIPTION
The commentary says this is allowed, but the normative text doesn't.  I don't like this behavior, but the manual should at least be self-consistent.