### PR TITLE
revise table of hypervisor states to include misa[7] status

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -64,18 +64,23 @@ possible operating modes of a RISC-V hart with the hypervisor extension.
 
 \begin{table*}[h!]
 \begin{center}
-\begin{tabular}{|c|c||l|l|l|}
+\begin{tabular}{|c|c|c||l|l|l|}
   \hline
-   Virtualization & Privilege & \multirow{2}{*}{Abbreviation} & \multirow{2}{*}{Name} & Two-Level \\
-   Mode (V)       & Encoding  &                               &                       & Translation \\ \hline
-   0              & 0         & U-mode  & User mode & Off \\
-   0              & 1         & HS-mode & Hypervisor-extended supervisor mode & Off \\
-   0              & 3         & M-mode  & Machine mode & Off \\
+  misa[7]& Virtualization & Privilege & \multirow{2}{*}{Abbreviation} & \multirow{2}{*}{Name} & Two-Level \\
+    (H) & Mode (V)       & Encoding  &                               &                       & Translation \\ \hline
+  0 or 1 &   0*   & 0         & U-mode  & User mode & Off \\
+\hline
+  0 &  0*              & 1         & S-mode & Supervisor mode & Off \\
+  0 &  0*              & 3         & M-mode  & Machine mode & Off \\
   \hline
-   1              & 0         & VU-mode & Virtual user mode & On \\
-   1              & 1         & VS-mode & Virtual supervisor mode & On \\
+  1 &  0              & 1         & HS-mode & Hypervisor-extended supervisor  & Off \\
+  1 &  0              & 3         & M-mode  & Hypervisor-extended Machine  & Off \\
+  \hline
+  1 &  1              & 0         & VU-mode & Virtual user mode & On \\
+ 1 &   1              & 1         & VS-mode & Virtual supervisor mode & On \\
   \hline
  \end{tabular}
+* Note: Virtualization Mode defaults to 0 when H = 0.
 \end{center}
 \caption{Operating modes with the hypervisor extension.}
 \label{h-operating-modes}


### PR DESCRIPTION
Adding misa[7] state to Table 5.1: Operating modes with the hypervisor extension :

1) emphasizes the recommendation to make hypervisor extension selectable.
2) clarifies U-mode is unchanged by adding the extension
3) emphasizes that M-mode,  in addition to HS-Mode, is also enhanced by the extension.
(even though we do not designate it HM-mode).

Signed-off-by: ds2horner <ds2horner@gmail.com>

