### PR TITLE
Clarify that mtvec is WARL

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1114,7 +1114,7 @@ interrupts, unless the interrupt results in a user-level context swap.
 
 \subsection{Machine Trap-Vector Base-Address Register ({\tt mtvec})}
 
-The {\tt mtvec} register is an MXLEN-bit read/write register that holds
+The {\tt mtvec} register is an MXLEN-bit \warl\ read/write register that holds
 trap vector configuration, consisting of a vector base address (BASE) and a
 vector mode (MODE).
 


### PR DESCRIPTION
Other WARL registers seem to be explicit (e.g. "The misa CSR is a WARL
read-write register..."). This patch adds a similar indication for
mtvec. This consistency is important, as otherwise the reader will spend
time trying to determine if the behaviour is different. You can
determine it's WARL by reading the field layout diagram, but I think a
little redundancy in favour of easing readability makes sense.

At least one simulator started off trapping on invalid field
modifications
<https://lists.gnu.org/archive/html/qemu-devel/2018-04/msg04510.html>.