### PR TITLE
Clarify and define categories of extensions

### DIFF
--- a/src/intro.tex
+++ b/src/intro.tex
@@ -289,19 +289,23 @@ RV32 variant.
 
 RISC-V has been designed to support extensive customization and
 specialization.  Each base integer ISA can be extended with one or
-more optional instruction-set extensions, and we divide each RISC-V
+more optional instruction-set extensions.  An extension may be
+categorized as either standard, custom, or non-conforming.
+For this purpose, we divide each RISC-V
 instruction-set encoding space (and related encoding spaces such as
 the CSRs) into three disjoint categories: {\em standard}, {\em
-  reserved}, and {\em custom}.  Standard encodings are defined by the
-Foundation, and shall not conflict with other standard extensions for
-the same base ISA.  Reserved encodings are currently not defined but
-are saved for future standard extensions.  We use the term {\em
-  non-standard} to describe an extension that is not defined by the
-Foundation.  Custom encodings shall never be used for standard
-extensions and are made available for vendor-specific non-standard
-extensions.  We use the term {\em non-conforming} to describe a
-non-standard extension that uses either a standard or a reserved
-encoding (i.e., custom extensions are {\em not} non-conforming).
+  reserved}, and {\em custom}.  Standard extensions and encodings
+are defined by the Foundation; any extensions not defined by the
+Foundation are {\em non-standard}.
+Each base ISA and its standard extensions use only standard encodings,
+and shall not conflict with each other in their uses of these encodings.
+Reserved encodings are currently not defined but are saved for future
+standard extensions; once thus used, they become standard encodings.
+Custom encodings shall never be used for standard extensions and are
+made available for vendor-specific non-standard extensions.
+Non-standard extensions are either custom extensions, that use only
+custom encodings, or {\em non-conforming} extensions, that use any
+standard or reserved encoding.
 Instruction-set extensions are generally shared but may provide slightly different
 functionality depending on the base ISA.  Chapter~\ref{extensions}
 describes various ways of extending the RISC-V ISA.  We have also


### PR DESCRIPTION
It was pointed out that "custom extension" is not explicitly defined.  Define it, and make it clear that the three defined categories are mutually exclusive.

Also, clarify what "conflict" refers to (it's not the encoding itself that conflicts with an extension; rather, it's the base ISA and its various extensions that might conflict in their uses of an encoding).