### PR TITLE
Use consistent terms for exception types.

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -138,7 +138,7 @@ For LR and SC, the A extension requires that the address held in {\em
   rs1} be naturally aligned to the size of the operand (i.e.,
 eight-byte aligned for 64-bit words and four-byte aligned for 32-bit
 words).  If the address is not naturally aligned, a misaligned address
-exception or an access exception will be generated.  The access
+exception or an access fault exception will be generated.  The access fault
 exception can be generated for a memory access that would otherwise be
 able to complete except for the misalignment, if the misaligned access
 should not be emulated.
@@ -327,7 +327,7 @@ For AMOs, the A extension requires that the address held in {\em rs1}
 be naturally aligned to the size of the operand (i.e., eight-byte
 aligned for 64-bit words and four-byte aligned for 32-bit words).  If
 the address is not naturally aligned, a misaligned address exception
-or an access exception will be generated.  The access exception can be
+or an access fault exception will be generated.  The access fault exception can be
 generated for a memory access that would otherwise be able to complete
 except for the misalignment, if the misaligned access should not be
 emulated.  The ``Zam'' extension, described in Chapter~\ref{sec:zam},

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -256,9 +256,9 @@ after SPV and {\tt sstatus}.SPP have supplied the new virtualization and
 privilege modes, they are written with SP2V and SP2P, respectively.
 
 The STL bit (Supervisor Translation Level), which indicates which address-translation level
-caused an access-fault or page-fault exception, is also written by the implementation whenever a trap
+caused an access fault or page fault exception, is also written by the implementation whenever a trap
 is taken into HS-mode.
-On an access or page fault due to guest physical address translation, STL is
+On an access fault or page fault due to guest physical address translation, STL is
 set to 1.
 For any other trap into HS-mode, STL is set to 0.
 
@@ -343,7 +343,7 @@ V=1, a trap that has been delegated to HS-mode (using {\tt medeleg} or {\tt
 mideleg}) is further delegated to VS-mode if the corresponding {\tt hedeleg} or
 {\tt hideleg} bit is set.
 
-When an access-fault or page-fault exception is caused by guest physical
+When an access fault or page fault exception is caused by guest physical
 address translation, the trap is not delegated beyond HS-mode, regardless of
 the setting of {\tt hedeleg}.
 
@@ -1281,9 +1281,9 @@ mode V at the time of the trap.  When an MRET instruction is executed, the
 virtualization mode V is set to MPV, unless MPP=3, in which case V remains 0.
 
 The MTL bit (Machine Translation Level), which indicates which address-translation level
-caused an access-fault or page-fault exception, is also written by the implementation whenever a trap
+caused an access fault or page fault exception, is also written by the implementation whenever a trap
 is taken into M-mode.
-On an access or page fault due to guest physical address translation, MTL is
+On an access fault or page fault due to guest physical address translation, MTL is
 set to 1.
 For any other trap into M-mode, MTL is set to 0.
 
@@ -1409,7 +1409,7 @@ Figure~\ref{sv39x4va}.
 This partitioning is identical to that for an Sv39 virtual address as depicted
 in Figure~\ref{sv39va} (page~\pageref{sv39va}), except with 2 more bits at the
 high end in VPN[2].
-Address bits 63:41 must all be zeros, or else a page-fault exception occurs,
+Address bits 63:41 must all be zeros, or else a page fault exception occurs,
 attributed to guest physical address translation.
 
 \begin{figure*}[h!]
@@ -1440,7 +1440,7 @@ Figure~\ref{sv48x4va}.
 This partitioning is identical to that for an Sv48 virtual address as depicted
 in Figure~\ref{sv48va} (page~\pageref{sv48va}), except with 2 more bits at the
 high end in VPN[3].
-Address bits 63:50 must all be zeros, or else a page-fault exception occurs,
+Address bits 63:50 must all be zeros, or else a page fault exception occurs,
 attributed to guest physical address translation.
 
 \begin{figure*}[h!]

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -713,7 +713,7 @@ not supported.
 \begin{commentary}
 The MXR and SUM mechanisms only affect the interpretation of permissions
 encoded in page-table entries.  In particular, they have no impact on whether
-access exceptions are raised due to PMAs or PMP.
+access fault exceptions are raised due to PMAs or PMP.
 \end{commentary}
 
 \subsubsection{Endianness Control in {\tt mstatus} and {\tt mstatush} Registers}
@@ -2133,8 +2133,8 @@ implementation, though it may be explicitly written by software.  The hardware
 platform will specify which exceptions must set {\tt mtval} informatively and
 which may unconditionally set it to zero.
 
-When a hardware breakpoint is triggered, or an instruction-fetch, load, or
-store address-misaligned, access, or page-fault exception occurs, {\tt
+When a hardware breakpoint is triggered, or an instruction, load, or
+store address-misaligned, access fault, or page fault exception occurs, {\tt
   mtval} is written with the faulting virtual address.  On an illegal
 instruction trap, {\tt mtval} may be written with the first XLEN or ILEN
 bits of the faulting instruction as described below.  For other traps,
@@ -2152,7 +2152,7 @@ bits of the faulting instruction as described below.  For other traps,
 \end{commentary}
 \begin{commentary}
   When page-based virtual memory is enabled, {\tt mtval} is written with
-  the faulting virtual address, even for physical-memory access exceptions.
+  the faulting virtual address, even for physical-memory access fault exceptions.
   This design reduces datapath cost for most implementations, particularly
   those with hardware page-table walkers.
 \end{commentary}
@@ -2174,9 +2174,9 @@ MXLEN \\
 \label{mtvalreg}
 \end{figure}
 
-For misaligned loads and stores that cause access or page-fault exceptions,
+For misaligned loads and stores that cause access fault or page fault exceptions,
 {\tt mtval} will contain the virtual address of the portion of the access that
-caused the fault.  For instruction-fetch access or page-fault exceptions on
+caused the fault.  For instruction access fault or page fault exceptions on
 systems with variable-length instructions, {\tt mtval} will contain the
 virtual address of the portion of the instruction that caused the fault while
 {\tt mepc} will point to the beginning of the instruction.
@@ -2549,8 +2549,8 @@ memory, including accesses that have undergone virtual to physical
 memory translation.  To aid in system debugging, we strongly recommend
 that, where possible, RISC-V processors precisely trap physical memory
 accesses that fail PMA checks.  Precisely trapped PMA violations manifest
-as load, store, or instruction-fetch access exceptions, distinct from
-virtual-memory page-fault exceptions. Precise PMA traps might not always be
+as instruction, load, or store access fault exceptions, distinct from
+virtual-memory page fault exceptions. Precise PMA traps might not always be
 possible, for example, when probing a legacy bus architecture that
 uses access failures as part of the discovery mechanism.  In this
 case, error responses from slave devices will be reported as imprecise
@@ -2680,10 +2680,10 @@ and stores uses the same mutex, all accesses to a given address that use the
 same word size will be mutually atomic.
 \end{commentary}
 
-Implementations may raise access exceptions instead of address-misaligned
+Implementations may raise access fault exceptions instead of address-misaligned
 exceptions for some misaligned accesses, indicating the instruction should not
 be emulated by a trap handler.  If, for a given address and access width, all
-misaligned LRs/SCs and AMOs generate access exceptions, then regular
+misaligned LRs/SCs and AMOs generate access fault exceptions, then regular
 misaligned loads and stores using the same address and access width are not
 required to execute atomically.
 
@@ -2841,7 +2841,7 @@ generate spurious accesses to non-idempotent memory regions.
 
 \begin{commentary}
 Non-idempotent regions might not support misaligned accesses.  Misaligned
-accesses to such regions should raise access exceptions rather than
+accesses to such regions should raise access fault exceptions rather than
 address-misaligned exceptions, indicating that software should not emulate the
 misaligned access using multiple smaller accesses, which could cause
 unexpected side effects.
@@ -3107,12 +3107,12 @@ described in the following sections.
 \end{figure}
 
 Attempting to fetch an instruction from a PMP region that does not have execute
-permissions raises a fetch access exception.  Attempting to execute
+permissions raises an instruction access fault exception.  Attempting to execute
 a load or load-reserved instruction whose effective address lies within
-a PMP region without read permissions raises a load access exception.
+a PMP region without read permissions raises a load access fault exception.
 Attempting to execute a store, store-conditional (regardless of success),
 or AMO instruction whose effective address lies within a PMP region without
-write permissions raises a store access exception.
+write permissions raises a store access fault exception.
 
 If MXLEN is changed, the contents of the {\tt pmp{\em x}cfg} fields are
 preserved, but appear in the {\tt pmpcfg{\em y}} CSR prescribed by the new
@@ -3243,16 +3243,16 @@ If at least one PMP entry is implemented, but all PMP entries' A fields are
 set to OFF, then all S-mode and U-mode memory accesses will fail.
 \end{commentary}
 
-Failed accesses generate a load, store, or instruction access exception.  Note
+Failed accesses generate an instruction, load, or store access fault exception.  Note
 that a single instruction may generate multiple accesses, which may not be
-mutually atomic.  An access exception is generated if at least one access
+mutually atomic.  An access fault exception is generated if at least one access
 generated by an instruction fails, though other accesses generated by that
 instruction may succeed with visible side effects.  Notably, instructions that
 reference virtual memory are decomposed into multiple accesses.
 
 On some implementations, misaligned loads, stores, and instruction fetches may
 also be decomposed into multiple accesses, some of which may succeed before an
-access exception occurs.  In particular, a portion of a misaligned store
+access fault exception occurs.  In particular, a portion of a misaligned store
 that passes the PMP check may become visible, even if another portion fails
 the PMP check.  The same behavior may manifest for floating-point stores wider
 than XLEN bits (e.g., the FSD instruction in RV32D), even when the store

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1070,7 +1070,7 @@ An EEI may not guarantee misaligned loads and stores are handled
 invisibly.  In this case, loads and stores that are not naturally
 aligned may either complete execution successfully or raise an
 exception.  The exception raised can be either an address-misaligned
-exception or an access exception.  For a memory access that would
+exception or an access fault exception.  For a memory access that would
 otherwise be able to complete except for the misalignment, an access
 exception can be raised instead of an address-misaligned exception if
 the misaligned access should not be emulated, e.g., if accesses to the

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -232,7 +232,7 @@ privileged software to partially execute in supervisor mode, while most
 programs run in user mode, all in a shared address space.  This use case can
 be realized by mapping the physical code pages at multiple virtual addresses
 with different permissions, possibly with the assistance of the
-instruction page-fault handler to direct supervisor software to use the
+instruction page fault handler to direct supervisor software to use the
 alternate mapping.
 \end{commentary}
 
@@ -639,8 +639,8 @@ which exceptions must set {\tt stval} informatively and which may
 unconditionally set it to zero.
 
 
-When a hardware breakpoint is triggered, or an instruction-fetch, load, or
-store address-misaligned, access, or page-fault exception occurs, {\tt stval}
+When a hardware breakpoint is triggered, or an instruction, load, or
+store address-misaligned, access fault, or page fault exception occurs, {\tt stval}
 is written with the faulting virtual address.  On an illegal instruction trap,
 {\tt stval} may be written with the first XLEN or ILEN bits of the faulting
 instruction as described below.  For other exceptions, {\tt stval} is set to
@@ -664,10 +664,10 @@ SXLEN \\
 \label{stvalreg}
 \end{figure}
 
-For misaligned loads and stores that cause access or page-fault
+For misaligned loads and stores that cause access fault or page fault
 exceptions, {\tt stval} will contain the virtual address of the
 portion of the access that caused the fault.  For
-instruction-fetch access or page-fault exceptions on systems
+instruction access fault or page fault exceptions on systems
 with variable-length instructions, {\tt stval} will contain the
 virtual address of the portion of the instruction that caused
 the fault while {\tt sepc} will point to the beginning of the
@@ -1188,16 +1188,16 @@ X & W & R & Meaning \\
 \end{table*}
 
 Attempting to fetch an instruction from a page that does not have execute
-permissions raises a fetch page-fault exception.  Attempting to execute
+permissions raises a fetch page fault exception.  Attempting to execute
 a load or load-reserved instruction whose effective address lies within
-a page without read permissions raises a load page-fault exception.
+a page without read permissions raises a load page fault exception.
 Attempting to execute a store, store-conditional (regardless of success),
 or AMO instruction whose effective address lies within a page without
-write permissions raises a store page-fault exception.
+write permissions raises a store page fault exception.
 \begin{commentary}
-AMOs never raise load page-fault exceptions.  Since any unreadable page is
+AMOs never raise load page fault exceptions.  Since any unreadable page is
 also unwritable, attempting to perform an AMO on an unreadable page always
-raises a store page-fault exception.
+raises a store page fault exception.
 \end{commentary}
 
 The U bit indicates whether the page is accessible to user mode.
@@ -1241,7 +1241,7 @@ since the last time the D bit was cleared.
 Two schemes to manage the A and D bits are permitted:
 \begin{itemize}
 \item When a virtual page is accessed and the A bit is clear, or is
-      written and the D bit is clear, a page-fault exception is raised.
+      written and the D bit is clear, a page fault exception is raised.
 
 \item When a virtual page is accessed and the A bit is clear, or is
       written and the D bit is clear, the implementation sets the
@@ -1267,7 +1267,7 @@ All harts in a system must employ the same PTE-update scheme as each other.
 \begin{commentary}
 Mandating that the PTE updates to be exact, atomic, and in program order
 simplifies the specification, and makes the feature more useful for system
-software.  Simple implementations may instead generate page-fault exceptions.
+software.  Simple implementations may instead generate page fault exceptions.
   
 The A and D bits are never cleared by the implementation.  If the
 supervisor software does not rely on accessed and/or dirty bits,
@@ -1278,7 +1278,7 @@ in the PTE to improve performance.
 
 Any level of PTE may be a leaf PTE, so in addition to 4 KiB pages, Sv32
 supports 4 MiB {\em megapages}.  A megapage must be virtually and
-physically aligned to a 4 MiB boundary; a page-fault exception is raised
+physically aligned to a 4 MiB boundary; a page fault exception is raised
 if the physical address is insufficiently aligned.
 
 For non-leaf PTEs, the D, A, and U bits are reserved for future use and
@@ -1297,33 +1297,33 @@ follows:
 \item Let $pte$ be the value of the PTE at address
   $a+va.vpn[i]\times \textrm{PTESIZE}$. (For Sv32, PTESIZE=4.)
   If accessing $pte$ violates a PMA or PMP check, raise an
-  access exception corresponding to the original access type.
+  access fault exception corresponding to the original access type.
 
 \item If $pte.v=0$, or if $pte.r=0$ and $pte.w=1$, stop and raise a
-  page-fault exception corresponding to the original access type.
+  page fault exception corresponding to the original access type.
 
 \item Otherwise, the PTE is valid.
   If $pte.r=1$ or $pte.x=1$, go to step 5.
   Otherwise, this PTE is a pointer to the next level of the page table.  Let
-  $i=i-1$.  If $i<0$, stop and raise a page-fault exception
+  $i=i-1$.  If $i<0$, stop and raise a page fault exception
   corresponding to the original access type.  Otherwise, let
   $a=pte.ppn \times \textrm{PAGESIZE}$ and go to step 2.
 
 \item A leaf PTE has been found.  Determine if the requested memory access is
   allowed by the $pte.r$, $pte.w$, $pte.x$, and $pte.u$ bits, given the
   current privilege mode and the value of the SUM and MXR fields of
-  the {\tt mstatus} register.  If not, stop and raise a page-fault
+  the {\tt mstatus} register.  If not, stop and raise a page fault
   exception corresponding to the original access type.
 
 \item If $i>0$ and $pte.ppn[i-1:0]\neq 0$, this is a misaligned superpage;
-  stop and raise a page-fault exception corresponding to the original access type.
+  stop and raise a page fault exception corresponding to the original access type.
 
 \item If $pte.a=0$, or if the memory access is a store and $pte.d=0$, either
-  raise a page-fault exception corresponding to the original access type, or:
+  raise a page fault exception corresponding to the original access type, or:
   \begin{itemize}
   \item Set $pte.a$ to 1 and, if the memory access is a store, also set
     $pte.d$ to 1.
-  \item If this access violates a PMA or PMP check, raise an access exception
+  \item If this access violates a PMA or PMP check, raise an access fault exception
     corresponding to the original access type.
   \item This update and the loading of $pte$ in step 2 must be atomic; in
     particular, no intervening store to the PTE may be perceived to have
@@ -1365,7 +1365,7 @@ into \wunits{4}{KiB} pages.  An Sv39 address is partitioned as
 shown in Figure~\ref{sv39va}.
 Instruction fetch addresses and load and store effective addresses,
 which are 64 bits, must have bits 63--39 all equal to bit 38, or else
-a page-fault exception will occur.  The 27-bit VPN is translated into a
+a page fault exception will occur.  The 27-bit VPN is translated into a
 44-bit PPN via a three-level page table, while the 12-bit page offset
 is untranslated.
 
@@ -1490,7 +1490,7 @@ Any level of PTE may be a leaf PTE, so in addition to \wunits{4}{KiB}
 pages, Sv39 supports \wunits{2}{MiB} {\em megapages} and
 \wunits{1}{GiB} {\em gigapages}, each of which must be virtually and
 physically aligned to a boundary equal to its size.
-A page-fault exception is raised if the physical address is insufficiently
+A page fault exception is raised if the physical address is insufficiently
 aligned.
 
 The algorithm for virtual-to-physical address translation is the same as in
@@ -1521,7 +1521,7 @@ into \wunits{4}{KiB} pages.  An Sv48 address is partitioned as
 shown in Figure~\ref{sv48va}.
 Instruction fetch addresses and load and store effective addresses,
 which are 64 bits, must have bits 63--48 all equal to bit 47, or else
-a page-fault exception will occur.  The 36-bit VPN is translated into a
+a page fault exception will occur.  The 36-bit VPN is translated into a
 44-bit PPN via a four-level page table, while the 12-bit page offset
 is untranslated.
 
@@ -1624,7 +1624,7 @@ PTE, so in addition to \wunits{4}{KiB} pages, Sv48 supports
 \wunits{2}{MiB} {\em megapages}, \wunits{1}{GiB} {\em gigapages}, and
 \wunits{512}{GiB} {\em terapages}, each of which must be virtually and
 physically aligned to a boundary equal to its size.
-A page-fault exception is raised if the physical address is insufficiently
+A page fault exception is raised if the physical address is insufficiently
 aligned.
 
 The algorithm for virtual-to-physical address translation is the same


### PR DESCRIPTION
Consistently use "access fault".

Consistently use "page fault".

Consistently use "instruction" instead of "instruction-fetch" or "fetch"
when qualifying exception types.

Consistently order list of "instruction, load, or store" with respect to
exception types.

No normative change is intended.