### PR TITLE
hypervisor: add performance counter delta registers

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -404,6 +404,51 @@ indicating reads to the corresponding counter will cause an exception
 when V=1.
 Hence, they are effectively \warl\ fields.
 
+\subsection{Hypervisor time delta registers ({\tt htimedelta}, {\tt htimedeltah})}
+
+The {\tt htimedelta} CSR is a VSXLEN-bit read/write register
+that contains a delta between the hardware value of the {\tt time} CSR
+and the value returned in VS/VU-mode.  That is, reading the {\tt time}
+or {\tt timeh} CSRs, or executing the {\tt RDTIME} instruction returns the
+value of the hardware counter plus the contents of {\tt htimedelta}.
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}J}
+\instbitrange{VSXLEN-1}{0} \\
+\hline
+\multicolumn{1}{|c|}{\tt htimedelta} \\
+\hline
+VSXLEN \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Hypervisor time delta register.}
+\label{hdeltareg}
+\end{figure*}
+
+On RV32 only, the time delta is split between
+{\tt htimedelta} and {\tt htimedeltah}.
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}J}
+\instbitrange{VSXLEN-1}{0} \\
+\hline
+\multicolumn{1}{|c|}{\tt htimedeltah} \\
+\hline
+VSXLEN \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Upper 32 bits of hypervisor time delta register. RV32 only.}
+\label{hdeltahreg}
+\end{figure*}
+
 \subsection{Hypervisor Guest Address Translation and Protection Register ({\tt hgatp})}
 \label{sec:hgatp}
 

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -253,6 +253,11 @@ Number    & Privilege & Name & Description \\
 \tt 0x244 & HRW  &\tt vsip       & Virtual supervisor interrupt pending. \\
 \tt 0x280 & HRW  &\tt vsatp      & Virtual supervisor address translation and protection. \\
 \hline
+\multicolumn{4}{|c|}{Virtual Counter/Timers Delta} \\
+\hline
+\tt 0xA01 & HRW  &\tt htimedelta   & Delta for VS/VU-mode timer. \\
+\tt 0xA81 & HRW  &\tt htimedeltah  & Upper 32 bits of {\tt htime}, RV32I only. \\
+\hline
 \end{tabular}
 \end{center}
 \caption{Currently allocated RISC-V hypervisor-level CSR addresses.}


### PR DESCRIPTION
It has been requested that we add htimedelta[h] CSRs so that hosts can
lie to guests about the current time, without requiring trapping and
emulating. cycle is also included, since the SBI set timer callback has
absolute cycles as the argument.  There is no intent to add equivalent
CSRs for instret and performance counters.

Fixes: #298