### PR TITLE
define CSRs reserved for trapping to HS-mode

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -118,6 +118,13 @@ for HS-mode and U-mode.
 Hypervisor software is expected to manually swap the contents of these
 registers as needed.
 
+Finally, CSRs in the range from 0x400 to 0x5FF are guaranteed to cause
+an illegal instruction when accessed from VS-mode or VU-mode, even in
+future versions of the spec\footnote{The exception could be delivered to
+  VS-mode if bit 2 is set in {\tt hedeleg}.}.  Hypervisors can use the
+custom CSR ranges 0x4C0--0x4FF and 0x5C0--0x5FF to implement
+platform-specific functionality.
+
 In this section, we use the term {\em HSXLEN} to refer to the effective XLEN
 when executing in HS-mode, and {\em VSXLEN} to refer to the effective
 XLEN when executing in VS-mode.

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -50,7 +50,9 @@ less-privileged software.
 \multicolumn{5}{|c|}{User CSRs}  \\
 \hline
 \tt   00   &\tt   00  &\tt   XXXX   & \tt 0x000-0x0FF & Standard read/write \\ 
-\tt   01   &\tt   00  &\tt   XXXX   & \tt 0x400-0x4FF & Standard read/write \\ 
+\tt   01   &\tt   00  &\tt   0XXX   & \tt 0x400-0x47F & Standard read/write \\
+\tt   01   &\tt   00  &\tt   10XX   & \tt 0x480-0x4BF & Standard read/write \\
+\tt   01   &\tt   00  &\tt   11XX   & \tt 0x4C0-0x4FF & Custom read/write \\
 \tt   10   &\tt   00  &\tt   XXXX   & \tt 0x800-0x8FF & Custom read/write \\ 
 \tt   11   &\tt   00  &\tt   0XXX   & \tt 0xC00-0xC7F & Standard read-only \\
 \tt   11   &\tt   00  &\tt   10XX   & \tt 0xC80-0xCBF & Standard read-only \\


### PR DESCRIPTION
This patch defines a range of CSRs that always trap to hypervisors, namely 0x400-0x5FF. Future releases of the standard should not define `vs*` CSRs that map to this range. These could be used to enable paravirtualization capabilities for the HEE, including:

* reporting of time when no host CPU was available to run the guest

* reporting host wallclock time at VM boot

* requesting the host to flush the TLB on the next guest entry (which avoids IPIs on overcommitted host)

* enabling asynchronous page faults (which could be delivered through scause>=16)

Standard CSRs in these ranges can be used to define paravirtualized interfaces that are accessible from multiple hypervisors.

Because U-mode CSRs in those range are all defined as standard CSRs rather than custom, the patch also redefines the range 0x4C0 to 0x4FF to custom read/write.