### PR TITLE
Fix transposed args in LR/SC CAS example

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -232,7 +232,7 @@ only take four instructions.
     cas:
         lr.w t0, (a0)        # Load original value.
         bne t0, a1, fail     # Doesn't match, so fail.
-        sc.w t0, a2, (a0)    # Try to update.
+        sc.w t0, (a0), a2    # Try to update.
         bnez t0, cas         # Retry if store-conditional failed.
         li a0, 0             # Set return to success.
         jr ra                # Return.


### PR DESCRIPTION
This commit fixes transposed arguments in the LR/SC CAS example of Chapter 8, Section 8.2.

According to the spec, "`sc.w` writes a word in `rs2` to the address in `rs1`...".  In the example, `a0` contains the address and `a2` contains the value to be written.  Therefore it appears that the instruction should be written as
```
        sc.w t0, (a0), a2
``` 