### PR TITLE
Define Upper-Half User-Level Timer CSRs for RV32I

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1821,11 +1821,16 @@ counters, the counters can be directly exposed to lower privilege modes.
 The {\tt cycle}, {\tt instret}, and {\tt hpmcounter{\em n}} CSRs are
 read-only shadows of {\tt mcycle}, {\tt minstret}, and {\tt mhpmcounter{\em
 n}}, respectively.  The {\tt time} CSR is a read-only shadow of the
-memory-mapped {\tt mtime} register.
+memory-mapped {\tt mtime} register.  Analogously, on RV32I the {\tt cycleh},
+{\tt instreth} and {\tt hpmcounter{\em n}} CSRs are read-only shadows of
+{\tt mcycleh}, {\tt minstreth} and {\tt mhpmcounter{\em n}h}, respectively.
+On RV32I the {\tt timeh} CSR is a read-only shadow of the upper 32 bits of
+the memory-mapped {\tt mtime} register, while {\tt time} shadows only the
+lower 32 bits of {\tt mtime}.
 \begin{commentary}
-Implementations can convert reads of the {\tt time} CSR into loads to the
-memory-mapped {\tt mtime} register, or emulate this functionality in M-mode
-software.
+Implementations can convert reads of the {\tt time} and {\tt timeh} CSRs
+into loads to the memory-mapped {\tt mtime} register, or emulate this
+functionality in M-mode software.
 \end{commentary}
 
 \subsection{Machine Counter-Inhibit CSR ({\tt mcountinhibit})}


### PR DESCRIPTION
Up to now the behavior of `cycleh`, `instreth`, `hpmcounterN` and `timeh` wasn’t defined in the privileged spec, other than in the initial table.