### PR TITLE
Allow RV32E to access the same CSRs as RV32I

### DIFF
--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -49,50 +49,50 @@ less-privileged software.
 \hline
 \multicolumn{5}{|c|}{User CSRs}  \\
 \hline
-\tt   00   &\tt   00  &\tt   XXXX   & \tt 0x000-0x0FF & Standard read/write \\ 
-\tt   01   &\tt   00  &\tt   XXXX   & \tt 0x400-0x4FF & Standard read/write \\ 
-\tt   10   &\tt   00  &\tt   XXXX   & \tt 0x800-0x8FF & Custom read/write \\ 
+\tt   00   &\tt   00  &\tt   XXXX   & \tt 0x000-0x0FF & Standard read/write \\
+\tt   01   &\tt   00  &\tt   XXXX   & \tt 0x400-0x4FF & Standard read/write \\
+\tt   10   &\tt   00  &\tt   XXXX   & \tt 0x800-0x8FF & Custom read/write \\
 \tt   11   &\tt   00  &\tt   0XXX   & \tt 0xC00-0xC7F & Standard read-only \\
 \tt   11   &\tt   00  &\tt   10XX   & \tt 0xC80-0xCBF & Standard read-only \\
 \tt   11   &\tt   00  &\tt   11XX   & \tt 0xCC0-0xCFF & Custom read-only \\
 \hline
 \multicolumn{5}{|c|}{Supervisor CSRs}  \\
-\hline                                         
-\tt   00   &\tt   01  &\tt   XXXX   & \tt 0x100-0x1FF & Standard read/write \\ 
-\tt   01   &\tt   01  &\tt   0XXX   & \tt 0x500-0x57F & Standard read/write \\ 
-\tt   01   &\tt   01  &\tt   10XX   & \tt 0x580-0x5BF & Standard read/write \\ 
-\tt   01   &\tt   01  &\tt   11XX   & \tt 0x5C0-0x5FF & Custom read/write \\ 
-\tt   10   &\tt   01  &\tt   0XXX   & \tt 0x900-0x97F & Standard read/write \\ 
-\tt   10   &\tt   01  &\tt   10XX   & \tt 0x980-0x9BF & Standard read/write \\ 
-\tt   10   &\tt   01  &\tt   11XX   & \tt 0x9C0-0x9FF & Custom read/write \\ 
+\hline
+\tt   00   &\tt   01  &\tt   XXXX   & \tt 0x100-0x1FF & Standard read/write \\
+\tt   01   &\tt   01  &\tt   0XXX   & \tt 0x500-0x57F & Standard read/write \\
+\tt   01   &\tt   01  &\tt   10XX   & \tt 0x580-0x5BF & Standard read/write \\
+\tt   01   &\tt   01  &\tt   11XX   & \tt 0x5C0-0x5FF & Custom read/write \\
+\tt   10   &\tt   01  &\tt   0XXX   & \tt 0x900-0x97F & Standard read/write \\
+\tt   10   &\tt   01  &\tt   10XX   & \tt 0x980-0x9BF & Standard read/write \\
+\tt   10   &\tt   01  &\tt   11XX   & \tt 0x9C0-0x9FF & Custom read/write \\
 \tt   11   &\tt   01  &\tt   0XXX   & \tt 0xD00-0xD7F & Standard read-only \\
 \tt   11   &\tt   01  &\tt   10XX   & \tt 0xD80-0xDBF & Standard read-only \\
 \tt   11   &\tt   01  &\tt   11XX   & \tt 0xDC0-0xDFF & Custom read-only \\
 \hline
 \multicolumn{5}{|c|}{Hypervisor CSRs} \\
-\hline                                         
-\tt   00   &\tt   10  &\tt   XXXX   & \tt 0x200-0x2FF & Standard read/write \\ 
-\tt   01   &\tt   10  &\tt   0XXX   & \tt 0x600-0x67F & Standard read/write \\ 
-\tt   01   &\tt   10  &\tt   10XX   & \tt 0x680-0x6BF & Standard read/write \\ 
-\tt   01   &\tt   10  &\tt   11XX   & \tt 0x6C0-0x6FF & Custom read/write \\ 
-\tt   10   &\tt   10  &\tt   0XXX   & \tt 0xA00-0xA7F & Standard read/write \\ 
-\tt   10   &\tt   10  &\tt   10XX   & \tt 0xA80-0xABF & Standard read/write \\ 
-\tt   10   &\tt   10  &\tt   11XX   & \tt 0xAC0-0xAFF & Custom read/write \\ 
+\hline
+\tt   00   &\tt   10  &\tt   XXXX   & \tt 0x200-0x2FF & Standard read/write \\
+\tt   01   &\tt   10  &\tt   0XXX   & \tt 0x600-0x67F & Standard read/write \\
+\tt   01   &\tt   10  &\tt   10XX   & \tt 0x680-0x6BF & Standard read/write \\
+\tt   01   &\tt   10  &\tt   11XX   & \tt 0x6C0-0x6FF & Custom read/write \\
+\tt   10   &\tt   10  &\tt   0XXX   & \tt 0xA00-0xA7F & Standard read/write \\
+\tt   10   &\tt   10  &\tt   10XX   & \tt 0xA80-0xABF & Standard read/write \\
+\tt   10   &\tt   10  &\tt   11XX   & \tt 0xAC0-0xAFF & Custom read/write \\
 \tt   11   &\tt   10  &\tt   0XXX   & \tt 0xE00-0xE7F & Standard read-only \\
 \tt   11   &\tt   10  &\tt   10XX   & \tt 0xE80-0xEBF & Standard read-only \\
 \tt   11   &\tt   10  &\tt   11XX   & \tt 0xEC0-0xEFF & Custom read-only \\
 \hline
 \multicolumn{5}{|c|}{Machine CSRs}  \\
-\hline                                         
-\tt   00   &\tt   11  &\tt   XXXX   & \tt 0x300-0x3FF & Standard read/write \\ 
-\tt   01   &\tt   11  &\tt   0XXX   & \tt 0x700-0x77F & Standard read/write \\ 
-\tt   01   &\tt   11  &\tt   100X   & \tt 0x780-0x79F & Standard read/write \\ 
-\tt   01   &\tt   11  &\tt   1010   & \tt 0x7A0-0x7AF & Standard read/write debug CSRs  \\ 
+\hline
+\tt   00   &\tt   11  &\tt   XXXX   & \tt 0x300-0x3FF & Standard read/write \\
+\tt   01   &\tt   11  &\tt   0XXX   & \tt 0x700-0x77F & Standard read/write \\
+\tt   01   &\tt   11  &\tt   100X   & \tt 0x780-0x79F & Standard read/write \\
+\tt   01   &\tt   11  &\tt   1010   & \tt 0x7A0-0x7AF & Standard read/write debug CSRs  \\
 \tt   01   &\tt   11  &\tt   1011   & \tt 0x7B0-0x7BF & Debug-mode-only CSRs \\
-\tt   01   &\tt   11  &\tt   11XX   & \tt 0x7C0-0x7FF & Custom read/write \\ 
-\tt   10   &\tt   11  &\tt   0XXX   & \tt 0xB00-0xB7F & Standard read/write \\ 
-\tt   10   &\tt   11  &\tt   10XX   & \tt 0xB80-0xBBF & Standard read/write \\ 
-\tt   10   &\tt   11  &\tt   11XX   & \tt 0xBC0-0xBFF & Custom read/write \\ 
+\tt   01   &\tt   11  &\tt   11XX   & \tt 0x7C0-0x7FF & Custom read/write \\
+\tt   10   &\tt   11  &\tt   0XXX   & \tt 0xB00-0xB7F & Standard read/write \\
+\tt   10   &\tt   11  &\tt   10XX   & \tt 0xB80-0xBBF & Standard read/write \\
+\tt   10   &\tt   11  &\tt   11XX   & \tt 0xBC0-0xBFF & Custom read/write \\
 \tt   11   &\tt   11  &\tt   0XXX   & \tt 0xF00-0xF7F & Standard read-only \\
 \tt   11   &\tt   11  &\tt   10XX   & \tt 0xF80-0xFBF & Standard read-only \\
 \tt   11   &\tt   11  &\tt   11XX   & \tt 0xFC0-0xFFF & Custom read-only \\
@@ -195,7 +195,7 @@ Register ({\tt frm} + {\tt fflags}). \\
 \begin{tabular}{|l|l|l|l|}
 \hline
 Number    & Privilege & Name & Description \\
-\hline  
+\hline
 \multicolumn{4}{|c|}{Supervisor Trap Setup} \\
 \hline
 \tt 0x100 & SRW  &\tt sstatus    & Supervisor status register. \\
@@ -228,7 +228,7 @@ Number    & Privilege & Name & Description \\
 \begin{tabular}{|l|l|l|l|}
 \hline
 Number    & Privilege & Name & Description \\
-\hline  
+\hline
 \multicolumn{4}{|c|}{Hypervisor Trap Setup} \\
 \hline
 \hline
@@ -270,14 +270,14 @@ Number    & Privilege & Name & Description \\
 \begin{tabular}{|l|l|l|l|}
 \hline
 Number    & Privilege & Name & Description \\
-\hline  
+\hline
 \multicolumn{4}{|c|}{Machine Information Registers} \\
 \hline
 \tt 0xF11 & MRO &\tt mvendorid   & Vendor ID. \\
 \tt 0xF12 & MRO &\tt marchid     & Architecture ID. \\
 \tt 0xF13 & MRO &\tt mimpid      & Implementation ID. \\
 \tt 0xF14 & MRO &\tt mhartid     & Hardware thread ID. \\
-\hline  
+\hline
 \multicolumn{4}{|c|}{Machine Trap Setup} \\
 \hline
 \tt 0x300 & MRW  &\tt mstatus    & Machine status register. \\
@@ -340,7 +340,7 @@ Number    & Privilege & Name & Description \\
 \tt 0xB84 & MRW  &\tt mhpmcounter4h  & Upper 32 bits of {\tt mhpmcounter4}, RV32I only. \\
 & & \multicolumn{1}{c|}{\vdots} & \ \\
 \tt 0xB9F & MRW  &\tt mhpmcounter31h & Upper 32 bits of {\tt mhpmcounter31}, RV32I only. \\
-\hline  
+\hline
 \multicolumn{4}{|c|}{Machine Counter Setup} \\
 \hline
 \tt 0x320 & MRW  &\tt mcountinhibit  & Machine counter-inhibit register. \\
@@ -406,7 +406,7 @@ should not assume a read will return a legal value unless the last
 write was of a legal value, or the register has not been written since
 another operation (e.g., reset) set the register to a legal value.
 These fields are labeled \wlrl\ in the register descriptions.
- 
+
 \begin{commentary}
 Hardware implementations need only implement enough state bits to
 differentiate between the supported values, but must always return the

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -176,13 +176,13 @@ Register ({\tt frm} + {\tt fflags}). \\
 \tt 0xC04 & URO  &\tt hpmcounter4   & Performance-monitoring counter. \\
 & & \multicolumn{1}{c|}{\vdots} & \ \\
 \tt 0xC1F & URO  &\tt hpmcounter31  & Performance-monitoring counter. \\
-\tt 0xC80 & URO  &\tt cycleh        & Upper 32 bits of {\tt cycle}, RV32I only. \\
-\tt 0xC81 & URO  &\tt timeh         & Upper 32 bits of {\tt time}, RV32I only. \\
-\tt 0xC82 & URO  &\tt instreth      & Upper 32 bits of {\tt instret}, RV32I only. \\
-\tt 0xC83 & URO  &\tt hpmcounter3h  & Upper 32 bits of {\tt hpmcounter3}, RV32I only. \\
-\tt 0xC84 & URO  &\tt hpmcounter4h  & Upper 32 bits of {\tt hpmcounter4}, RV32I only. \\
+\tt 0xC80 & URO  &\tt cycleh        & Upper 32 bits of {\tt cycle}, RV32 only. \\
+\tt 0xC81 & URO  &\tt timeh         & Upper 32 bits of {\tt time}, RV32 only. \\
+\tt 0xC82 & URO  &\tt instreth      & Upper 32 bits of {\tt instret}, RV32 only. \\
+\tt 0xC83 & URO  &\tt hpmcounter3h  & Upper 32 bits of {\tt hpmcounter3}, RV32 only. \\
+\tt 0xC84 & URO  &\tt hpmcounter4h  & Upper 32 bits of {\tt hpmcounter4}, RV32 only. \\
 & & \multicolumn{1}{c|}{\vdots} & \ \\
-\tt 0xC9F & URO  &\tt hpmcounter31h & Upper 32 bits of {\tt hpmcounter31}, RV32I only. \\
+\tt 0xC9F & URO  &\tt hpmcounter31h & Upper 32 bits of {\tt hpmcounter31}, RV32 only. \\
 \hline
 \end{tabular}
 \end{center}
@@ -244,7 +244,7 @@ Number    & Privilege & Name & Description \\
 \multicolumn{4}{|c|}{Hypervisor Counter/Timer Virtualization Registers} \\
 \hline
 \tt 0x605 & HRW  &\tt htimedelta   & Delta for VS/VU-mode timer. \\
-\tt 0x615 & HRW  &\tt htimedeltah  & Upper 32 bits of {\tt htimedelta}, RV32I only. \\
+\tt 0x615 & HRW  &\tt htimedeltah  & Upper 32 bits of {\tt htimedelta}, RV32 only. \\
 \hline
 \multicolumn{4}{|c|}{Virtual Supervisor Registers} \\
 \hline
@@ -334,12 +334,12 @@ Number    & Privilege & Name & Description \\
 \tt 0xB04 & MRW  &\tt mhpmcounter4   & Machine performance-monitoring counter. \\
 & & \multicolumn{1}{c|}{\vdots} & \ \\
 \tt 0xB1F & MRW  &\tt mhpmcounter31  & Machine performance-monitoring counter. \\
-\tt 0xB80 & MRW  &\tt mcycleh        & Upper 32 bits of {\tt mcycle}, RV32I only. \\
-\tt 0xB82 & MRW  &\tt minstreth      & Upper 32 bits of {\tt minstret}, RV32I only. \\
-\tt 0xB83 & MRW  &\tt mhpmcounter3h  & Upper 32 bits of {\tt mhpmcounter3}, RV32I only. \\
-\tt 0xB84 & MRW  &\tt mhpmcounter4h  & Upper 32 bits of {\tt mhpmcounter4}, RV32I only. \\
+\tt 0xB80 & MRW  &\tt mcycleh        & Upper 32 bits of {\tt mcycle}, RV32 only. \\
+\tt 0xB82 & MRW  &\tt minstreth      & Upper 32 bits of {\tt minstret}, RV32 only. \\
+\tt 0xB83 & MRW  &\tt mhpmcounter3h  & Upper 32 bits of {\tt mhpmcounter3}, RV32 only. \\
+\tt 0xB84 & MRW  &\tt mhpmcounter4h  & Upper 32 bits of {\tt mhpmcounter4}, RV32 only. \\
 & & \multicolumn{1}{c|}{\vdots} & \ \\
-\tt 0xB9F & MRW  &\tt mhpmcounter31h & Upper 32 bits of {\tt mhpmcounter31}, RV32I only. \\
+\tt 0xB9F & MRW  &\tt mhpmcounter31h & Upper 32 bits of {\tt mhpmcounter31}, RV32 only. \\
 \hline
 \multicolumn{4}{|c|}{Machine Counter Setup} \\
 \hline


### PR DESCRIPTION
A fix for issue #440.
Includes fixes for trailing whitespace.