### PR TITLE
Changes nominally for AMBA

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -124,6 +124,13 @@ synchronization libraries and other software that assumes DW-CAS is
 the basic machine primitive.  A possible mitigating factor is the
 recent addition of transactional memory instructions to x86, which
 might cause a move away from DW-CAS.
+
+More generally, a multi-word atomic primitive is desirable, but there is
+still considerable debate about what form this should take, and
+guaranteeing forward progress adds complexity to a system.  Our
+current thoughts are to include a small limited-capacity transactional
+memory buffer along the lines of the original transactional memory
+proposals as an optional standard extension ``T''.
 \end{commentary}
 
 The failure code with value 1 is reserved to encode an unspecified
@@ -189,10 +196,27 @@ during a preemptive context switch to forcibly yield any existing load
 reservation.
 \end{commentary}
 
-LR/SC can be used to construct lock-free data structures.  An example
-using LR/SC to implement a compare-and-swap function is shown in
-Figure~\ref{cas}.  If inlined, compare-and-swap functionality need
-only take four instructions.
+An SC instruction can never be observed by another RISC-V hart
+before the immediately preceding LR.
+The LR/SC
+sequence can be given acquire semantics by setting the {\em aq} bit on
+the LR instruction.  The LR/SC sequence can be given release semantics
+by setting the {\em rl} bit on the SC instruction.  Setting the {\em
+  aq} bit on the LR instruction, and setting both the {\em aq} and the {\em
+  rl} bit on the SC instruction makes the LR/SC sequence sequentially
+consistent, meaning that it cannot be reordered with earlier or
+later memory operations from the same hart.
+
+If neither bit is set on both LR and SC, the LR/SC sequence can be
+observed to occur before or after surrounding memory operations from
+the same RISC-V hart.  This can be appropriate when the LR/SC
+sequence is used to implement a parallel reduction operation.
+
+Software should not set the {\em rl} bit on an LR instruction unless the {\em
+aq} bit is also set, nor should software set the {\em aq} bit on an SC
+instruction unless the {\em rl} bit is also set.  LR.{\em rl} and SC.{\em aq}
+instructions are not guaranteed to provide any stronger ordering than those
+with both bits clear, but may result in lower performance.
 
 \begin{figure}[h!]
 \begin{center}
@@ -217,36 +241,10 @@ only take four instructions.
 \label{cas}
 \end{figure}
 
-An SC instruction can never be observed by another RISC-V hart
-before the immediately preceding LR.
-The LR/SC
-sequence can be given acquire semantics by setting the {\em aq} bit on
-the LR instruction.  The LR/SC sequence can be given release semantics
-by setting the {\em rl} bit on the SC instruction.  Setting the {\em
-  aq} bit on the LR instruction, and setting both the {\em aq} and the {\em
-  rl} bit on the SC instruction makes the LR/SC sequence sequentially
-consistent, meaning that it cannot be reordered with earlier or
-later memory operations from the same hart.
-
-If neither bit is set on both LR and SC, the LR/SC sequence can be
-observed to occur before or after surrounding memory operations from
-the same RISC-V hart.  This can be appropriate when the LR/SC
-sequence is used to implement a parallel reduction operation.
-
-Software should not set the {\em rl} bit on an LR instruction unless the {\em
-aq} bit is also set, nor should software set the {\em aq} bit on an SC
-instruction unless the {\em rl} bit is also set.  LR.{\em rl} and SC.{\em aq}
-instructions are not guaranteed to provide any stronger ordering than those
-with both bits clear, but may result in lower performance.
-
-\begin{commentary}
-In general, a multi-word atomic primitive is desirable but there is
-still considerable debate about what form this should take, and
-guaranteeing forward progress adds complexity to a system.  Our
-current thoughts are to include a small limited-capacity transactional
-memory buffer along the lines of the original transactional memory
-proposals as an optional standard extension ``T''.
-\end{commentary}
+LR/SC can be used to construct lock-free data structures.  An example
+using LR/SC to implement a compare-and-swap function is shown in
+Figure~\ref{cas}.  If inlined, compare-and-swap functionality need
+only take four instructions.
 
 \section{Eventual Success of Store-Conditional Instructions}
 \label{sec:lrscseq}

--- a/src/a.tex
+++ b/src/a.tex
@@ -267,8 +267,10 @@ the following properties:
 \item The code to retry a failing LR/SC sequence can contain backwards jumps
   and/or branches to repeat the LR/SC sequence, but otherwise has the same
   constraint as the code between the LR and SC.
-\item The LR address must lie either within a main memory region or within some
-  other memory region specified by the execution environment.
+\item The LR address must lie within a memory region with the {\em LR/SC
+  eventuality} property.  Main memory regions have this property.  The
+  execution environment may specify additional memory regions that have
+  this property.
 \item The SC must be to the same virtual address and of the same data size as
   the latest LR executed by the same hart.
 \end{itemize}
@@ -308,8 +310,7 @@ must guarantee that one of the following events eventually occurs:
   the reservation set of the LR instruction in {\em H}'s constrained LR/SC
   loop, or some other device in the system writes to that reservation set.
 \item {\em H} executes a branch or jump that exits the constrained LR/SC loop.
-\item {\em H} executes an instruction that raises a synchronous exception.
-\item {\em H} takes an interrupt.
+\item {\em H} takes a trap.
 \end{itemize}
 
 \begin{commentary}

--- a/src/a.tex
+++ b/src/a.tex
@@ -241,35 +241,36 @@ proposals as an optional standard extension ``T''.
 \section{Eventual Success of Store-Conditional Instructions}
 \label{sec:lrscseq}
 
-The standard A extension defines {\em constrained LR/SC sequences}, which have
+The standard A extension defines {\em constrained LR/SC loops}, which have
 the following properties:
 \vspace{-0.2in}
 \begin{itemize}
 \parskip 0pt
 \itemsep 1pt
-\item The static code for the LR/SC sequence, plus the code to retry the
-  sequence in the case of failure, must comprise at most 16 instructions
-  placed sequentially in memory.
-\item The dynamic code executed between the LR and SC instructions can only
-  contain instructions from the base ``I'' instruction set, excluding loads,
-  stores, backward jumps or taken backward branches, JALR, FENCE, and SYSTEM
-  instructions.  If the ``C'' extension is supported, then compressed forms
-  of the aforementioned ``I'' instructions are also permitted.
+\item The loop comprises only an LR/SC sequence and code to retry the sequence
+  in the case of failure, and must comprise at most 16 instructions placed
+  sequentially in memory.
+\item An LR/SC sequence begins with an LR instruction and ends with an SC
+  instruction.  The dynamic code executed between the LR and SC instructions
+  can only contain instructions from the base ``I'' instruction set, excluding
+  loads, stores, backward jumps or taken backward branches, JALR, FENCE, and
+  SYSTEM instructions.  If the ``C'' extension is supported, then compressed
+  forms of the aforementioned ``I'' instructions are also permitted.
 \item The code to retry a failing LR/SC sequence can contain backwards jumps
   and/or branches to repeat the LR/SC sequence, but otherwise has the same
   constraint as the code between the LR and SC.
 \item The LR address must lie either within a main memory region or within some
   other memory region specified by the execution environment.
 \item The SC must be to the same address and of the same data size as the
-  latest LR executed.
+  latest LR executed by the same hart.
 \end{itemize}
 
-LR/SC sequences that do not meet these constraints are {\em unconstrained}.
-Unconstrained LR/SC sequences might succeed on some attempts on some
-implementations, but might never succeed on other implementations.
+LR/SC sequences that do not lie within constrained LR/SC loops are {\em
+unconstrained}.  Unconstrained LR/SC sequences might succeed on some attempts
+on some implementations, but might never succeed on other implementations.
 
 \begin{commentary}
-The restrictions on LR/SC sequence contents allow a simple implementation
+The restrictions on LR/SC loop contents allow a simple implementation
 to capture a cache line on the LR and complete the LR/SC sequence by
 holding off remote cache interventions for a bounded short
 time.  Interrupts and TLB misses might cause the reservation to be
@@ -277,10 +278,10 @@ lost, but eventually the atomic sequence can complete.  More scalable
 implementations that do not obtain exclusive access to the cache line
 on the LR are also possible, and also benefit from these restrictions.
 
-We restricted the length of LR/SC sequences to fit within 64 contiguous
+We restricted the length of LR/SC loops to fit within 64 contiguous
 instruction bytes in the base ISA to avoid undue restrictions on instruction
 cache and TLB size and associativity.  Similarly, we disallowed other loads
-and stores within the sequences to avoid restrictions on data-cache
+and stores within the loops to avoid restrictions on data-cache
 associativity.  The restrictions on branches and jumps limit the time that
 can be spent in the sequence.  Floating-point operations and integer
 multiply/divide were disallowed to simplify the operating system's emulation
@@ -293,29 +294,29 @@ unconstrained LR/SC sequence.  Implementations are permitted to
 unconditionally fail any unconstrained LR/SC sequence.
 \end{commentary}
 
-If a hart {\em H} enters a constrained LR/SC sequence, the execution environment
+If a hart {\em H} enters a constrained LR/SC loop, the execution environment
 must guarantee that one of the following events eventually occurs:
 \vspace{-0.2in}
 \begin{itemize}
 \parskip 0pt
 \itemsep 1pt
 \item {\em H} or some other hart executes a successful SC to the subset of
-  memory reserved by the LR instruction in {\em H}'s constrained LR/SC sequence.
+  memory reserved by the LR instruction in {\em H}'s constrained LR/SC loops.
 \item Some other hart executes an unconditional store or AMO instruction to
   the subset of memory reserved by the LR instruction in {\em H}'s constrained
-  LR/SC sequence, or some other device in the system writes to that subset of
+  LR/SC loop, or some other device in the system writes to that subset of
   memory.
-\item {\em H} executes a branch or jump that exits the constrained LR/SC
-  sequence.
+\item {\em H} executes a branch or jump that exits the constrained LR/SC loop.
 \item {\em H} executes an instruction that raises a synchronous exception.
 \item {\em H} takes an interrupt.
 \end{itemize}
 
 \begin{commentary}
 As a consequence of this requirement, if some harts in an execution
-environment are executing constrained LR/SC sequences, and no other harts in
-the execution environment execute an unconditional store or AMO, then at least
-one hart will eventually exit its constrained LR/SC sequence.
+environment are executing constrained LR/SC loops, and no other harts or
+devices in the execution environment execute an unconditional store or AMO to
+that granule, then at least one hart will eventually exit its constrained
+LR/SC loop.
 
 Loads and load-reserved instructions do not by themselves impede the progress
 of other harts' LR/SC sequences.
@@ -328,7 +329,7 @@ fail for for implementation reasons, provided progress is eventually made.
 One advantage of CAS is that it guarantees that some hart eventually
 makes progress, whereas an LR/SC atomic sequence could livelock
 indefinitely on some systems.  To avoid this concern, we added an
-architectural guarantee of livelock freedom for LR/SC sequences.
+architectural guarantee of livelock freedom for certain LR/SC sequences.
 
 Earlier versions of this specification imposed a stronger starvation-freedom
 guarantee.  However, the weaker livelock-freedom guarantee is sufficient to

--- a/src/a.tex
+++ b/src/a.tex
@@ -213,9 +213,8 @@ only take four instructions.
 \end{figure}
 
 An SC instruction can never be observed by another RISC-V hart
-before the immediately preceding LR.  Due to the atomic nature of the
-LR/SC sequence, no memory operations from another hart can be observed
-to have occurred between the LR and a successful SC.  The LR/SC
+before the immediately preceding LR.
+The LR/SC
 sequence can be given acquire semantics by setting the {\em aq} bit on
 the LR instruction.  The LR/SC sequence can be given release semantics
 by setting the {\em rl} bit on the SC instruction.  Setting the {\em

--- a/src/a.tex
+++ b/src/a.tex
@@ -85,13 +85,17 @@ SC.W/D & \multicolumn{2}{c}{ordering} & src & addr & width & dest & AMO  \\
 Complex atomic memory operations on a single memory word or doubleword are performed
 with the load-reserved (LR) and store-conditional (SC) instructions.
 LR.W loads a word from the address in {\em rs1}, places the sign-extended
-value in {\em rd}, and registers a {\em reservation set}---a set of addresses
+value in {\em rd}, and registers a {\em reservation set}---a set of bytes
 that subsumes the bytes in the addressed word.
-SC.W writes a word in {\em rs2} to the address in {\em rs1}, provided the
-reservation is still valid and the reservation set contains the addresses of
-the bytes being stored to.
-SC.W writes zero to {\em rd} on success or a nonzero code on failure, then,
-regardless of success, yields any load reservation held by this hart.
+SC.W conditionally writes a word in {\em rs2} to the address in {\em rs1}: the
+SC.W succeeds only if the reservation is still valid and the reservation set
+contains the bytes being written.
+If the SC.W succeeds, the instruction writes the word in {\em rs2} to memory,
+and it writes zero to {\em rd}.
+If the SC.W fails, the instruction does not write to memory, and it writes
+a nonzero value to {\em rd}.
+Regardless of success or failure, executing an SC.W instruction invalidates
+any reservation held by this hart.
 LR.D and SC.D act analogously on doublewords and are only available on RV64.
 For RV64, LR.W and SC.W sign-extend the value placed in {\em rd}.
 
@@ -155,6 +159,9 @@ should not be emulated.
 
 \begin{commentary}
 Emulating misaligned LR/SC sequences is impractical in most systems.
+
+Misaligned LR/SC sequences also raise the possibility of accessing multiple
+reservation sets at once, which present definitions do not provide for.
 \end{commentary}
 
 An implementation can register an arbitrarily large reservation set on each
@@ -192,12 +199,38 @@ contiguous and no greater than the virtual memory page size.
 
 \begin{commentary}
 A store-conditional instruction to a scratch word of memory should be used
-during a preemptive context switch to forcibly yield any existing load
-reservation.
+to forcibly invalidate any existing load reservation:
+\begin{itemize}
+\item during a preemptive context switch, and
+\item if necessary when changing virtual to physical address mappings,
+  such as when migrating pages that might contain an active reservation.
+\end{itemize}
+\end{commentary}
+
+\begin{commentary}
+The invalidation of a hart's reservation when it executes an LR or SC
+imply that a hart can only hold one reservation at a time, and that
+an SC can only pair with the most recent LR, and LR with the next
+following SC, in program order.  This is a restriction to the
+Atomicity Axiom in Section~\ref{sec:rvwmo} that ensures software runs
+correctly on expected common implementations that operate in this manner.
+
+It is conceivable for a future extension to allow the same hart to hold
+multiple independent reservations at once, such as to help improve performance
+in some scenarios.  Such an extension would presumably introduce a mechanism
+to clear all of a hart's reservations, replacing the no longer effective SC
+to a scratch word.  The practicality of such an extension is not established.
+\end{commentary}
+
+\begin{commentary}
+Another example effective memory write that invalidate a reservation
+is the invalidation of a dirty cache line.  It is also possible for
+operations that prepare for a write without actually doing the write
+to also invalidate a reservation, such as prefetch-for-write requests.
 \end{commentary}
 
 An SC instruction can never be observed by another RISC-V hart
-before the immediately preceding LR.
+before the LR instruction that established the reservation.
 The LR/SC
 sequence can be given acquire semantics by setting the {\em aq} bit on
 the LR instruction.  The LR/SC sequence can be given release semantics
@@ -267,10 +300,9 @@ the following properties:
 \item The code to retry a failing LR/SC sequence can contain backwards jumps
   and/or branches to repeat the LR/SC sequence, but otherwise has the same
   constraint as the code between the LR and SC.
-\item The LR address must lie within a memory region with the {\em LR/SC
-  eventuality} property.  Main memory regions have this property.  The
-  execution environment may specify additional memory regions that have
-  this property.
+\item The LR and SC addresses must lie within a memory region with the
+  {\em LR/SC eventuality} property.  The execution environment is responsible
+  for communicating which regions have this property.
 \item The SC must be to the same virtual address and of the same data size as
   the latest LR executed by the same hart.
 \end{itemize}
@@ -285,7 +317,7 @@ instruction bytes in the base ISA to avoid undue restrictions on instruction
 cache and TLB size and associativity.
 Similarly, we disallowed other loads and stores within the loops to avoid
 restrictions on data-cache associativity in simple implementations that track
-the reservation within the cache.
+the reservation within a private cache.
 The restrictions on branches and jumps limit the time that
 can be spent in the sequence.  Floating-point operations and integer
 multiply/divide were disallowed to simplify the operating system's emulation
@@ -310,11 +342,17 @@ must guarantee that one of the following events eventually occurs:
   the reservation set of the LR instruction in {\em H}'s constrained LR/SC
   loop, or some other device in the system writes to that reservation set.
 \item {\em H} executes a branch or jump that exits the constrained LR/SC loop.
-\item {\em H} takes a trap.
+\item {\em H} traps.
 \end{itemize}
 
 \begin{commentary}
-As a consequence of this requirement, if some harts in an execution
+Note that these definitions permit an implementation to fail an SC instruction
+occasionally for any reason, provided the aforementioned guarantee is not
+violated.
+\end{commentary}
+
+\begin{commentary}
+As a consequence of the eventuality guarantee, if some harts in an execution
 environment are executing constrained LR/SC loops, and no other harts or
 devices in the execution environment execute an unconditional store or AMO to
 that reservation set, then at least one hart will eventually exit its
@@ -327,8 +365,10 @@ of other harts' LR/SC sequences.
 We note this constraint implies, among other things, that loads and
 load-reserved instructions executed by other harts (possibly within the same
 core) cannot impede LR/SC progress indefinitely.
-For example, conflict misses caused by another hart sharing the cache cannot
+For example, cache evictions caused by another hart sharing the cache cannot
 impede LR/SC progress indefinitely.
+Typically, this implies reservations are tracked independently of
+evictions from any shared cache.
 Similarly, cache misses caused by speculative execution within a hart cannot
 impede LR/SC progress indefinitely.
 

--- a/src/a.tex
+++ b/src/a.tex
@@ -84,12 +84,14 @@ SC.W/D & \multicolumn{2}{c}{ordering} & src & addr & width & dest & AMO  \\
 
 Complex atomic memory operations on a single memory word or doubleword are performed
 with the load-reserved (LR) and store-conditional (SC) instructions.
-LR.W loads a word from the address in {\em rs1}, places the
-sign-extended value in {\em rd}, and registers a reservation on the
-memory address and a range of bytes including at least all bytes of
-the addressed word.  SC.W writes a word in {\em rs2} to the address in
-{\em rs1}, provided a valid reservation still exists on that address.
-SC.W writes zero to {\em rd} on success or a nonzero code on failure.
+LR.W loads a word from the address in {\em rs1}, places the sign-extended
+value in {\em rd}, and registers a {\em reservation set}---a set of addresses
+that subsumes the bytes in the addressed word.
+SC.W writes a word in {\em rs2} to the address in {\em rs1}, provided the
+reservation is still valid and the reservation set contains the addresses of
+the bytes being stored to.
+SC.W writes zero to {\em rd} on success or a nonzero code on failure, then,
+regardless of success, yields any load reservation held by this hart.
 LR.D and SC.D act analogously on doublewords and are only available on RV64.
 For RV64, LR.W and SC.W sign-extend the value placed in {\em rd}.
 
@@ -144,38 +146,41 @@ exception can be generated for a memory access that would otherwise be
 able to complete except for the misalignment, if the misaligned access
 should not be emulated.
 
-An implementation can reserve an arbitrarily large subset of the
-address space on each LR, provided the memory range includes all bytes
-of the addressed data word or doubleword.
-An SC can only pair with the most recent LR in program order.  An SC may
-succeed if no store from another hart, nor a write from some other device, to
-the address range reserved by the LR can be observed to have occurred between
-the LR and the SC, and if there is no other SC between the LR and itself in
-program order.
-Note this LR might have had a different address
-argument and data size, but reserved the SC's address as part of the memory subset.
-Following this model, in systems with memory translation, an SC is
-allowed to succeed if the earlier LR reserved the same location using
-an alias with a different virtual address, but is also allowed to fail
-if the virtual address is different.
-The SC must fail if the address is not within the memory subset reserved
-by the most recent LR in program order.
+\begin{commentary}
+Emulating misaligned LR/SC sequences is impractical in most systems.
+\end{commentary}
+
+An implementation can register an arbitrarily large reservation set on each
+LR, provided the reservation set includes all bytes of the addressed data word
+or doubleword.
+An SC can only pair with the most recent LR in program order.
+An SC may succeed if no store from another hart, nor a write from some other
+device, to the reservation set can be observed to have occurred between the LR
+and the SC, and if there is no other SC between the LR and itself in program
+order.
+Note this LR might have had a different address argument and data size, but
+reserved the SC's address as part of the reservation set.
+Following this model, in systems with memory translation, an SC is allowed to
+succeed if the earlier LR reserved the same location using an alias with
+a different virtual address, but is also allowed to fail if the virtual
+address is different.
+The SC must fail if the address is not within the reservation set of the most
+recent LR in program order.
 The SC must fail if a store from another hart, or a write from some other
-device, to the address range reserved by the LR can be observed to occur
-between the LR and the SC.
-An SC must fail if there is
-another SC (to any address) between the LR and the SC in program
-order.  The precise statement of the atomicity requirements for
-successful LR/SC sequences is defined by the Atomicity Axiom in
-Section~\ref{sec:rvwmo}.
+device, to the reservation set can be observed to occur between the LR and the
+SC.
+An SC must fail if there is another SC (to any address) between the LR and the
+SC in program order.
+The precise statement of the atomicity requirements for successful LR/SC
+sequences is defined by the Atomicity Axiom in Section~\ref{sec:rvwmo}.
 
 \begin{commentary}
 The platform should provide a means to determine the size and shape of the
-memory range reserved on an LR.
+reservation set.
 
-A platform specification may constrain the size and shape of the memory range
-reserved on an LR.  For example, the Unix platform is expected to require the
-range be contiguous and no greater than the virtual memory page size.
+A platform specification may constrain the size and shape of the reservation
+set.  For example, the Unix platform is expected to require the set be
+contiguous and no greater than the virtual memory page size.
 \end{commentary}
 
 \begin{commentary}
@@ -299,12 +304,11 @@ must guarantee that one of the following events eventually occurs:
 \begin{itemize}
 \parskip 0pt
 \itemsep 1pt
-\item {\em H} or some other hart executes a successful SC to the subset of
-  memory reserved by the LR instruction in {\em H}'s constrained LR/SC loops.
+\item {\em H} or some other hart executes a successful SC to the reservation
+  set of the LR instruction in {\em H}'s constrained LR/SC loops.
 \item Some other hart executes an unconditional store or AMO instruction to
-  the subset of memory reserved by the LR instruction in {\em H}'s constrained
-  LR/SC loop, or some other device in the system writes to that subset of
-  memory.
+  the reservation set of the LR instruction in {\em H}'s constrained LR/SC
+  loop, or some other device in the system writes to that reservation set.
 \item {\em H} executes a branch or jump that exits the constrained LR/SC loop.
 \item {\em H} executes an instruction that raises a synchronous exception.
 \item {\em H} takes an interrupt.
@@ -314,15 +318,20 @@ must guarantee that one of the following events eventually occurs:
 As a consequence of this requirement, if some harts in an execution
 environment are executing constrained LR/SC loops, and no other harts or
 devices in the execution environment execute an unconditional store or AMO to
-that granule, then at least one hart will eventually exit its constrained
-LR/SC loop.
-By contrast, if other harts or devices continue to write to that granule,
-it is not guaranteed that any hart will exit its LR/SC loop.
+that reservation set, then at least one hart will eventually exit its
+constrained LR/SC loop.
+By contrast, if other harts or devices continue to write to that reservation
+set, it is not guaranteed that any hart will exit its LR/SC loop.
 
 Loads and load-reserved instructions do not by themselves impede the progress
 of other harts' LR/SC sequences.
-We note this constraint implies that multithreaded cores require a mechanism
-to prevent other threads' cache contention from precluding LR/SC progress.
+We note this constraint implies, among other things, that loads and
+load-reserved instructions executed by other harts (possibly within the same
+core) cannot impede LR/SC progress indefinitely.
+For example, conflict misses caused by another hart sharing the cache cannot
+impede LR/SC progress indefinitely.
+Similarly, cache misses caused by speculative execution within a hart cannot
+impede LR/SC progress indefinitely.
 
 These definitions admit the possibility that SC instructions may spuriously
 fail for for implementation reasons, provided progress is eventually made.

--- a/src/a.tex
+++ b/src/a.tex
@@ -143,54 +143,6 @@ exception can be generated for a memory access that would otherwise be
 able to complete except for the misalignment, if the misaligned access
 should not be emulated.
 
-\label{lrscseq}
-
-In the standard A extension, certain constrained LR/SC sequences are
-guaranteed to succeed eventually.  The static code for the LR/SC
-sequence plus the code to retry the sequence in case of failure must
-comprise at most 16 integer instructions placed sequentially in
-memory.  For the sequence to be guaranteed to eventually succeed, the
-dynamic code executed between the LR and SC instructions can only
-contain other instructions from the base ``I'' instruction set, excluding
-loads, stores, backward jumps or taken backward branches, JALR, FENCE,
-FENCE.I, and SYSTEM instructions.  The code to retry a failing LR/SC
-sequence can contain backward jumps and/or branches to repeat the
-LR/SC sequence, but otherwise has the same constraints.  The SC must
-be to the same address and of the same data size as the latest LR
-executed.  The execution environment can limit the instruction and
-data memory regions within which forward progress is guaranteed.
-LR/SC sequences that do not meet all these constraints might complete on
-some attempts on some implementations, but there is no guarantee of
-eventual success.
-
-\begin{commentary}
-One advantage of CAS is that it guarantees that some hart eventually
-makes progress, whereas an LR/SC atomic sequence could livelock
-indefinitely on some systems.  To avoid this concern, we added an
-architectural guarantee of forward progress to LR/SC atomic sequences.
-The restrictions on LR/SC sequence contents allows an implementation
-to capture a cache line on the LR and complete the LR/SC sequence by
-holding off remote cache interventions for a bounded short
-time. Interrupts and TLB misses might cause the reservation to be
-lost, but eventually the atomic sequence can complete.  We restricted
-the length of LR/SC sequences to fit within 64 contiguous instruction
-bytes in the base ISA to avoid undue restrictions on instruction cache
-and TLB size and associativity.  Similarly, we disallowed other loads
-and stores within the sequences to avoid restrictions on data-cache
-associativity.  The restrictions on branches and jumps limits the time
-that can be spent in the sequence.  Floating-point operations and
-integer multiply/divide were disallowed to simplify the operating
-system's emulation of these instructions on implementations lacking
-appropriate hardware support.
-
-Although software is not forbidden from using LR/SC sequences that do not meet
-the forward-progress constraints, portable software must detect the case that
-the sequence repeatedly fails, then fall back to an alternate code sequence
-that does not run afoul of the forward-progress constraints.
-Implementations are permitted to simply always fail any LR/SC sequence that does
-not meet the forward-progress guarantee.
-\end{commentary}
-
 An implementation can reserve an arbitrarily large subset of the
 address space on each LR, provided the memory range includes all bytes
 of the addressed data word or doubleword.
@@ -199,7 +151,7 @@ may succeed if no store from another hart to the address range
 reserved by the LR can be observed to have occurred between the LR and
 the SC, and if there is no other SC between the LR and itself in
 program order.  Note this LR might have had a different address
-argument, but reserved the SC's address as part of the memory subset.
+argument and data size, but reserved the SC's address as part of the memory subset.
 Following this model, in systems with memory translation, an SC is
 allowed to succeed if the earlier LR reserved the same location using
 an alias with a different virtual address, but is also allowed to fail
@@ -210,6 +162,15 @@ another SC (to any address) between the LR and the SC in program
 order.  The precise statement of the atomicity requirements for
 successful LR/SC sequences is defined by the Atomicity Axiom in
 Section~\ref{sec:rvwmo}.
+
+\begin{commentary}
+The platform should provide a means to determine the size and shape of the
+memory range reserved on an LR.
+
+A platform specification may constrain the size and shape of the memory range
+reserved on an LR.  For example, the Unix platform is expected to require the
+range be contiguous and no greater than the virtual memory page size.
+\end{commentary}
 
 \begin{commentary}
 A store-conditional instruction to a scratch word of memory should be used
@@ -277,6 +238,102 @@ memory buffer along the lines of the original transactional memory
 proposals as an optional standard extension ``T''.
 \end{commentary}
 
+\newpage
+\section{Eventual Success of Store-Conditional Instructions}
+\label{sec:lrscseq}
+
+The standard A extension defines {\em constrained LR/SC sequences}, which have
+the following properties:
+\vspace{-0.2in}
+\begin{itemize}
+\parskip 0pt
+\itemsep 1pt
+\item The static code for the LR/SC sequence, plus the code to retry the
+  sequence in the case of failure, must comprise at most 16 instructions
+  placed sequentially in memory.
+\item The dynamic code executed between the LR and SC instructions can only
+  contain instructions from the base ``I'' instruction set, excluding loads,
+  stores, backward jumps or taken backward branches, JALR, FENCE, and SYSTEM
+  instructions.  If the ``C'' extension is supported, then compressed forms
+  of the aforementioned ``I'' instructions are also permitted.
+\item The code to retry a failing LR/SC sequence can contain backwards jumps
+  and/or branches to repeat the LR/SC sequence, but otherwise has the same
+  constraint as the code between the LR and SC.
+\item The LR address must lie either within a main memory region or within some
+  other memory region specified by the execution environment.
+\item The SC must be to the same address and of the same data size as the
+  latest LR executed.
+\end{itemize}
+
+LR/SC sequences that do not meet these constraints are {\em unconstrained}.
+Unconstrained LR/SC sequences might succeed on some attempts on some
+implementations, but might never succeed on other implementations.
+
+\begin{commentary}
+The restrictions on LR/SC sequence contents allow a simple implementation
+to capture a cache line on the LR and complete the LR/SC sequence by
+holding off remote cache interventions for a bounded short
+time.  Interrupts and TLB misses might cause the reservation to be
+lost, but eventually the atomic sequence can complete.  More scalable
+implementations that do not obtain exclusive access to the cache line
+on the LR are also possible, and also benefit from these restrictions.
+
+We restricted the length of LR/SC sequences to fit within 64 contiguous
+instruction bytes in the base ISA to avoid undue restrictions on instruction
+cache and TLB size and associativity.  Similarly, we disallowed other loads
+and stores within the sequences to avoid restrictions on data-cache
+associativity.  The restrictions on branches and jumps limit the time that
+can be spent in the sequence.  Floating-point operations and integer
+multiply/divide were disallowed to simplify the operating system's emulation
+of these instructions on implementations lacking appropriate hardware support.
+
+Software is not forbidden from using unconstrained LR/SC sequences, but
+portable software must detect the case that the sequence repeatedly fails,
+then fall back to an alternate code sequence that does not rely on an
+unconstrained LR/SC sequence.  Implementations are permitted to
+unconditionally fail any unconstrained LR/SC sequence.
+\end{commentary}
+
+If a hart {\em H} enters a constrained LR/SC sequence, the execution environment
+must guarantee that one of the following events eventually occurs:
+\vspace{-0.2in}
+\begin{itemize}
+\parskip 0pt
+\itemsep 1pt
+\item {\em H} or some other hart executes a successful SC to the subset of
+  memory reserved by the LR instruction in {\em H}'s constrained LR/SC sequence.
+\item Some other hart executes an unconditional store or AMO instruction to
+  the subset of memory reserved by the LR instruction in {\em H}'s constrained
+  LR/SC sequence.
+\item {\em H} executes a branch or jump that exits the constrained LR/SC
+  sequence.
+\item {\em H} executes an instruction that raises a synchronous exception.
+\item {\em H} takes an interrupt.
+\end{itemize}
+
+\begin{commentary}
+As a consequence of this requirement, if some harts in an execution
+environment are executing constrained LR/SC sequences, and no other harts in
+the execution environment execute an unconditional store or AMO, then at least
+one hart will eventually exit its constrained LR/SC sequence.
+
+Loads and load-reserved instructions do not by themselves impede the progress
+of other harts' LR/SC sequences.
+\end{commentary}
+
+\begin{commentary}
+One advantage of CAS is that it guarantees that some hart eventually
+makes progress, whereas an LR/SC atomic sequence could livelock
+indefinitely on some systems.  To avoid this concern, we added an
+architectural guarantee of livelock freedom for LR/SC sequences.
+
+Earlier versions of this specification imposed a stronger starvation-freedom
+guarantee.  However, the weaker livelock-freedom guarantee is sufficient to
+implement the C11 and C++11 languages, and is substantially easier to provide
+in some microarchitectural styles.
+\end{commentary}
+
+\newpage
 \section{Atomic Memory Operations}
 \label{sec:amo}
 

--- a/src/a.tex
+++ b/src/a.tex
@@ -172,12 +172,15 @@ An SC may succeed if no store from another hart, nor a write from some other
 device, to the reservation set can be observed to have occurred between the LR
 and the SC, and if there is no other SC between the LR and itself in program
 order.
-Note this LR might have had a different address argument and data size, but
+Note this LR might have had a different effective address and data size, but
 reserved the SC's address as part of the reservation set.
+\begin{commentary}
 Following this model, in systems with memory translation, an SC is allowed to
 succeed if the earlier LR reserved the same location using an alias with
 a different virtual address, but is also allowed to fail if the virtual
 address is different.
+\end{commentary}
+
 The SC must fail if the address is not within the reservation set of the most
 recent LR in program order.
 The SC must fail if a store from another hart, or a write from some other
@@ -303,7 +306,7 @@ the following properties:
 \item The LR and SC addresses must lie within a memory region with the
   {\em LR/SC eventuality} property.  The execution environment is responsible
   for communicating which regions have this property.
-\item The SC must be to the same virtual address and of the same data size as
+\item The SC must be to the same effective address and of the same data size as
   the latest LR executed by the same hart.
 \end{itemize}
 

--- a/src/a.tex
+++ b/src/a.tex
@@ -238,7 +238,6 @@ memory buffer along the lines of the original transactional memory
 proposals as an optional standard extension ``T''.
 \end{commentary}
 
-\newpage
 \section{Eventual Success of Store-Conditional Instructions}
 \label{sec:lrscseq}
 
@@ -333,7 +332,6 @@ implement the C11 and C++11 languages, and is substantially easier to provide
 in some microarchitectural styles.
 \end{commentary}
 
-\newpage
 \section{Atomic Memory Operations}
 \label{sec:amo}
 

--- a/src/a.tex
+++ b/src/a.tex
@@ -113,7 +113,8 @@ the CAS instruction to obtain a value for speculative computation,
 then a second load as part of the CAS instruction to check if value is
 unchanged before updating).
 
-The main disadvantage of LR/SC over CAS is livelock, which we avoid
+The main disadvantage of LR/SC over CAS is livelock, which we avoid,
+under certain circumstances,
 with an architected guarantee of eventual forward progress as
 described below.  Another concern is whether the influence of the
 current x86 architecture, with its DW-CAS, will complicate porting of
@@ -146,18 +147,23 @@ should not be emulated.
 An implementation can reserve an arbitrarily large subset of the
 address space on each LR, provided the memory range includes all bytes
 of the addressed data word or doubleword.
-An SC can only pair with the most recent LR in program order.  An SC
-may succeed if no store from another hart to the address range
-reserved by the LR can be observed to have occurred between the LR and
-the SC, and if there is no other SC between the LR and itself in
-program order.  Note this LR might have had a different address
+An SC can only pair with the most recent LR in program order.  An SC may
+succeed if no store from another hart, nor a write from some other device, to
+the address range reserved by the LR can be observed to have occurred between
+the LR and the SC, and if there is no other SC between the LR and itself in
+program order.
+Note this LR might have had a different address
 argument and data size, but reserved the SC's address as part of the memory subset.
 Following this model, in systems with memory translation, an SC is
 allowed to succeed if the earlier LR reserved the same location using
 an alias with a different virtual address, but is also allowed to fail
-if the virtual address is different.  The SC must fail if a store from
-another hart to the address range reserved by the LR can be observed
-to occur between the LR and the SC.  An SC must fail if there is
+if the virtual address is different.
+The SC must fail if the address is not within the memory subset reserved
+by the most recent LR in program order.
+The SC must fail if a store from another hart, or a write from some other
+device, to the address range reserved by the LR can be observed to occur
+between the LR and the SC.
+An SC must fail if there is
 another SC (to any address) between the LR and the SC in program
 order.  The precise statement of the atomicity requirements for
 successful LR/SC sequences is defined by the Atomicity Axiom in
@@ -270,19 +276,13 @@ unconstrained}.  Unconstrained LR/SC sequences might succeed on some attempts
 on some implementations, but might never succeed on other implementations.
 
 \begin{commentary}
-The restrictions on LR/SC loop contents allow a simple implementation
-to capture a cache line on the LR and complete the LR/SC sequence by
-holding off remote cache interventions for a bounded short
-time.  Interrupts and TLB misses might cause the reservation to be
-lost, but eventually the atomic sequence can complete.  More scalable
-implementations that do not obtain exclusive access to the cache line
-on the LR are also possible, and also benefit from these restrictions.
-
 We restricted the length of LR/SC loops to fit within 64 contiguous
 instruction bytes in the base ISA to avoid undue restrictions on instruction
-cache and TLB size and associativity.  Similarly, we disallowed other loads
-and stores within the loops to avoid restrictions on data-cache
-associativity.  The restrictions on branches and jumps limit the time that
+cache and TLB size and associativity.
+Similarly, we disallowed other loads and stores within the loops to avoid
+restrictions on data-cache associativity in simple implementations that track
+the reservation within the cache.
+The restrictions on branches and jumps limit the time that
 can be spent in the sequence.  Floating-point operations and integer
 multiply/divide were disallowed to simplify the operating system's emulation
 of these instructions on implementations lacking appropriate hardware support.
@@ -317,9 +317,13 @@ environment are executing constrained LR/SC loops, and no other harts or
 devices in the execution environment execute an unconditional store or AMO to
 that granule, then at least one hart will eventually exit its constrained
 LR/SC loop.
+By contrast, if other harts or devices continue to write to that granule,
+it is not guaranteed that any hart will exit its LR/SC loop.
 
 Loads and load-reserved instructions do not by themselves impede the progress
 of other harts' LR/SC sequences.
+We note this constraint implies that multithreaded cores require a mechanism
+to prevent other threads' cache contention from precluding LR/SC progress.
 
 These definitions admit the possibility that SC instructions may spuriously
 fail for for implementation reasons, provided progress is eventually made.
@@ -435,7 +439,7 @@ compared to AMOs with the corresponding {\em aq} or {\em rl} bit set.
 \end{commentary}
 
 An example code sequence for a critical section guarded by a
-test-and-set spinlock is shown in Figure~\ref{critical}.  Note the
+test-and-test-and-set spinlock is shown in Figure~\ref{critical}.  Note the
 first AMO is marked {\em aq} to order the lock acquisition before the
 critical section, and the second AMO is marked {\em rl} to order
 the critical section before the lock relinquishment.
@@ -445,8 +449,10 @@ the critical section before the lock relinquishment.
 \begin{verbatim}
         li           t0, 1        # Initialize swap value.
     again:
-        amoswap.w.aq t0, t0, (a0) # Attempt to acquire lock.
-        bnez         t0, again    # Retry if held.
+        lw           t1, (a0)     # Check if lock is held.
+        bnez         t1, again    # Retry if held.
+        amoswap.w.aq t1, t0, (a0) # Attempt to acquire lock.
+        bnez         t1, again    # Retry if held.
         # ...
         # Critical section.
         # ...

--- a/src/a.tex
+++ b/src/a.tex
@@ -303,7 +303,8 @@ must guarantee that one of the following events eventually occurs:
   memory reserved by the LR instruction in {\em H}'s constrained LR/SC sequence.
 \item Some other hart executes an unconditional store or AMO instruction to
   the subset of memory reserved by the LR instruction in {\em H}'s constrained
-  LR/SC sequence.
+  LR/SC sequence, or some other device in the system writes to that subset of
+  memory.
 \item {\em H} executes a branch or jump that exits the constrained LR/SC
   sequence.
 \item {\em H} executes an instruction that raises a synchronous exception.
@@ -318,6 +319,9 @@ one hart will eventually exit its constrained LR/SC sequence.
 
 Loads and load-reserved instructions do not by themselves impede the progress
 of other harts' LR/SC sequences.
+
+These definitions admit the possibility that SC instructions may spuriously
+fail for for implementation reasons, provided progress is eventually made.
 \end{commentary}
 
 \begin{commentary}

--- a/src/a.tex
+++ b/src/a.tex
@@ -261,8 +261,8 @@ the following properties:
   constraint as the code between the LR and SC.
 \item The LR address must lie either within a main memory region or within some
   other memory region specified by the execution environment.
-\item The SC must be to the same address and of the same data size as the
-  latest LR executed by the same hart.
+\item The SC must be to the same virtual address and of the same data size as
+  the latest LR executed by the same hart.
 \end{itemize}
 
 LR/SC sequences that do not lie within constrained LR/SC loops are {\em

--- a/src/a.tex
+++ b/src/a.tex
@@ -167,11 +167,23 @@ reservation sets at once, which present definitions do not provide for.
 An implementation can register an arbitrarily large reservation set on each
 LR, provided the reservation set includes all bytes of the addressed data word
 or doubleword.
-The SC must fail if a store from another hart, or a write from some other
-device, to the reservation set can be observed to occur between the LR and the
-SC.
-An SC must fail if there is another SC (to any address) between the LR and the
-SC in program order.
+
+When LR is followed by SC in program order, with no other LR or SC between them:
+\vspace{-0.2in}
+\begin{itemize}
+\parskip 0pt
+\itemsep 1pt
+\item As already defined, SC must fail if the LR's reservation is no longer
+valid or SC accesses bytes outside its reservation set.
+\item The LR's reservation must be invalidated, causing the SC to fail,
+if a write by any hart to any bytes in the reservation set can be observed
+to occur between the LR and SC.
+\item The LR's reservation may be invalidated, possibly consistently,
+causing the SC to fail, if a write by any device or other mechanism to
+any bytes in the reservation set can be observed to occur between the LR and SC.
+\item The LR's reservation is always invalidated upon SC completion,
+regardless of SC success.
+\end{itemize}
 \begin{commentary}
 The LR preceding a successful SC might have had a different effective
 address and data size, but reserved the SC's address as part of the reservation set.
@@ -190,6 +202,11 @@ reservation set.
 A platform specification may constrain the size and shape of the reservation
 set.  For example, the Unix platform is expected to require the set be
 contiguous and no greater than the virtual memory page size.
+
+In the common case where reservation sets are contiguous and NAPOT, a PMA
+is expected to specify the minimum size of the reservation set.
+If this minimum size is at least as large as the largest supported LR/SC,
+reservation sets are uniformly of that size throughout their region.
 \end{commentary}
 
 \begin{commentary}

--- a/src/a.tex
+++ b/src/a.tex
@@ -167,29 +167,21 @@ reservation sets at once, which present definitions do not provide for.
 An implementation can register an arbitrarily large reservation set on each
 LR, provided the reservation set includes all bytes of the addressed data word
 or doubleword.
-An SC can only pair with the most recent LR in program order.
-An SC may succeed if no store from another hart, nor a write from some other
-device, to the reservation set can be observed to have occurred between the LR
-and the SC, and if there is no other SC between the LR and itself in program
-order.
-Note this LR might have had a different effective address and data size, but
-reserved the SC's address as part of the reservation set.
+The SC must fail if a store from another hart, or a write from some other
+device, to the reservation set can be observed to occur between the LR and the
+SC.
+An SC must fail if there is another SC (to any address) between the LR and the
+SC in program order.
+\begin{commentary}
+The LR preceding a successful SC might have had a different effective
+address and data size, but reserved the SC's address as part of the reservation set.
+\end{commentary}
 \begin{commentary}
 Following this model, in systems with memory translation, an SC is allowed to
 succeed if the earlier LR reserved the same location using an alias with
 a different virtual address, but is also allowed to fail if the virtual
 address is different.
 \end{commentary}
-
-The SC must fail if the address is not within the reservation set of the most
-recent LR in program order.
-The SC must fail if a store from another hart, or a write from some other
-device, to the reservation set can be observed to occur between the LR and the
-SC.
-An SC must fail if there is another SC (to any address) between the LR and the
-SC in program order.
-The precise statement of the atomicity requirements for successful LR/SC
-sequences is defined by the Atomicity Axiom in Section~\ref{sec:rvwmo}.
 
 \begin{commentary}
 The platform should provide a means to determine the size and shape of the

--- a/src/c.tex
+++ b/src/c.tex
@@ -1173,10 +1173,10 @@ C.EBREAK shares the opcode with the C.ADD instruction, but with {\em
 
 \section{Usage of C Instructions in LR/SC Sequences}
 
-On implementations that support the C extension, compressed forms of
-the I instructions permitted inside LR/SC sequences can be used while
-retaining the guarantee of eventual success, as described in
-Section~\ref{lrscseq}.
+On implementations that support the C extension, compressed forms of the
+I instructions permitted inside constrained LR/SC sequences, as described in
+Section~\ref{sec:lrscseq}, are also permitted inside constrained LR/SC
+sequences.
 
 \begin{commentary}
 The implication is that any implementation that claims to support both

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2637,12 +2637,12 @@ accesses to which data widths are supported.
 \subsection{Atomicity PMAs}
 
 Atomicity PMAs describes which atomic instructions are supported in
-this address region.  Main memory regions must support the atomic
-operations required by the processors attached.  I/O regions may only
-support a subset or none of the processor-supported atomic operations.
+this address region.  Support for atomic instructions is divided into two
+categories: {\em LR/SC} and {\em AMOs}.
 
-Support for atomic instructions is divided into two categories: {\em
-  LR/SC} and {\em AMOs}. Within AMOs, there are four levels of
+\subsubsection{AMO PMA}
+
+  Within AMOs, there are four levels of
 support: {\em AMONone}, {\em AMOSwap}, {\em AMOLogical}, and {\em
   AMOArithmetic}.  AMONone indicates that no AMO operations are
 supported.  AMOSwap indicates that only {\tt amoswap} instructions are
@@ -2651,7 +2651,9 @@ instructions plus all the logical AMOs ({\tt amoand}, {\tt amoor},
 {\tt amoxor}) are supported.  AMOArithmetic indicates that all RISC-V
 AMOs are supported.  For each level of support, naturally aligned AMOs
 of a given width are supported if the underlying memory region
-supports reads and writes of that width.
+supports reads and writes of that width.  Main memory regions must support the
+atomic operations required by the processors attached.  I/O regions may only
+support a subset or none of the processor-supported atomic operations.
 
 \begin{table*}[h!]
 \begin{center}
@@ -2673,14 +2675,34 @@ supports reads and writes of that width.
 
 \begin{commentary}
 We recommend providing at least AMOLogical support for I/O regions
-where possible.  Most I/O regions will not support LR/SC accesses, as
-these are most conveniently built on top of a cache-coherence scheme.
+where possible.
 \end{commentary}
 
-Memory regions that support LR/SC will define the conditions under which LR/SC
-sequences must succeed or must fail.  Main memory must guarantee the eventual
-success of any LR/SC sequence that meets the requirements described in the
-user ISA specification.
+\subsubsection{Reservability PMA}
+
+For {\em LR/SC}, there are three levels of support indicating combinations of
+the reservability and eventuality properties:  {\em RsrvNone},
+{\em RsrvNonEventual}, and {\em RsrvEventual}.
+RsrvNone indicates that no LR/SC operations are supported (the location is
+non-reservable).  RsrvNonEventual indicates that the operations are supported
+(the location is reservable), but without the eventual success guarantee
+described in the unprivileged ISA specification.  RsrvEventual indicates that
+the operations are supported and provide the eventual success guarantee.
+
+\begin{commentary}
+We recommend providing RsrvEventual support for main memory regions
+where possible.  Most I/O regions will not support LR/SC accesses, as
+these are most conveniently built on top of a cache-coherence scheme, but some
+may support RsrvNonEventual or RsrvEventual.
+\end{commentary}
+
+\begin{commentary}
+When LR/SC is used for memory locations marked RsrvNonEventual, software should
+provide alternative fall-back mechanisms used when lack of progress is
+detected.
+\end{commentary}
+
+\subsubsection{Alignment}
 
 Memory regions that support aligned LR/SC or aligned AMOs might also support
 misaligned LR/SC or misaligned AMOs for some addresses and access widths.  If,

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -34,8 +34,8 @@ Changes from version 1.11 include:
 \item Revised the hypervisor architecture proposal to represent VS-mode CSR
   state more simply.
 \item Added optional big-endian and bi-endian support.
-\item Constrained the LR/SC reservation granule size when using page-based
-  virtual memory.
+\item Constrained the LR/SC reservation set size and shape when using
+  page-based virtual memory.
 \end{itemize}
 
 \newpage

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -34,8 +34,8 @@ Changes from version 1.11 include:
 \item Revised the hypervisor architecture proposal to represent VS-mode CSR
   state more simply.
 \item Added optional big-endian and bi-endian support.
-\item A constraint on the LR/SC reservation granule size when using
-  page-based virtual memory.
+\item Constrained the LR/SC reservation granule size when using page-based
+  virtual memory.
 \end{itemize}
 
 \newpage

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -34,6 +34,8 @@ Changes from version 1.11 include:
 \item Revised the hypervisor architecture proposal to represent VS-mode CSR
   state more simply.
 \item Added optional big-endian and bi-endian support.
+\item A constraint on the LR/SC reservation granule size when using
+  page-based virtual memory.
 \end{itemize}
 
 \newpage

--- a/src/riscv-spec.tex
+++ b/src/riscv-spec.tex
@@ -41,7 +41,7 @@ Olof Johansson, Ben Keller, David Kruckemyer, Yunsup Lee,
 Paul Loewenstein, Daniel Lustig, Yatin Manerkar, Luc Maranget, Margaret
 Martonosi, Joseph Myers, Vijayanand Nagarajan, Rishiyur Nikhil, Jonas
 Oberhauser, Stefan O'Rear, Albert Ou, John Ousterhout, David Patterson,
-Christopher Pulte, Jose Renau, Colin Schmidt, Peter Sewell, Susmit Sarkar,
+Christopher Pulte, Jose Renau, Colin Schmidt, Peter Sewell, Susmit Sarkar, Josh Scheid,
 Michael Taylor, Wesley Terpstra, Matt Thomas, Tommy Thorn, Caroline Trippel,
 Ray VanDeWalker, Muralidaran Vijayaraghavan, Megan Wachs, Andrew Waterman,
 Robert Watson, Derek Williams, Andrew Wright, Reinoud Zandijk, and Sizhuo

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1038,7 +1038,7 @@ offset[11:5] & src & base & width & offset[4:0] & STORE \\
 
 Load and store instructions transfer a value between the registers and
 memory.  Loads are encoded in the I-type format and stores are
-S-type.  The effective byte address is obtained by adding register
+S-type.  The effective address is obtained by adding register
 {\em rs1} to the sign-extended 12-bit offset.  Loads copy a value
 from memory to register {\em rd}.  Stores copy the value in register
 {\em rs2} to memory.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1352,7 +1352,7 @@ For non-leaf PTEs, the D, A, and U bits are reserved for future use and
 must be cleared by software for forward compatibility.
 
 For implementations with both page-based virtual memory and the ``A'' standard
-extension, the LR/SC reservation granule must lie completely within a single
+extension, the LR/SC reservation set must lie completely within a single
 base page (i.e., a naturally aligned \wunits{4}{KiB} region).
 
 \subsection{Virtual Address Translation Process}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1351,6 +1351,10 @@ if the physical address is insufficiently aligned.
 For non-leaf PTEs, the D, A, and U bits are reserved for future use and
 must be cleared by software for forward compatibility.
 
+For implementations with both page-based virtual memory and the ``A''
+standard extension, the LR/SC reservation granule must not exceed the
+base page size (\wunits{4}{KiB}).
+
 \subsection{Virtual Address Translation Process}
 \label{sv32algorithm}
 

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1351,9 +1351,9 @@ if the physical address is insufficiently aligned.
 For non-leaf PTEs, the D, A, and U bits are reserved for future use and
 must be cleared by software for forward compatibility.
 
-For implementations with both page-based virtual memory and the ``A''
-standard extension, the LR/SC reservation granule must not exceed the
-base page size (\wunits{4}{KiB}).
+For implementations with both page-based virtual memory and the ``A'' standard
+extension, the LR/SC reservation granule must lie completely within a single
+base page (i.e., a naturally aligned \wunits{4}{KiB} region).
 
 \subsection{Virtual Address Translation Process}
 \label{sv32algorithm}


### PR DESCRIPTION
There are two commits.  The first removes a fair bit of redundancy between the two paragraphs at lines 167 through 192 of a.tex.  The second adds a simplified version of wording suggested earlier.
