### PR TITLE
Consistently claim that U-immediate is 32 bits, not 20 bits

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -562,16 +562,19 @@ U-immediate[31:12] & dest & AUIPC
 \end{center}
 
 LUI (load upper immediate) is used to build 32-bit constants and uses
-the U-type format.  LUI places the U-immediate value in the top 20
-bits of the destination register {\em rd}, filling in the lowest 12
+the U-type format.  LUI places the 32-bit U-immediate value into
+the destination register {\em rd}, filling in the lowest 12
 bits with zeros.
 
 AUIPC (add upper immediate to {\tt pc}) is used to build {\tt pc}-relative
 addresses and uses the U-type format.  AUIPC forms a 32-bit offset from the
-20-bit U-immediate, filling in the lowest 12 bits with zeros, adds this offset
+U-immediate, filling in the lowest 12 bits with zeros, adds this offset
 to the address of the AUIPC instruction, then places the result in register {\em rd}.
 
 \begin{commentary}
+The assembly syntax for {\tt lui} and {\tt auipc} does not represent the lower
+12 bits of the U-immediate, which are always zero.
+
 The AUIPC instruction supports two-instruction sequences to access
 arbitrary offsets from the PC for both control-flow transfers and data
 accesses.  The combination of an AUIPC and the 12-bit immediate in a

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -134,15 +134,16 @@ U-immediate[31:12] & dest & AUIPC
 \end{center}
 
 LUI (load upper immediate) uses the same opcode as RV32I.  LUI places
-the 20-bit U-immediate into bits 31--12 of register {\em rd} and
-places zero in the lowest 12 bits.  The 32-bit result is
-sign-extended to 64 bits.
+the 32-bit U-immediate into register {\em rd}, filling in the lowest 12
+bits with zeros.
+The 32-bit result is sign-extended to 64 bits.
 
 AUIPC (add upper immediate to {\tt pc}) uses the same opcode as RV32I.
 AUIPC is used to build {\tt
-  pc}-relative addresses and uses the U-type format.  AUIPC appends 12
-low-order zero bits to the 20-bit U-immediate, sign-extends the result
-to 64 bits, adds it to the address of the AUIPC instruction,
+  pc}-relative addresses and uses the U-type format.  AUIPC forms a 32-bit
+offset from the U-immediate, filling in the lowest 12 bits with zeros,
+sign-extends the result to 64 bits,
+adds it to the address of the AUIPC instruction,
 then places the result in register {\em rd}.
 
 \subsubsection*{Integer Register-Register Operations}


### PR DESCRIPTION
The text vacillates between describing the U-immediate as a 20-bit
quantity, and as a 32-bit quantity whose lower 12 bits are zero.
Standardize on the latter.  Note the discrepancy in the ASM syntax.

Resolves #452