### PR TITLE
ignore write to "controlled" SBE and UBE.

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -746,9 +746,9 @@ ordinarily be required for a world switch.
 \end{commentary}
 
 If S-mode is supported, an implementation may hardwire SBE so that
-SBE=MBE.
+SBE=MBE and writes to SBE are ignored.
 If U-mode is supported, an implementation may hardwire UBE so that
-UBE=MBE or UBE=SBE.
+UBE=MBE or UBE=SBE and writes to SBE are ignored.
 
 \begin{commentary}
 An implementation supports only little-endian memory accesses if fields

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -748,7 +748,7 @@ ordinarily be required for a world switch.
 If S-mode is supported, an implementation may hardwire SBE so that
 SBE=MBE and writes to SBE are ignored.
 If U-mode is supported, an implementation may hardwire UBE so that
-UBE=MBE or UBE=SBE and writes to SBE are ignored.
+UBE=MBE or UBE=SBE and writes to UBE are ignored.
 
 \begin{commentary}
 An implementation supports only little-endian memory accesses if fields


### PR DESCRIPTION
Behaviour when endian fields are hard-coupled is not well defined.
If both fields are written with opposite endianness which takes precedence,
 or are the fields left unchanged?
Both approaches are currently used in CSRs.
Further complicating the situation on RV32 systems is the separation
of UBE from MBE/SBE into two CSRs.
Whereas precedence and conflict cannot be determined for two discrete CSR
 updates I propose instead that controlled fields not be directly writable.

Signed-off-by: David Horner <ds2horner@gmail.com>

[ I would have preferred to introduce the concept of "controlling fields" which would be generally applicable to the other situations where this coupling occurs and allows for soft coupling in addition to  "hard-wiring". More possibilities, including transition setting by multiple controlling fields is possible. Future evolution of the standard may benefit from the concept but I expect there is currently little desire for greater flexibility in setting endian fields. ]