### PR TITLE
The RVWMO is version 2.0

### DIFF
--- a/src/rvwmo.tex
+++ b/src/rvwmo.tex
@@ -1,4 +1,4 @@
-\chapter{RVWMO Memory Consistency Model, Version 0.1}
+\chapter{RVWMO Memory Consistency Model, Version 2.0}
 \label{ch:memorymodel}
 
 This chapter defines the RISC-V memory consistency model.


### PR DESCRIPTION
The preface says the RVWMO is version 2.0 and has been ratified, but the text
of the standard still says it's version 0.1.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>