### PR TITLE
Extensions: List all integer base ISAs

### DIFF
--- a/src/extensions.tex
+++ b/src/extensions.tex
@@ -26,9 +26,9 @@ extensions.
 \subsection*{Standard versus Non-Standard Extension}
 
 Any RISC-V processor implementation must support a base integer ISA
-(RV32I or RV64I).  In addition, an implementation may support one or
-more extensions.  We divide extensions into two broad categories: {\em
-  standard} versus {\em non-standard}.
+(RV32I, RV32E, RV64I, or RV128I).  In addition, an implementation may
+support one or more extensions.  We divide extensions into two broad
+categories: {\em standard} versus {\em non-standard}.
 \begin{itemize}
 \item A standard extension is one that is generally useful and that is
   designed to not conflict with any other standard extension.


### PR DESCRIPTION
The text currently mandates extensions to build on top of any base
integer ISA, but only lists two of them (RV32I and RV64I). Add the two
remaining ones (RV32E and RV128I) as well.