### PR TITLE
Clarify offset range in RV64I

### DIFF
--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -147,9 +147,9 @@ adds it to the address of the AUIPC instruction,
 then places the result in register {\em rd}.
 
 \begin{commentary}
-Note that the set of addresses or offsets that can be formed by pairing LUI
-with LD, AUIPC with JALR, etc.\@ in RV64I includes all signed 32-bit offsets
-except for the range [$2^{31}{-}2^{11}$, $2^{31}{-}1$].
+Note that the set of address offsets that can be formed by pairing LUI
+with LD, AUIPC with JALR, etc.\@ in RV64I is
+[${-}2^{31}{-}2^{11}$, $2^{31}{-}2^{11}{-}1$].
 \end{commentary}
 
 \subsubsection*{Integer Register-Register Operations}


### PR DESCRIPTION
Claire Wolf pointed out in email to [isa-dev] that "The 2048 points missing on the higher [end] are "tacked on" on the lower end". This PR adds this detail to the previous commentary.