### PR TITLE
Clarify that FENCE + remote FENCE.I is insufficient for local hart

### DIFF
--- a/src/zifencei.tex
+++ b/src/zifencei.tex
@@ -92,7 +92,7 @@ will see any previous data stores already visible to the same RISC-V
 hart.  FENCE.I does {\em not} ensure that other RISC-V harts'
 instruction fetches will observe the local hart's stores in a
 multiprocessor system. To make a store to instruction memory visible
-to all RISC-V harts, the writing hart has to execute a data FENCE
+to all RISC-V harts, the writing hart also has to execute a data FENCE
 before requesting that all remote RISC-V harts execute a FENCE.I.
 
 The unused fields in the FENCE.I instruction, {\em imm[11:0]}, {\em rs1}, and


### PR DESCRIPTION
This sequence only synchronises the remote harts; the local hart still needs to perform a normal FENCE.I.