### PR TITLE
Clarify semantics of sfence.vma with rs1 != x0

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1041,10 +1041,10 @@ SFENCE.VMA depends on {\em rs1} and {\em rs2} as follows:
       Accesses to {\em global} mappings (see Section~\ref{sec:translation})
       are not ordered.
 \item If {\em rs1}$\neq${\tt x0} and {\em rs2}={\tt x0}, the fence orders
-      only reads and writes made to the leaf page table entry corresponding
+      only reads and writes made to leaf page table entries corresponding
       to the virtual address in {\em rs1}, for all address spaces.
 \item If {\em rs1}$\neq${\tt x0} and {\em rs2}$\neq${\tt x0}, the fence
-      orders only reads and writes made to the leaf page table entry
+      orders only reads and writes made to leaf page table entries
       corresponding to the virtual address in {\em rs1}, for the address
       space identified by integer register {\em rs2}.
       Accesses to global mappings are not ordered.


### PR DESCRIPTION
Based on discussion on the mailing list, the instruction fences accesses not just to one leaf PTE but to any leaf PTE that includes the address (subject to address space constraints specified via rs2).