### PR TITLE
Add VTW field to hstatus; improve rules for WFI in virtual modes

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -164,7 +164,7 @@ for tracking and controlling the exception behavior of a VS-mode guest.
 \hline
 \multicolumn{1}{|c|}{\wpri} &
 \multicolumn{1}{c|}{VTSR} &
-\multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{VTW} &
 \multicolumn{1}{c|}{VTVM} &
 \multicolumn{1}{c|}{\wpri} &
 \multicolumn{1}{c|}{VGEIN[5:0]} &
@@ -203,7 +203,7 @@ for tracking and controlling the exception behavior of a VS-mode guest.
 \multicolumn{1}{c|}{VSXL[1:0]} &
 \multicolumn{1}{c|}{\wpri} &
 \multicolumn{1}{c|}{VTSR} &
-\multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{VTW} &
 \multicolumn{1}{c|}{VTVM} &
  \\
 \hline
@@ -255,12 +255,15 @@ If HSXLEN is changed from 32 to a wider width, and if field VSXL is not
 hardwired to a forced value, it gets the value corresponding to the
 widest supported width not wider than the new HSXLEN.
 
-The {\tt hstatus} fields VTSR and VTVM are defined analogously to the
-{\tt mstatus} fields TSR and TVM, but affect execution only in VS-mode,
+The {\tt hstatus} fields VTSR, VTW, and VTVM are defined analogously to the
+{\tt mstatus} fields TSR, TW, and TVM, but affect execution only in VS-mode,
 and cause virtual instruction exceptions instead of illegal instruction
 exceptions.
 When VTSR=1, an attempt in VS-mode to execute SRET raises a virtual
 instruction exception.
+When VTW=1 (and assuming {\tt mstatus}.TW=0), an attempt in VS-mode to
+execute WFI raises a virtual instruction exception if the WFI does not
+complete within an implementation-specific, bounded time limit.
 When VTVM=1, an attempt in VS-mode to execute SFENCE.VMA or to access CSR
 {\tt satp} raises a virtual instruction exception.
 
@@ -2511,18 +2514,6 @@ guest-physical page tables point, an HFENCE.GVMA instruction with
 PMP CSRs are written.
 An HFENCE.VVMA instruction is not required.
 
-\section{WFI in Virtual Operating Modes}
-
-Executing instruction WFI when V=1 causes a virtual instruction
-exception, unless it completes within an implementation-specific, bounded time
-limit.
-
-\begin{commentary}
-The behavior required of WFI in VS-mode and VU-mode is the same as required of
-it in U-mode when S-mode exists, except with a virtual instruction
-exception substituting for an illegal instruction exception.
-\end{commentary}
-
 \section{Traps}
 
 \subsection{Trap Cause Codes}
@@ -2605,16 +2596,18 @@ attempts to access a counter CSR when the corresponding bit in
 {\tt hcounteren} is~0 and the same bit in {\tt mcounteren} is~1;
 
 \item
-attempts to execute WFI, unless the instruction completes within an
-implementation-specific, bounded time;
-
-\item
 attempts to execute a hypervisor instruction (HLV, HLVX, HSV, or HFENCE)
 or to access an implemented hypervisor CSR or VS CSR;
 
 \item
-in VU-mode, attempts to execute a supervisor instruction (SRET or SFENCE)
+in VU-mode, attempts to execute WFI or a
+supervisor instruction (SRET or SFENCE),
 or to access an implemented supervisor CSR;
+
+\item
+in VS-mode, attempts to execute WFI when {\tt hstatus}.VTW=1 and
+{\tt mstatus}.TW=0, unless the instruction completes within an
+implementation-specific, bounded time;
 
 \item
 in VS-mode, attempts to execute SRET when {\tt hstatus}.VTSR=1; or


### PR DESCRIPTION
Add (restore) field VTW to CSR hstatus, analogous to mstatus.TW.  Also, better clarify the rules for the exceptions raised by instruction WFI when in virtual operating modes (VS mode and VU mode).