### PR TITLE
Clarifications to the perceived ordering of CSR accesses and their effects

### DIFF
--- a/src/csr.tex
+++ b/src/csr.tex
@@ -157,19 +157,23 @@ bits in the CSR when the old value is not required: CSRS/CSRC {\em
 
 \subsection*{CSR Access Ordering}
 
-On a given hart, explicit and implicit CSR access are performed in program
-order with respect to those instructions whose execution behavior is affected
-by the state of the accessed CSR. In particular, a CSR access is performed
+Each RISC-V hart normally observes its own CSR accesses, including its
+implicit CSR accesses, as performed in program order.
+In particular, unless specified otherwise, a CSR access is performed
 after the execution of any prior instructions in program order whose behavior
 modifies or is modified by the CSR state and before the execution of any
 subsequent instructions in program order whose behavior modifies or is modified
-by the CSR state. Furthermore, a CSR read access instruction returns the
-accessed CSR state before the execution of the instruction, while a CSR write
-access instruction updates the accessed CSR state after the execution of the
+by the CSR state.
+Any side effects from a CSR access are likewise observed to occur
+synchronously in program order, unless documented otherwise.
+Furthermore, an explicit CSR read returns the
+CSR state before the execution of the instruction, while an
+explict CSR write updates the CSR state after the execution of the
 instruction.
 
-Where the above program order does not hold, CSR accesses are weakly ordered,
-and the local hart or other harts may observe the CSR accesses in an order
+For the RVWMO memory consistency model (Chapter~\ref{ch:memorymodel}),
+CSR accesses are weakly ordered by default,
+so other harts or devices may observe CSR accesses in an order
 different from program order. In addition, CSR accesses are not ordered with
 respect to explicit memory accesses, unless a CSR access modifies the execution
 behavior of the instruction that performs the explicit memory access or unless
@@ -194,16 +198,19 @@ CSR.  With the exception of the {\tt time}, {\tt cycle}, and {\tt mcycle} CSRs,
 the CSRs defined thus far in Volumes I and II of this specification are not
 directly accessible to other harts or devices and cause no side effects visible
 to other harts or devices.  Thus, accesses to CSRs other than the
-aforementioned three can be freely reordered with respect to FENCE instructions
+aforementioned three can be freely reordered in the global memory order
+with respect to FENCE instructions
 without violating this specification.
 \end{commentary}
-
-For CSR accesses that cause side effects, the above ordering constraints apply
-to the order of the initiation of those side effects but does not necessarily
-apply to the order of the completion of those side effects.
 
 The hardware platform may define that accesses to certain CSRs are
 strongly ordered, as defined by the Memory-Ordering PMAs section in Volume II
 of this manual. Accesses to strongly ordered CSRs have stronger ordering
 constraints with respect to accesses to both weakly ordered CSRs and accesses
 to memory-mapped I/O regions.
+
+\begin{commentary}
+The rules for the reordering of CSR accesses in the global memory order
+should probably be moved to Chapter~\ref{ch:memorymodel} concerning the
+RVWMO memory consistency model.
+\end{commentary}

--- a/src/csr.tex
+++ b/src/csr.tex
@@ -164,12 +164,18 @@ after the execution of any prior instructions in program order whose behavior
 modifies or is modified by the CSR state and before the execution of any
 subsequent instructions in program order whose behavior modifies or is modified
 by the CSR state.
-Any side effects from a CSR access are likewise observed to occur
-synchronously in program order, unless documented otherwise.
 Furthermore, an explicit CSR read returns the
 CSR state before the execution of the instruction, while an
-explict CSR write updates the CSR state after the execution of the
-instruction.
+explict CSR write suppresses and overrides any implicit writes or
+modifications to the same CSR by the same instruction.
+
+Likewise, any side effects from an explicit CSR access are normally
+observed to occur synchronously in program order.
+Unless specified otherwise, the full consequences of any such side
+effects are observable by the very next instruction, and no consequences
+may be observed out-of-order by preceding instructions.
+(Note the distinction made earlier between side effects and indirect
+effects of CSR writes.)
 
 For the RVWMO memory consistency model (Chapter~\ref{ch:memorymodel}),
 CSR accesses are weakly ordered by default,


### PR DESCRIPTION
More clearly distinguished the ordering rules that apply to the same hart from those that involve other agents (harts and devices).  Made CSR side effects completely synchronous to the same hart by default.  (Deviances are still allowed, when documented.)  Added a comment that rules about the reordering of CSR accesses in the global memory order should probably be moved to the RVWMO chapter.