### PR TITLE
Add an "lga" pseudoinstruction for GOT loads even in non-PIC

### DIFF
--- a/src/assembly.tex
+++ b/src/assembly.tex
@@ -59,12 +59,14 @@ RISC-V pseudoinstructions.
 \begin{tabular}{l l l}
 pseudoinstruction & Base Instruction(s) & Meaning \\ \hline
 
-\tt la rd, symbol (\emph{non-PIC}) & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load absolute address, \\
+\tt la rd, symbol (\emph{non-PIC}) & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load address, \\
                   & {\tt addi rd, rd, delta[11:0]}                         & where ${\tt delta} = {\tt symbol} - {\tt pc}$ \\[1ex]
-\tt la rd, symbol (\emph{PIC})& {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load absolute address, \\
+\tt la rd, symbol (\emph{PIC})& {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load address, \\
                   & {\tt l\{w|d\} rd, rd, delta[11:0]}                         & where ${\tt delta} = {\tt GOT[symbol]} - {\tt pc}$ \\[1ex]
 \tt lla rd, symbol& {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load local address, \\
                   & {\tt addi rd, rd, delta[11:0]}                         & where ${\tt delta} = {\tt symbol} - {\tt pc}$ \\[1ex]
+\tt lga rd, symbol& {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load global address, \\
+                  & {\tt l\{w|d\} rd, rd, delta[11:0]}                     & where ${\tt delta} = {\tt GOT[symbol]} - {\tt pc}$ \\[1ex]
 \tt l\{b|h|w|d\} rd, symbol & {\tt auipc rd, ${\tt delta[31:12]} + {\tt delta[11]}$} & Load global \\
                             & {\tt l\{b|h|w|d\} rd, delta[11:0](rd)}                 & \\[1ex]
 \tt s\{b|h|w|d\} rd, symbol, rt & {\tt auipc rt, ${\tt delta[31:12]} + {\tt delta[11]}$} & Store global \\


### PR DESCRIPTION
This is useful for cases where compilers and/or assembly writers want to force the use of a GOT. For example, this could be used to address [1], but more generally it's a useful thing to have, and is a strange hole in the set of pseudoinstructions provided.

Whilst here, alter the description of "la" to not mention absolute. All addresses are absolute, but highlighting it for "la" specifically is confusing as it potentially implies that it's using an absolute lui/addi sequence rather than a PC-relative sequence.

[1] https://github.com/riscv/riscv-elf-psabi-doc/issues/126

I have not yet created patches against riscv-asm-manual and riscv-elf-psabi-doc. However, those are already outdated and only mention `la` without `lla`. Defining `lga` will also make it far less confusing to fix that; then, `lla` and `lga` can be documented individually, with `la` simply saying it's equivalent to the relevant one depending on -fPIC.