### PR TITLE
Fix Sv48 VALEN typo

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1772,5 +1772,5 @@ A page-fault exception is raised if the physical address is insufficiently
 aligned.
 
 The algorithm for virtual-to-physical address translation is the same as in
-Section~\ref{sv32algorithm}, except VALEN equals 39, LEVELS equals 4, and
+Section~\ref{sv32algorithm}, except VALEN equals 48, LEVELS equals 4, and
 PTESIZE equals 8.


### PR DESCRIPTION
Seems like a simple copy-paste error introduced in f251913