### PR TITLE
Add scontext, hcontext, and mcontext CSRs for Debug

### DIFF
--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -225,6 +225,10 @@ Number    & Privilege & Name & Description \\
 \hline
 \tt 0x180 & SRW  &\tt satp       & Supervisor address translation and protection. \\
 \hline
+\multicolumn{4}{|c|}{Debug/Trace Registers} \\
+\hline
+\tt 0x5A8 & SRW &\tt scontext & Supervisor-mode context register. \\
+\hline
 \end{tabular}
 \end{center}
 \caption{Currently allocated RISC-V supervisor-level CSR addresses.}
@@ -258,6 +262,10 @@ Number    & Privilege & Name & Description \\
 \multicolumn{4}{|c|}{Hypervisor Protection and Translation} \\
 \hline
 \tt 0x680 & HRW  &\tt hgatp      & Hypervisor guest address translation and protection. \\
+\hline
+\multicolumn{4}{|c|}{Debug/Trace Registers} \\
+\hline
+\tt 0x6A8 & HRW &\tt hcontext & Hypervisor-mode context register. \\
 \hline
 \multicolumn{4}{|c|}{Hypervisor Counter/Timer Virtualization Registers} \\
 \hline
@@ -378,8 +386,6 @@ Number    & Privilege & Name & Description \\
 \tt 0x7A1 & MRW &\tt tdata1 & First Debug/Trace trigger data register. \\
 \tt 0x7A2 & MRW &\tt tdata2 & Second Debug/Trace trigger data register. \\
 \tt 0x7A3 & MRW &\tt tdata3 & Third Debug/Trace trigger data register. \\
-\tt 0x5A8 & SRW &\tt scontext & Supervisor-mode context register. \\
-\tt 0x6A8 & HRW &\tt hcontext & Hypervisor-mode context register. \\
 \tt 0x7A8 & MRW &\tt mcontext & Machine-mode context register. \\
 \hline
 \multicolumn{4}{|c|}{Debug Mode Registers } \\

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -124,9 +124,6 @@ for use by the debug system.  Of these CSRs, {\tt 0x7A0}--{\tt 0x7AF} are
 accessible to machine mode, whereas {\tt 0x7B0}--{\tt 0x7BF} are only visible
 to debug mode.  Implementations should raise illegal instruction exceptions on
 machine-mode access to the latter set of registers.
-In addition, supervisor-mode standard read-write CSRs {\tt 0x5A0}--{\tt 0x5AF}
-and hypervisor-mode standard read-write CSRs {\tt 0x6A0}--{\tt 0x6AF} are
-reserved for use by the debug system.
 
 \begin{commentary}
 Effective virtualization requires that as many instructions run natively as

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -124,6 +124,9 @@ for use by the debug system.  Of these CSRs, {\tt 0x7A0}--{\tt 0x7AF} are
 accessible to machine mode, whereas {\tt 0x7B0}--{\tt 0x7BF} are only visible
 to debug mode.  Implementations should raise illegal instruction exceptions on
 machine-mode access to the latter set of registers.
+In addition, supervisor-mode standard read-write CSRs {\tt 0x5A0}--{\tt 0x5AF}
+and hypervisor-mode standard read-write CSRs {\tt 0x6A0}--{\tt 0x6AF} are
+reserved for use by the debug system.
 
 \begin{commentary}
 Effective virtualization requires that as many instructions run natively as
@@ -375,6 +378,9 @@ Number    & Privilege & Name & Description \\
 \tt 0x7A1 & MRW &\tt tdata1 & First Debug/Trace trigger data register. \\
 \tt 0x7A2 & MRW &\tt tdata2 & Second Debug/Trace trigger data register. \\
 \tt 0x7A3 & MRW &\tt tdata3 & Third Debug/Trace trigger data register. \\
+\tt 0x5A8 & SRW &\tt scontext & Supervisor-mode context register. \\
+\tt 0x6A8 & HRW &\tt hcontext & Hypervisor-mode context register. \\
+\tt 0x7A8 & MRW &\tt mcontext & Machine-mode context register. \\
 \hline
 \multicolumn{4}{|c|}{Debug Mode Registers } \\
 \hline


### PR DESCRIPTION
These registers may be written with process ID information by operating systems running in their respective privilege levels.  A debugger may use tdata3 (aka textra) to  qualify breakpoints based on a comparison of context register(s) with corresponding trigger field(s).  These registers and comparison fields are described in the RISC-V Debug Specification.