### PR TITLE
Change "reserved for custom" to "designated for custom"

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -895,7 +895,7 @@ C.SLLI expands into {\tt slli rd, rd, shamt}, except for
 RV128C with {\tt shamt=0}, which expands to {\tt slli rd, rd, 64}.
 
 For RV32C, {\em shamt[5]} must be zero; the code points with {\em shamt[5]}=1
-are reserved for custom extensions.  For RV32C and RV64C, the shift
+are designated for custom extensions.  For RV32C and RV64C, the shift
 amount must be non-zero; the code points with {\em shamt}=0 are HINTs.  For
 all base ISAs, the code points with {\em rd}={\tt x0} are HINTs, except those
 with {\em shamt[5]}=1 in RV32C.
@@ -935,7 +935,7 @@ except for RV128C with {\tt shamt=0}, which expands to
 {\tt srli \rdprime, \rdprime, 64}.
 
 For RV32C, {\em shamt[5]} must be zero; the code points with {\em shamt[5]}=1
-are reserved for custom extensions.  For RV32C and RV64C, the shift
+are designated for custom extensions.  For RV32C and RV64C, the shift
 amount must be non-zero; the code points with {\em shamt}=0 are HINTs.
 
 C.SRAI is defined analogously to C.SRLI, but instead performs an arithmetic
@@ -1219,7 +1219,7 @@ amenable to macro-op fusion.
 
 Table~\ref{tab:rvc-hints} lists all RVC HINT code points.  For RV32C, 78\% of
 the HINT space is reserved for standard HINTs, but none are presently defined.
-The remainder of the HINT space is reserved for custom HINTs: no standard
+The remainder of the HINT space is designated for custom HINTs; no standard
 HINTs will ever be defined in this subspace.
 
 \begin{table}[hbt]
@@ -1233,7 +1233,7 @@ HINTs will ever be defined in this subspace.
   C.LUI                   & {\em rd}={\tt x0}, {\em nzimm}$\neq$0       & 63          & \\ \cline{1-3}
   C.MV                    & {\em rd}={\tt x0}, {\em rs2}$\neq${\tt x0}  & 31          & \\ \cline{1-3}
   C.ADD                   & {\em rd}={\tt x0}, {\em rs2}$\neq${\tt x0}  & 31          & \\ \hline \hline
-  \multirow{2}{*}{C.SLLI} & \multirow{2}{*}{{\em rd}={\tt x0}, {\em nzimm}$\neq$0} & 31 (RV32)   & \multirow{6}{*}{\em Reserved for custom use} \\
+  \multirow{2}{*}{C.SLLI} & \multirow{2}{*}{{\em rd}={\tt x0}, {\em nzimm}$\neq$0} & 31 (RV32)   & \multirow{6}{*}{\em Designated for custom use} \\
                           &                                             & 63 (RV64/128) & \\ \cline{1-3}
   C.SLLI64                & {\em rd}={\tt x0}                           & 1           & \\ \cline{1-3}
   C.SLLI64                & {\em rd}$\neq${\tt x0}, RV32 and RV64 only  & 31          & \\ \cline{1-3}
@@ -1255,7 +1255,7 @@ least-significant bits set, corresponds to instructions wider
 than 16 bits, including those in the base ISAs.  Several instructions
 are only valid for certain operands; when invalid, they are marked
 either {\em RES} to indicate that the opcode is reserved for future
-standard extensions; {\em NSE} to indicate that the opcode is reserved
+standard extensions; {\em NSE} to indicate that the opcode is designated
 for custom extensions; or {\em HINT} to indicate that the opcode
 is reserved for microarchitectural hints (see Section~\ref{sec:rvc-hints}).
 

--- a/src/extensions.tex
+++ b/src/extensions.tex
@@ -254,14 +254,14 @@ available encoding space within the 32-bit format.
 A 25-bit instruction encoding space corresponds to a major opcode in
 the base and standard extension encodings.
 
-There are four major opcodes expressly reserved for custom extensions
+There are four major opcodes expressly designated for custom extensions
 (Table~\ref{opcodemap}), each of which represents a 25-bit encoding
 space.  Two of these are reserved for eventual use in the RV128 base
-encoding (will be OP-IMM-64 and OP-64), but can be used for standard
-or non-standard extensions for RV32 and RV64.
+encoding (will be OP-IMM-64 and OP-64), but can be used for
+non-standard extensions for RV32 and RV64.
 
-The two opcodes reserved for RV64 (OP-IMM-32 and OP-32) can also be
-used for standard and non-standard extensions to RV32 only.
+The two major opcodes reserved for RV64 (OP-IMM-32 and OP-32) can also be
+used for non-standard extensions to RV32 only.
 
 If an implementation does not require floating-point, then the seven
 major opcodes reserved for standard floating-point extensions

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2548,7 +2548,7 @@ whereas those from HS-mode or S-mode use cause~9 as usual.
   1         & 11              & Machine external interrupt \\ \hline
   1         & 12              & Supervisor guest external interrupt \\
   1         & 13--15          & {\em Reserved} \\
-  1         & $\ge$16         & {\em Available for platform or custom use} \\ \hline
+  1         & $\ge$16         & {\em Designated for platform or custom use} \\ \hline
   0         & 0               & Instruction address misaligned \\
   0         & 1               & Instruction access fault \\
   0         & 2               & Illegal instruction \\
@@ -2570,9 +2570,9 @@ whereas those from HS-mode or S-mode use cause~9 as usual.
   0         & 21              & Load guest-page fault \\
   0         & 22              & Virtual instruction \\
   0         & 23              & Store/AMO guest-page fault \\
-  0         & 24--31          & {\em Available for custom use} \\
+  0         & 24--31          & {\em Designated for custom use} \\
   0         & 32--47          & {\em Reserved} \\
-  0         & 48--63          & {\em Available for custom use} \\
+  0         & 48--63          & {\em Designated for custom use} \\
   0         & $\ge$64         & {\em Reserved} \\
   \hline
 \end{tabular}
@@ -2786,7 +2786,7 @@ trapping LW instruction.
 
 \item
 Bit~0 is {\tt 1}, and replacing bit~1 with {\tt 1} makes the value into
-an instruction encoding that is explicitly available for a custom
+an instruction encoding that is explicitly designated for a custom
 instruction (\emph{not} an unused reserved encoding).
 
 This is a \textit{custom value}.

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1319,7 +1319,7 @@ Interrupt cause number \textit{i} (as reported in CSR {\tt mcause},
 Section~\ref{sec:mcause}) corresponds with bit~\textit{i} in both
 {\tt mip} and {\tt mie}.
 Bits 15:0 are allocated to standard interrupt causes only, while bits 16
-and above are available for platform or custom use.
+and above are designated for platform or custom use.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -2097,7 +2097,7 @@ codes.
   1         & 10              & {\em Reserved} \\
   1         & 11              & Machine external interrupt \\ \hline
   1         & 12--15          & {\em Reserved} \\
-  1         & $\ge$16         & {\em Available for platform use} \\ \hline
+  1         & $\ge$16         & {\em Designated for platform use} \\ \hline
   0         & 0               & Instruction address misaligned \\
   0         & 1               & Instruction access fault \\
   0         & 2               & Illegal instruction \\   
@@ -2115,9 +2115,9 @@ codes.
   0         & 14              & {\em Reserved} \\
   0         & 15              & Store/AMO page fault \\
   0         & 16--23          & {\em Reserved} \\
-  0         & 24--31          & {\em Available for custom use} \\
+  0         & 24--31          & {\em Designated for custom use} \\
   0         & 32--47          & {\em Reserved} \\
-  0         & 48--63          & {\em Available for custom use} \\
+  0         & 48--63          & {\em Designated for custom use} \\
   0         & $\ge$64         & {\em Reserved} \\
   \hline
 

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -116,7 +116,7 @@ are read-only, in which case writes to the read-only bits are ignored.
 
 Table~\ref{csrrwpriv} also indicates the convention to allocate CSR
 addresses between standard and custom uses.  The CSR addresses
-reserved for custom uses will not be redefined by future
+designated for custom uses will not be redefined by future
 standard extensions.
 
 Machine-mode standard read-write CSRs {\tt 0x7A0}--{\tt 0x7BF} are reserved

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1397,7 +1397,7 @@ x0}, which has no architecturally visible effect.
 
 Table~\ref{tab:rv32i-hints} lists all RV32I HINT code points.  91\% of the HINT
 space is reserved for standard HINTs, but none are presently defined.  The
-remainder of the HINT space is reserved for custom HINTs: no standard HINTs
+remainder of the HINT space is designated for custom HINTs; no standard HINTs
 will ever be defined in this subspace.
 
 \begin{commentary}
@@ -1429,7 +1429,7 @@ simulation/emulation.
   SRL                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   SRA                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   FENCE                 & {\em pred}=0 or {\em succ}=0                & $2^{5}-1$                   & \\ \hline \hline
-  SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{7}{*}{\em Reserved for custom use} \\ \cline{1-3}
+  SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{7}{*}{\em Designated for custom use} \\ \cline{1-3}
   SLTIU                 & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   SLLI                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   SRLI                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}

--- a/src/rv32e.tex
+++ b/src/rv32e.tex
@@ -44,7 +44,7 @@ and RV32I.
 RV32E uses the same instruction-set encoding as RV32I, except that
 only registers {\tt x0}--{\tt x15} are provided.  Any future standard
 extensions will not make use of the instruction bits freed up by the
-reduced register-specifier fields and so these are available for
+reduced register-specifier fields and so these are designated for
 custom extensions.
 
 \begin{commentary}

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -266,7 +266,7 @@ custom HINT encoding spaces.
 
 Table~\ref{tab:rv64i-hints} lists all RV64I HINT code points.  91\% of the HINT
 space is reserved for standard HINTs, but none are presently defined.  The
-remainder of the HINT space is reserved for custom HINTs: no standard HINTs
+remainder of the HINT space is designated for custom HINTs; no standard HINTs
 will ever be defined in this subspace.
 
 \begin{table}[hbt]
@@ -296,7 +296,7 @@ will ever be defined in this subspace.
   SRLW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   SRAW                  & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   FENCE                 & {\em pred}=0 or {\em succ}=0                & $2^{5}-1$                   & \\ \hline \hline
-  SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{10}{*}{\em Reserved for custom use} \\ \cline{1-3}
+  SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{10}{*}{\em Designated for custom use} \\ \cline{1-3}
   SLTIU                 & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   SLLI                  & {\em rd}={\tt x0}                           & $2^{11}$                    & \\ \cline{1-3}
   SRLI                  & {\em rd}={\tt x0}                           & $2^{11}$                    & \\ \cline{1-3}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -329,7 +329,7 @@ Interrupt cause number \textit{i} (as reported in CSR {\tt scause},
 Section~\ref{sec:scause}) corresponds with bit~\textit{i} in both
 {\tt sip} and {\tt sie}.
 Bits 15:0 are allocated to standard interrupt causes only, while bits 16
-and above are available for platform or custom use.
+and above are designated for platform or custom use.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -686,7 +686,7 @@ it is only guaranteed to hold supported exception codes.
   1         & 6--8            & {\em Reserved} \\
   1         & 9               & Supervisor external interrupt \\
   1         & 10--15          & {\em Reserved} \\
-  1         & $\ge$16         & {\em Available for platform use} \\ \hline
+  1         & $\ge$16         & {\em Designated for platform use} \\ \hline
   0         & 0               & Instruction address misaligned \\
   0         & 1               & Instruction access fault \\
   0         & 2               & Illegal instruction \\   
@@ -703,9 +703,9 @@ it is only guaranteed to hold supported exception codes.
   0         & 14              & {\em Reserved} \\
   0         & 15              & Store/AMO page fault \\
   0         & 16--23          & {\em Reserved} \\
-  0         & 24--31          & {\em Available for custom use} \\
+  0         & 24--31          & {\em Designated for custom use} \\
   0         & 32--47          & {\em Reserved} \\
-  0         & 48--63          & {\em Available for custom use} \\
+  0         & 48--63          & {\em Designated for custom use} \\
   0         & $\ge$64         & {\em Reserved} \\
   \hline
 \end{tabular}
@@ -871,7 +871,7 @@ Attempting to select MODE=Bare with a nonzero pattern in the remaining fields
 has an \unspecified\ effect on the value that the remaining fields assume
 and an \unspecified\ effect on address translation and protection behavior.
 
-For RV32, the {\tt satp} encodings corresponding to MODE=Bare and ASID[8:7]=3 are reserved
+For RV32, the {\tt satp} encodings corresponding to MODE=Bare and ASID[8:7]=3 are designated
 for custom use, whereas the encodings corresponding to MODE=Bare and ASID[8:7]$\ne$3 are
 reserved for future standard use.
 For RV64, all {\tt satp} encodings corresponding to MODE=Bare are reserved for future
@@ -921,7 +921,7 @@ Value  & Name & Description \\
 10      & {\em Sv57} & {\em Reserved for page-based 57-bit virtual addressing.} \\
 11      & {\em Sv64} & {\em Reserved for page-based 64-bit virtual addressing.} \\
 12--13  & ---   & {\em Reserved for standard use} \\
-14--15  & ---   & {\em Reserved for custom use} \\
+14--15  & ---   & {\em Designated for custom use} \\
 \hline
 \end{tabular}
 \end{center}


### PR DESCRIPTION
In Volume I, section 1.3, "RISC-V ISA Overview", the words *reserved* and *custom* are defined as disjoint categories.  I believe the phrase "reserved for custom use" undermines the meaning we usually want to convey with the word *reserved*.