### PR TITLE
Change "hardwired to other field" to "read-only field"

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -248,11 +248,11 @@ When HSXLEN=32, the VSXL field does not exist, and VSXLEN=32.
 When HSXLEN=64, VSXL is a \warl\ field that is encoded the same as the
 MXL field of {\tt misa}, shown in Table~\ref{misabase} on
 page~\pageref{misabase}.
-In particular, the implementation may make VSXL a read-only field forcing
-VSXLEN=HSXLEN.
+In particular, an implementation may make VSXL be a read-only field whose
+value always ensures that VSXLEN=HSXLEN.
 
 If HSXLEN is changed from 32 to a wider width, and if field VSXL is not
-hardwired to a forced value, it gets the value corresponding to the
+restricted to a single value, it gets the value corresponding to the
 widest supported width not wider than the new HSXLEN.
 
 The {\tt hstatus} fields VTSR, VTW, and VTVM are defined analogously to the
@@ -1272,11 +1272,11 @@ When VSXLEN=32, the UXL field does not exist, and VU-mode XLEN=32.
 When VSXLEN=64, UXL is a \warl\ field that is encoded the same as the MXL
 field of {\tt misa}, shown in Table~\ref{misabase} on
 page~\pageref{misabase}.
-In particular, the implementation may hardwire field UXL so that VU-mode
-XLEN=VSXLEN.
+In particular, an implementation may make UXL be a read-only copy of
+field VSXL of {\tt hstatus}, forcing VU-mode XLEN=VSXLEN.
 
 If VSXLEN is changed from 32 to a wider width, and if field UXL is not
-hardwired to a forced value, it gets the value corresponding to the
+restricted to a single value, it gets the value corresponding to the
 widest supported width not wider than the new VSXLEN.
 
 When V=1, both {\tt vsstatus}.FS and the HS-level {\tt sstatus}.FS are in

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -637,13 +637,13 @@ SXLEN=32 and UXLEN=32.
 
 For RV64 systems, if S-mode is not supported, then SXL is hardwired
 to zero.  Otherwise, it is a \warl\ field that encodes the current value of
-SXLEN.  In particular, the implementation may hardwire SXL so that
-SXLEN=MXLEN.
+SXLEN.  In particular, an implementation may make SXL be a read-only
+field whose value always ensures that SXLEN=MXLEN.
 
 For RV64 systems, if U-mode is not supported, then UXL is hardwired
 to zero.  Otherwise, it is a \warl\ field that encodes the current value of
-UXLEN.  In particular, the implementation may hardwire UXL so that
-UXLEN=MXLEN or UXLEN=SXLEN.
+UXLEN.  In particular, an implementation may make UXL be a read-only
+field whose value always ensures that UXLEN=MXLEN or UXLEN=SXLEN.
 
 Whenever XLEN in any mode is set to a value less than the widest
 supported XLEN, all operations must ignore source operand register
@@ -664,7 +664,7 @@ case.
 \end{commentary}
 
 If MXLEN is changed from 32 to a wider width, each of {\tt mstatus} fields SXL and
-UXL, if not hardwired to a forced value, gets the value corresponding to the
+UXL, if not restricted to a single value, gets the value corresponding to the
 widest supported width not wider than the new MXLEN.
 
 \subsubsection{Memory Privilege in {\tt mstatus} Register}
@@ -751,10 +751,10 @@ In this case, no additional SFENCE.VMA is necessary, beyond what would
 ordinarily be required for a world switch.
 \end{commentary}
 
-If S-mode is supported, an implementation may hardwire SBE so that
-SBE=MBE and writes to SBE are ignored.
-If U-mode is supported, an implementation may hardwire UBE so that
-UBE=MBE or UBE=SBE and writes to UBE are ignored.
+If S-mode is supported, an implementation may make SBE be a read-only
+copy of MBE.
+If U-mode is supported, an implementation may make UBE be a read-only
+copy of either MBE or SBE.
 
 \begin{commentary}
 An implementation supports only little-endian memory accesses if fields

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -187,7 +187,8 @@ Table~\ref{misabase}.
 
 For RV32 systems, the UXL field does not exist, and UXLEN=32.  For RV64
 systems, it is a \warl\ field that encodes the current value of UXLEN.
-In particular, the implementation may hardwire UXL so that UXLEN=SXLEN.
+In particular, an implementation may make UXL be a read-only field whose
+value always ensures that UXLEN=SXLEN.
 
 If UXLEN~$\ne$~SXLEN, instructions executed in the narrower mode must ignore
 source register operand bits above the configured XLEN, and must sign-extend
@@ -242,8 +243,8 @@ alternate mapping.
 The UBE bit is a \warl\ field that controls the endianness of explicit
 memory accesses made from U-mode, which may differ from the endianness of
 memory accesses in S-mode.
-An implementation may hardwire UBE to specify always the same endianness
-as for S-mode.
+An implementation may make UBE be a read-only field that always specifies
+the same endianness as for S-mode.
 
 UBE controls whether explicit
 load and store memory accesses made from U-mode are little-endian (UBE=0)


### PR DESCRIPTION
Instead of describing CSR fields for XLEN (SXL, VSXL, UXL) and endianness (SBE, VSBE, UBE) as possibly being "hardwired" to another field, describe them as possibly being read-only fields with matching values.