### PR TITLE
add architecture ID for NEORV32 core

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -36,3 +36,4 @@ C-Class       | IIT Madras                      | [Neel Gala](mailto:neelgala@gm
 SweRV EL2     | Western Digital Corporation     | [Thomas Wicki](mailto:Thomas.Wicki@wdc.com)                 | 16                | https://github.com/chipsalliance/Cores-SweRV-EL2
 SweRV EH2     | Western Digital Corporation     | [Thomas Wicki](mailto:Thomas.Wicki@wdc.com)                 | 17                | https://github.com/chipsalliance/Cores-SweRV-EH2
 SERV          | Olof Kindgren Enterprises       | [Olof Kindgren](mailto:olof.kindgren@gmail.com)             | 18                | https://github.com/olofk/serv
+NEORV32       | Stephan Nolting                 | [Stephan Nolting](mailto:stnolting@gmail.com)               | 19                | https://github.com/stnolting/neorv32


### PR DESCRIPTION
According to [marchid.md](https://github.com/riscv/riscv-isa-manual/blob/master/marchid.md)

> Open-source project maintainers may make pull requests against this repository to request the allocation of an architecture ID.

I would like to request an architecture ID assignment (architecture ID 19) for the [NEORV32 processor](https://github.com/stnolting/neorv32).
:)