### PR TITLE
Use a defined architectural term since "reserved" behavior is not defined

### DIFF
--- a/src/f.tex
+++ b/src/f.tex
@@ -159,7 +159,7 @@ Rounding modes are encoded as shown in Table~\ref{rm}.  A value of 111
 in the instruction's {\em rm} field selects the dynamic rounding mode
 held in {\tt frm}.  The behavior of floating-point instructions that
 depend on rounding mode when executed with a reserved rounding mode is
-{\em reserved}, including both static reserved rounding modes (101--110) and
+\unspecified, including both static reserved rounding modes (101--110) and
 dynamic reserved rounding modes (101--111).  Some instructions, including
 widening conversions, have the {\em rm} field but are nevertheless
 unaffected by the rounding mode; software should set their {\em rm}
@@ -224,13 +224,13 @@ Static rounding modes are used to implement specialized arithmetic
 operations that often have to switch frequently between different
 rounding modes.
 
-The ratified version of the F spec mandated that an illegal
+Earlier versions of the F extension mandated that an illegal
 instruction exception was raised when an instruction was executed with
-a reserved dynamic rounding mode.  This has been weakened to reserved,
+a reserved dynamic rounding mode.  This has been weakened to \unspecified,
 which matches the behavior of static rounding-mode instructions.
 Raising an illegal instruction exception is still valid behavior when
 encountering a reserved encoding, so implementations compatible with
-the ratified spec are compatible with the weakened spec.
+the earlier requirement are compatible with the weakened language.
 \end{commentary}
  
 The accrued exception flags indicate the exception conditions that

--- a/src/f.tex
+++ b/src/f.tex
@@ -224,13 +224,13 @@ Static rounding modes are used to implement specialized arithmetic
 operations that often have to switch frequently between different
 rounding modes.
 
-Earlier versions of the F extension mandated that an illegal
+The ratified version of the F spec mandated that an illegal
 instruction exception was raised when an instruction was executed with
 a reserved dynamic rounding mode.  This has been weakened to \unspecified,
 which matches the behavior of static rounding-mode instructions.
 Raising an illegal instruction exception is still valid behavior when
 encountering a reserved encoding, so implementations compatible with
-the earlier requirement are compatible with the weakened language.
+the ratified spec are compatible with the weakened spec.
 \end{commentary}
  
 The accrued exception flags indicate the exception conditions that


### PR DESCRIPTION
Changed the language to not preclude this change from ever being ratified.