### PR TITLE
Improve description of interrupt traps

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -566,12 +566,6 @@ privilege than HS-mode;
 {\tt hip} and {\tt hie}; and
 (c)~bit~\textit{i} is not set in {\tt hideleg}.
 
-After execution of each instruction in program order, if the conditions
-for an interrupt trap to HS-mode are true, the trap occurs immediately,
-before another instruction executes.
-Interrupts to HS-mode take priority over any interrupts to operating
-modes of lower privilege.
-
 If bit~\textit{i} of {\tt sie} is hardwired to zero, the same bit in
 register {\tt hip} may be writable or may be read-only.
 When bit~\textit{i} in {\tt hip} is writable, a pending interrupt

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -510,9 +510,6 @@ Registers {\tt hip} and {\tt hie} are HSXLEN-bit read/write registers
 that supplement HS-level's {\tt sip} and {\tt sie} respectively.
 The {\tt hip} register indicates pending VS-level and hypervisor-specific
 interrupts, while {\tt hie} contains enable bits for the same interrupts.
-As with {\tt sip} and {\tt sie}, an interrupt \textit{i} will be taken in
-HS-mode if bit~\textit{i} is set in both {\tt hip} and {\tt hie}, and if
-supervisor-level interrupts are globally enabled.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -559,6 +556,21 @@ The active bits of {\tt hip} and {\tt hie} cannot be placed in HS-level's
 software to emulate the hypervisor extension on platforms that do not
 implement it in hardware.
 \end{commentary}
+
+An interrupt~\textit{i} will trap to HS-mode whenever all of the
+following are true:
+(a)~either the current operating mode is HS-mode and the SIE bit in the
+{\tt sstatus} register is set, or the current operating mode has less
+privilege than HS-mode;
+(b)~bit~\textit{i} is set in both {\tt sip} and {\tt sie}, or in both
+{\tt hip} and {\tt hie}; and
+(c)~bit~\textit{i} is not set in {\tt hideleg}.
+
+After execution of each instruction in program order, if the conditions
+for an interrupt trap to HS-mode are true, the trap occurs immediately,
+before another instruction executes.
+Interrupts to HS-mode take priority over any interrupts to operating
+modes of lower privilege.
 
 If bit~\textit{i} of {\tt sie} is hardwired to zero, the same bit in
 register {\tt hip} may be writable or may be read-only.

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1365,7 +1365,7 @@ privilege than M-mode;
 {\tt mideleg}.
 
 After execution of each instruction in program order, if the conditions
-for an interrupt trap to M-mode are true, the trap occurs immediately,
+for an interrupt trap are true, the trap occurs immediately,
 before another instruction executes.
 Interrupts to M-mode take priority over any interrupts to lower privilege
 modes.

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1355,17 +1355,20 @@ MXLEN \\
 \label{miereg}
 \end{figure}
 
-An interrupt \textit{i} will be taken if bit \textit{i} is set in both
-{\tt mip} and {\tt mie}, and if interrupts are globally enabled.  By
-default, M-mode interrupts are globally enabled if the hart's current
-privilege mode is less than M, or if the current privilege mode is M
-and the MIE bit in the {\tt mstatus} register is set.  If bit \textit{i}
-in {\tt mideleg} is set, however, interrupts are considered to be
-globally enabled if the hart's current privilege mode equals the
-delegated privilege mode and that mode's interrupt enable
-bit (\textit{x}\/IE in {\tt mstatus} for mode~\textit{x}) is set,
-or if the current
-privilege mode is less than the delegated privilege mode.
+An interrupt~\textit{i} will trap to M-mode (causing the privilege mode
+to change to M-mode) whenever all of the following are true:
+(a)~either the current privilege mode is M and the MIE bit in the
+{\tt mstatus} register is set, or the current privilege mode has less
+privilege than M-mode;
+(b)~bit~\textit{i} is set in both {\tt mip} and {\tt mie}; and
+(c)~if register {\tt mideleg} exists, bit~\textit{i} is not set in
+{\tt mideleg}.
+
+After execution of each instruction in program order, if the conditions
+for an interrupt trap to M-mode are true, the trap occurs immediately,
+before another instruction executes.
+Interrupts to M-mode take priority over any interrupts to lower privilege
+modes.
 
 Each individual bit in register {\tt mip} may be writable or may be
 read-only.
@@ -1555,17 +1558,15 @@ using uncached I/O writes to memory-mapped control registers depending
 on the platform specification.
 \end{commentary}
 
-Multiple simultaneous interrupts destined for different privilege modes are
-handled in decreasing order of destined privilege mode.  Multiple simultaneous
-interrupts destined for the same privilege mode are handled in the following
+Multiple simultaneous
+interrupts destined for M-mode are handled in the following
 decreasing priority order: MEI, MSI, MTI, SEI, SSI, STI.
-Synchronous exceptions are of lower priority than all interrupts.
 
 \begin{commentary}
   The machine-level interrupt fixed-priority ordering rules were developed
   with the following rationale.
   
-  Interrupts for higher privilege modes must be serviced before
+  Interrupts for M-mode must be serviced before
   interrupts for lower privilege modes to support preemption.
 
   The platform-specific machine-level interrupt sources in bits 16 and above
@@ -1586,9 +1587,6 @@ Synchronous exceptions are of lower priority than all interrupts.
   Software interrupts are located in the lowest four bits of {\tt mip}
   as these are often written by software, and this position allows the
   use of a single CSR instruction with a five-bit immediate.
-
-  Synchronous exceptions are given the lowest priority to minimize
-  worst-case interrupt latency.
 \end{commentary}
 
 Restricted views of the {\tt mip} and {\tt mie} registers appear as

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -374,7 +374,7 @@ privilege than S-mode; and
 (b)~bit~\textit{i} is set in both {\tt sip} and {\tt sie}.
 
 After execution of each instruction in program order, if the conditions
-for an interrupt trap to S-mode are true, the trap occurs immediately,
+for an interrupt trap are true, the trap occurs immediately,
 before another instruction executes.
 Interrupts to S-mode take priority over any interrupts to lower privilege
 modes.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -366,12 +366,18 @@ SXLEN \\
 \label{siereg}
 \end{figure}
 
-An interrupt \textit{i} will be taken if bit \textit{i} is set in both
-{\tt sip} and {\tt sie}, and if supervisor-level interrupts are globally
-enabled.
-Supervisor-level interrupts are globally enabled if the hart's current
-privilege mode is less than S, or if the current privilege mode is S
-and the SIE bit in the {\tt sstatus} register is set.
+An interrupt~\textit{i} will trap to S-mode whenever both of the
+following are true:
+(a)~either the current privilege mode is S and the SIE bit in the
+{\tt sstatus} register is set, or the current privilege mode has less
+privilege than S-mode; and
+(b)~bit~\textit{i} is set in both {\tt sip} and {\tt sie}.
+
+After execution of each instruction in program order, if the conditions
+for an interrupt trap to S-mode are true, the trap occurs immediately,
+before another instruction executes.
+Interrupts to S-mode take priority over any interrupts to lower privilege
+modes.
 
 Each individual bit in register {\tt sip} may be writable or may be
 read-only.
@@ -499,7 +505,6 @@ they are shown as hardwired to 0 in Figures~\ref{sipreg-standard} and
 Multiple simultaneous
 interrupts destined for supervisor mode are handled in the following
 decreasing priority order: SEI, SSI, STI.
-Synchronous exceptions are of lower priority than all interrupts.
 
 \subsection{Supervisor Timers and Performance Counters}
 


### PR DESCRIPTION
Simplify the description of when interrupt traps are taken, in part by abandoning the concept that interrupt sources are globally enabled selectively, depending on delegation registers.  (Global enablement on a per-interrupt basis had always been in conflict with other text in the document that says that interrupts are globally enabled for M-mode or S-mode simply when field MIE or SIE in mstatus is set.)

Also make clear that pending-and-enabled interrupts must trap immediately, before another instruction is executed.  This requirement is sufficient to prove (within the bounds of what is enforceable) that interrupts must have higher priority than synchronous exception traps.