### PR TITLE
change FCVT.D.S frm to useless

### DIFF
--- a/src/dep-table.tex
+++ b/src/dep-table.tex
@@ -415,7 +415,7 @@ $^\ddagger$The instruction carries dependencies from source register(s) to desti
    \cline{2-4}
    FCVT.S.D & {\em rs1}, frm$^*$ & {\em rd} & NV, OF, UF, NX & $^*$if rm=111  \\
    \cline{2-4}
-   FCVT.D.S & {\em rs1}, frm$^*$ & {\em rd} & NV & $^*$if rm=111  \\
+   FCVT.D.S & {\em rs1} & {\em rd} & NV &  &  \\
    \cline{2-4}
    FEQ.D & {\em rs1}, {\em rs2} & {\em rd} & NV &   \\
    \cline{2-4}


### PR DESCRIPTION
FCVT.D.S will never round,  frm* and if rm=111 shouldn't be included