### PR TITLE
Disabling H extension does not ensure illegal instruction traps

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -25,10 +25,8 @@ SBI as an OS normally does from S-mode.  An HS-mode hypervisor is expected to
 implement the SBI for its VS-mode guest.
 
 The hypervisor extension is enabled by setting bit 7 in the {\tt misa} CSR,
-which corresponds to the letter H.  When {\tt misa}[7] is clear, the hart
-behaves as though this extension were not implemented, and attempts to use
-hypervisor CSRs or instructions raise an illegal instruction exception.
-Implementations that include the hypervisor extension are encouraged
+which corresponds to the letter H.
+RISC-V harts that implement the hypervisor extension are encouraged
 not to hardwire {\tt misa}[7], so that the extension may be disabled.
 
 \begin{commentary}


### PR DESCRIPTION
The consequences of disabling an extension by clearing a bit in misa is specified with the misa CSR.