### PR TITLE
Both HWBPs and EBREAKs populate mtval

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2226,7 +2226,7 @@ implementation, though it may be explicitly written by software.  The hardware
 platform will specify which exceptions must set {\tt mtval} informatively and
 which may unconditionally set it to zero.
 
-When a hardware breakpoint is triggered, or an
+When a breakpoint,
 address-misaligned, access-fault, or page-fault exception occurs
 on an instruction fetch, load, or store, {\tt
   mtval} is written with the faulting virtual address.  On an illegal

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -727,8 +727,9 @@ which exceptions must set {\tt stval} informatively and which may
 unconditionally set it to zero.
 
 
-When a hardware breakpoint is triggered, or an instruction, load, or
-store address-misaligned, access-fault, or page-fault exception occurs, {\tt stval}
+When a breakpoint,
+address-misaligned, access-fault, or page-fault exception occurs
+on an instruction fetch, load, or store, {\tt stval}
 is written with the faulting virtual address.  On an illegal instruction trap,
 {\tt stval} may be written with the first XLEN or ILEN bits of the faulting
 instruction as described below.  For other exceptions, {\tt stval} is set to


### PR DESCRIPTION
This is a normative change, but it is backwards compatible, since writing 0 to mtval remains a legal option.

Resolves #600