### PR TITLE
Make unused misa fields 0 (WARL) rather than WLRL.

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -35,7 +35,7 @@ mechanism.
 \instbitrange{25}{0} \\
 \hline
 \multicolumn{1}{|c|}{MXL[1:0] (\warl)} &
-\multicolumn{1}{c|}{\wlrl} &
+\multicolumn{1}{c|}{0 (\warl)} &
 \multicolumn{1}{c|}{Extensions[25:0] (\warl)} \\
 \hline
 2 & MXLEN-28 & 26 \\


### PR DESCRIPTION
Fixes #537 
