### PR TITLE
Allow an optional vendor name filed for non-standard extension names

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -125,10 +125,13 @@ they should be ordered alphabetically.
 
 \section{Non-Standard Extension Names}
 
-Non-standard extensions are named using a single ``X'' followed by an
-alphabetical name and an optional version number.
+Non-standard extensions are named using a single ``X'' followed by an optional vendor
+name field seperated by a single ``-'' an alphabetical name and an optional version
+number.
 For example, ``Xhwacha'' names the Hwacha vector-fetch ISA extension;
 ``Xhwacha2'' and ``Xhwacha2p0'' name version 2.0 of same.
+``Xucb-hwacha'' names the cache extension from UCB,
+``Xucb-hwacha2'' and ``Xucb-hwacha2'' name version 2.0 of same.
 
 Non-standard extensions must be listed after all standard extensions.
 They must be separated from other multi-letter extensions


### PR DESCRIPTION
I would like to add an optional field for vendor name, that could be used as kind of namespace to prevent naming collision for non-standard extension.