### PR TITLE
Clarify type of timer interrupt

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2228,7 +2228,7 @@ mechanism for determining the timebase of {\tt mtime}.  The {\tt
 The {\tt mtime} register has a 64-bit precision on all RV32 and RV64
 systems.  Platforms provide a 64-bit memory-mapped machine-mode
 timer compare register ({\tt mtimecmp}).
-A timer interrupt becomes pending whenever {\tt mtime} contains
+A machine timer interrupt becomes pending whenever {\tt mtime} contains
 a value greater than or equal to {\tt mtimecmp}, treating the values
 as unsigned integers.
 The interrupt remains posted until {\tt mtimecmp} becomes greater than


### PR DESCRIPTION
Clarify that mtime >= mtimecmp results in a *machine* timer interrupt being posted.