### PR TITLE
Add Sv57 and Sv57x4

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -949,7 +949,7 @@ wide as 34 bits, and {\tt htval} reports bits 33:2 of the address.
 This shift-by-2 encoding of guest physical addresses matches the encoding
 of physical addresses in PMP address registers (Section~\ref{sec:pmp})
 and in page table entries (Sections \ref{sec:sv32}, \ref{sec:sv39},
-and~\ref{sec:sv48}).
+\ref{sec:sv48}, and~\ref{sec:sv57}).
 
 If the least-significant two bits of a faulting guest physical address
 are needed, these bits are ordinarily the same as the least-significant
@@ -1060,7 +1060,7 @@ in HS-mode will raise an illegal instruction exception.
 }
 \vspace{-0.1in}
 \caption{RV64 Hypervisor guest address translation and protection register
-{\tt hgatp}, for MODE values Bare, Sv39x4, and Sv48x4.}
+{\tt hgatp}, for MODE values Bare, Sv39x4, Sv48x4, and Sv57x4.}
 \label{rv64hgatp}
 \end{figure}
 
@@ -1075,8 +1075,8 @@ In this case, the remaining fields in {\tt hgatp} must be set to zeros.
 For RV32, the only other valid setting for MODE is Sv32x4, which is a
 modification of the usual Sv32 paged virtual-memory scheme, extended to support
 34-bit guest physical addresses.
-For RV64, modes Sv39x4 and Sv48x4 are defined as modifications of the Sv39 and
-Sv48 paged virtual-memory schemes.
+For RV64, modes Sv39x4, Sv48x4, and Sv57x4 are defined as modifications of the
+Sv39, Sv48, and Sv57 paged virtual-memory schemes.
 All of these paged virtual-memory schemes are described in
 Section~\ref{sec:guest-addr-translation}.
 An additional RV64 scheme, Sv57x4, may be defined in a later version of this
@@ -1104,7 +1104,7 @@ Value  & Name & Description \\
 1--7   & ---    & {\em Reserved} \\
 8      & Sv39x4 & Page-based 41-bit virtual addressing (2-bit extension of Sv39). \\
 9      & Sv48x4 & Page-based 50-bit virtual addressing (2-bit extension of Sv48). \\
-10     & {\em Sv57x4} & {\em Reserved for page-based 59-bit virtual addressing.} \\
+10     & Sv57x4 & Page-based 59-bit virtual addressing (2-bit extension of Sv57). \\
 11--15 & ---    & {\em Reserved} \\
 \hline
 \end{tabular}
@@ -1122,7 +1122,7 @@ Instead, the fields of {\tt hgatp} are {\warl} in the normal way, when so
 indicated.
 
 As explained in Section~\ref{sec:guest-addr-translation}, for the paged
-virtual-memory schemes (Sv32x4, Sv39x4, and Sv48x4), the root page table is
+virtual-memory schemes (Sv32x4, Sv39x4, Sv48x4, and Sv57x4), the root page table is
 16~KiB and must be aligned to a 16-KiB boundary.
 In these modes, the lowest two bits of the physical page number (PPN) in
 {\tt hgatp} always read as zeros.
@@ -1136,8 +1136,8 @@ back the value in {\tt hgatp} to see which bit positions in the VMID field hold
 a one.
 The least-significant bits of VMID are implemented first:
 that is, if VMIDLEN~$>$~0, VMID[VMIDLEN-1:0] is writable.
-The maximal value of VMIDLEN, termed VMIDMAX, is 7 for Sv32x4 or 14 for Sv39x4
-and Sv48x4.
+The maximal value of VMIDLEN, termed VMIDMAX, is 7 for Sv32x4 or 14 for Sv39x4,
+Sv48x4, and Sv57x4.
 
 Note that writing {\tt hgatp} does not imply any ordering constraints between
 page-table updates and subsequent G-stage address translations.
@@ -1642,7 +1642,7 @@ Section~\ref{sec:two-stage-translation}).
 }
 \vspace{-0.1in}
 \caption{RV64 virtual supervisor address translation and protection register {\tt vsatp}, for MODE
-values Bare, Sv39, and Sv48.}
+values Bare, Sv39, Sv48, and Sv57.}
 \label{rv64vsatpreg}
 \end{figure*}
 
@@ -2276,9 +2276,9 @@ is Bare, guest physical addresses are equal to supervisor physical addresses
 without modification, and no memory protection applies in the trivial
 translation of guest physical addresses to supervisor physical addresses.
 
-When {\tt hgatp}.MODE specifies a translation scheme of Sv32x4, Sv39x4, or
-Sv48x4, G-stage address translation is a variation on the usual
-page-based virtual address translation scheme of Sv32, Sv39, or Sv48,
+When {\tt hgatp}.MODE specifies a translation scheme of Sv32x4, Sv39x4,
+Sv48x4, or Sv57x4, G-stage address translation is a variation on the usual
+page-based virtual address translation scheme of Sv32, Sv39, Sv48, or Sv57,
 respectively.
 In each case, the size of the incoming address is widened by 2~bits (to 34, 41,
 or 50 bits).
@@ -2286,10 +2286,11 @@ To accommodate the 2~extra bits, the root page table (only) is expanded by a
 factor of four to be 16~KiB instead of the usual 4~KiB.
 Matching its larger size, the root page table also must be aligned to a 16~KiB
 boundary instead of the usual 4~KiB page boundary.
-Except as noted, all other aspects of Sv32, Sv39, or Sv48 are adopted unchanged
-for G-stage translation.
+Except as noted, all other aspects of Sv32, Sv39, Sv48, or Sv57 are adopted
+unchanged for G-stage translation.
 Non-root page tables and all page table entries (PTEs) have the same formats as
-documented in Sections \ref{sec:sv32}, \ref{sec:sv39}, and~\ref{sec:sv48}.
+documented in Sections \ref{sec:sv32}, \ref{sec:sv39}, \ref{sec:sv48},
+and~\ref{sec:sv57}.
 
 For Sv32x4, an incoming guest physical address is partitioned into a virtual
 page number (VPN) and page offset as shown in Figure~\ref{sv32x4va}.
@@ -2385,6 +2386,41 @@ exception occurs.
 \label{sv48x4va}
 \end{figure*}
 
+For Sv57x4, an incoming guest physical address is partitioned as shown in
+Figure~\ref{sv57x4va}.
+This partitioning is identical to that for an Sv57 virtual address as depicted
+in Figure~\ref{sv57va} (page~\pageref{sv57va}), except with 2 more bits at the
+high end in VPN[3].
+Address bits 63:50 must all be zeros, or else a guest-page-fault
+exception occurs.
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}S@{}R@{}R@{}R@{}R@{}S}
+\instbitrange{58}{50} &
+\instbitrange{49}{39} &
+\instbitrange{38}{30} &
+\instbitrange{29}{21} &
+\instbitrange{20}{12} &
+\instbitrange{11}{0} \\
+\hline
+\multicolumn{1}{|c|}{VPN[4]} &
+\multicolumn{1}{c|}{VPN[3]} &
+\multicolumn{1}{c|}{VPN[2]} &
+\multicolumn{1}{c|}{VPN[1]} &
+\multicolumn{1}{c|}{VPN[0]} &
+\multicolumn{1}{c|}{page offset} \\
+\hline
+11 & 9 & 9 & 9 & 9 & 12 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Sv57x4 virtual address (guest physical address).}
+\label{sv57x4va}
+\end{figure*}
+
 \begin{commentary}
 The page-based G-stage address translation scheme for RV32, Sv32x4, is
 defined to support a 34-bit guest physical address so that an RV32 hypervisor
@@ -2407,9 +2443,9 @@ addresses (Sv48) or falling back to emulating the larger address space using
 shadow page tables.
 \end{commentary}
 
-The conversion of an Sv32x4, Sv39x4, or Sv48x4 guest physical address is
-accomplished with the same algorithm used for Sv32, Sv39, or Sv48, as presented
-in Section~\ref{sv32algorithm}, except that:
+The conversion of an Sv32x4, Sv39x4, Sv48x4, or Sv57x4 guest physical address is
+accomplished with the same algorithm used for Sv32, Sv39, Sv48, or Sv57, as
+presented in Section~\ref{sv32algorithm}, except that:
 \begin{compactitem}
 \item
 in step~1, $a = \mbox{{\tt hgatp}.PPN}\times\mbox{PAGESIZE}$;

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -1079,8 +1079,6 @@ For RV64, modes Sv39x4, Sv48x4, and Sv57x4 are defined as modifications of the
 Sv39, Sv48, and Sv57 paged virtual-memory schemes.
 All of these paged virtual-memory schemes are described in
 Section~\ref{sec:guest-addr-translation}.
-An additional RV64 scheme, Sv57x4, may be defined in a later version of this
-specification.
 
 The remaining MODE settings for RV64 are reserved for future use and may define
 different interpretations of the other fields in {\tt hgatp}.

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -51,6 +51,7 @@ Additionally, the following compatible changes have been made since version
 \begin{itemize}
   \parskip 0pt
   \itemsep 1pt
+\item Added Sv57 and Sv57x4 address translation modes
 \item Moved N extension into its own chapter.
 \item Defined the RV32-only CSR {\tt mstatush}, which contains most of the
   same fields as the upper 32 bits of RV64's {\tt mstatus}.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -892,7 +892,7 @@ virtual-memory scheme described in Section~\ref{sec:sv32}.
 
 For RV64, three paged virtual-memory schemes are defined: Sv39, Sv48, and Sv57,
 described in Sections~\ref{sec:sv39}, \ref{sec:sv48}, and \ref{sec:sv57}, respectively.
-Two additional schemes, Sv57 and Sv64, will be defined in a later version
+One additional scheme, Sv64, will be defined in a later version
 of this specification.  The remaining MODE settings are reserved
 for future use and may define different interpretations of the other fields in
 {\tt satp}.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -850,7 +850,7 @@ main memory be representable.
 }
 \vspace{-0.1in}
 \caption{RV64 Supervisor address translation and protection register {\tt satp}, for MODE
-values Bare, Sv39, and Sv48.}
+values Bare, Sv39, Sv48, and Sv57.}
 \label{rv64satp}
 \end{figure}
 
@@ -890,8 +890,8 @@ all patterns of the existing MODE field have already been allocated.
 For RV32, the only other valid setting for MODE is Sv32, a paged
 virtual-memory scheme described in Section~\ref{sec:sv32}.
 
-For RV64, two paged virtual-memory schemes are defined: Sv39 and Sv48,
-described in Sections~\ref{sec:sv39} and \ref{sec:sv48}, respectively.
+For RV64, three paged virtual-memory schemes are defined: Sv39, Sv48, and Sv57,
+described in Sections~\ref{sec:sv39}, \ref{sec:sv48}, and \ref{sec:sv57}, respectively.
 Two additional schemes, Sv57 and Sv64, will be defined in a later version
 of this specification.  The remaining MODE settings are reserved
 for future use and may define different interpretations of the other fields in
@@ -920,7 +920,7 @@ Value  & Name & Description \\
 1--7    & ---   & {\em Reserved for standard use} \\
 8       & Sv39  & Page-based 39-bit virtual addressing (see Section~\ref{sec:sv39}). \\
 9       & Sv48  & Page-based 48-bit virtual addressing (see Section~\ref{sec:sv48}). \\
-10      & {\em Sv57} & {\em Reserved for page-based 57-bit virtual addressing.} \\
+10      & Sv57  & Page-based 57-bit virtual addressing (see Section~\ref{sec:sv57}). \\
 11      & {\em Sv64} & {\em Reserved for page-based 64-bit virtual addressing.} \\
 12--13  & ---   & {\em Reserved for standard use} \\
 14--15  & ---   & {\em Designated for custom use} \\
@@ -937,7 +937,7 @@ determined by writing one to every bit position in the ASID field, then
 reading back the value in {\tt satp} to see which bit positions in the ASID
 field hold a one.  The least-significant bits of ASID are implemented first:
 that is, if ASIDLEN~$>$~0, ASID[ASIDLEN-1:0] is writable.  The maximal value
-of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for Sv39 and Sv48.
+of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for Sv39, Sv48, and Sv57.
 
 \begin{commentary}
 For many applications, the choice of page size has a substantial
@@ -1502,7 +1502,9 @@ cost.  For many systems, \wunits{512}{GiB} of virtual-address space is ample,
 and so Sv39 suffices.  Sv48 increases the virtual address space to
 \wunits{256}{TiB}, but increases the physical memory
 capacity dedicated to page tables, the latency of page-table traversals, and
-the size of hardware structures that store virtual addresses.
+the size of hardware structures that store virtual addresses.  Sv57 increases
+the virtual address space, page table capacity requirement, and translation
+latency even further.
 \end{commentary}
 
 \subsection{Addressing and Memory Protection}
@@ -1776,4 +1778,141 @@ aligned.
 
 The algorithm for virtual-to-physical address translation is the same
 as in Section~\ref{sv32algorithm}, except LEVELS equals 4 and PTESIZE
+equals 8.
+
+\section{Sv57: Page-Based 57-bit Virtual-Memory System}
+\label{sec:sv57}
+
+This section describes a simple paged virtual-memory system designed
+for RV64 systems, which supports 57-bit virtual address spaces.  Sv57
+is intended for systems for which a 48-bit virtual address space is
+insufficient.  It closely follows the design of Sv48, simply adding an
+additional level of page table, and so this chapter only details the
+differences between the two schemes.
+
+Implementations that support Sv57 must also support Sv48.
+
+\begin{commentary}
+Systems that support Sv57 can also support Sv48 at essentially no cost, and so
+should do so to maintain compatibility with supervisor software that assumes
+Sv48.
+\end{commentary}
+
+\subsection{Addressing and Memory Protection}
+
+Sv57 implementations support a 57-bit virtual address space, divided
+into \wunits{4}{KiB} pages.  An Sv57 address is partitioned as
+shown in Figure~\ref{sv57va}.
+Instruction fetch addresses and load and store effective addresses,
+which are 64 bits, must have bits 63--57 all equal to bit 56, or else
+a page-fault exception will occur.  The 45-bit VPN is translated into a
+44-bit PPN via a five-level page table, while the 12-bit page offset
+is untranslated.
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}S@{}S@{}S@{}S@{}S@{}S}
+\instbitrange{56}{48} &
+\instbitrange{47}{39} &
+\instbitrange{38}{30} &
+\instbitrange{29}{21} &
+\instbitrange{20}{12} &
+\instbitrange{11}{0} \\
+\hline
+\multicolumn{1}{|c|}{VPN[4]} &
+\multicolumn{1}{c|}{VPN[3]} &
+\multicolumn{1}{c|}{VPN[2]} &
+\multicolumn{1}{c|}{VPN[1]} &
+\multicolumn{1}{c|}{VPN[0]} &
+\multicolumn{1}{c|}{page offset} \\
+\hline
+9 & 9 & 9 & 9 & 9 & 12 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Sv57 virtual address.}
+\label{sv57va}
+\end{figure*}
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}E@{}O@{}O@{}O@{}O}
+\instbitrange{55}{39} &
+\instbitrange{38}{30} &
+\instbitrange{29}{21} &
+\instbitrange{20}{12} &
+\instbitrange{11}{0} \\
+\hline
+\multicolumn{1}{|c|}{PPN[3]} &
+\multicolumn{1}{c|}{PPN[2]} &
+\multicolumn{1}{c|}{PPN[1]} &
+\multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{page offset} \\
+\hline
+17 & 9 & 9 & 9 & 12 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Sv57 physical address.}
+\label{sv57pa}
+\end{figure*}
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
+\instbitrange{63}{54} &
+\instbitrange{53}{37} &
+\instbitrange{36}{28} &
+\instbitrange{27}{19} &
+\instbitrange{18}{10} &
+\instbitrange{9}{8} &
+\instbit{7} &
+\instbit{6} &
+\instbit{5} &
+\instbit{4} &
+\instbit{3} &
+\instbit{2} &
+\instbit{1} &
+\instbit{0} \\
+\hline
+\multicolumn{1}{|c|}{\it Reserved} &
+\multicolumn{1}{c|}{PPN[3]} &
+\multicolumn{1}{c|}{PPN[2]} &
+\multicolumn{1}{c|}{PPN[1]} &
+\multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{RSW} &
+\multicolumn{1}{c|}{D} &
+\multicolumn{1}{c|}{A} &
+\multicolumn{1}{c|}{G} &
+\multicolumn{1}{c|}{U} &
+\multicolumn{1}{c|}{X} &
+\multicolumn{1}{c|}{W} &
+\multicolumn{1}{c|}{R} &
+\multicolumn{1}{c|}{V} \\
+\hline
+10 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Sv57 page table entry.}
+\label{sv57pte}
+\end{figure*}
+
+The PTE format for Sv57 is shown in Figure~\ref{sv57pte}.  Bits 9--0
+have the same meaning as for Sv32.  Any level of PTE may be a leaf
+PTE, so in addition to \wunits{4}{KiB} pages, Sv57 supports
+\wunits{2}{MiB} {\em megapages}, \wunits{1}{GiB} {\em gigapages},
+\wunits{512}{GiB} {\em terapages}, and \wunits{256}{TiB} {\em petapages},
+each of which must be virtually and physically aligned to a boundary equal
+to its size.  A page-fault exception is raised if the physical address is
+insufficiently aligned.
+
+The algorithm for virtual-to-physical address translation is the same
+as in Section~\ref{sv32algorithm}, except LEVELS equals 5 and PTESIZE
 equals 8.


### PR DESCRIPTION
The virtual memory TG would like to enable Sv57.  Encoding space was already reserved for Sv57, and this commit adds it in the "expected" way.

We expect this to go through the RISC-V fast track review process.  Marking as draft while that process plays out.