### PR TITLE
Svnapot Extension

### DIFF
--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -10,12 +10,13 @@ modules:
   \centering
   \begin{tabular}{|c|l|c|}
     \hline
-    Module             & Version  & Status\\
+    Module                & Version  & Status\\
     \hline
-    \em Machine ISA    & \em 1.12 & \em Draft \\
-    \em Supervisor ISA & \em 1.12 & \em Draft \\
-    \em Hypervisor ISA & \em 0.6  & \em Draft \\
-    \em N Extension    & \em 1.1 & \em Draft \\
+    \em Machine ISA       & \em 1.12 & \em Draft \\
+    \em Supervisor ISA    & \em 1.12 & \em Draft \\
+    \em Svnapot Extension & \em 0.1  & \em Draft \\
+    \em Hypervisor ISA    & \em 0.6  & \em Draft \\
+    \em N Extension       & \em 1.1 & \em Draft \\
     \hline
   \end{tabular}
 \end{table}
@@ -61,6 +62,8 @@ Additionally, the following compatible changes have been made since version
   and access-fault exceptions.
 \item PMP reset values are now platform-defined.
 \item An additional 48 optional PMP registers have been defined.
+\item Added the Svnapot Standard Extension draft, along with the N bit in
+  Sv39, Sv48, and Sv57 PTEs
 \item Added the C bit to Sv39 and Sv48 PTEs to indicate custom encodings
 \item Described the behavior of address-translation caches a little more
   explicitly

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1812,13 +1812,10 @@ root page table is stored in the {\tt satp} register's PPN field.
 The PTE format for Sv39 is shown in Figure~\ref{sv39pte}.  Bits 9--0
 have the same meaning as for Sv32.
 
-The N bit indicates that the page represents a
-naturally-aligned power-of-two range of contiguous translations, as defined in
-the Svnapot extension in Chapter~\ref{svnapot}.
-
-Bits 62--54 are reserved
-for future standard use and must be zeroed by software for forward compatibility.
-If any of these bits are set, a page-fault exception is raised.
+Bit 63 is reserved for use by the Svnapot extension in
+Chapter~\ref{svnapot}.  Bits 62--54 are reserved for future standard use.  All
+of these bits must be zeroed by software for forward compatibility.  If any of
+these bits are set, a page-fault exception is raised.
 
 \begin{commentary}
 We reserved several PTE bits for a possible extension that improves
@@ -2124,7 +2121,7 @@ equals 8.
 \chapter{``Svnapot'' Standard Extension for NAPOT Translation Contiguity, Version 0.1}
 \label{svnapot}
 
-In Sv39, Sv48, and Sv57, when a PTE has N=1, the PTE represents a
+In Sv39, Sv48, and Sv57, when Svnapot is enabled and a PTE has N=1, the PTE represents a
 translation that is part of a range of contiguous virtual-to-physical
 translations with the same values for PTE bits 5--0.  Such ranges must be of a
 naturally aligned power-of-2 (NAPOT) granularity larger than the base page

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2203,7 +2203,7 @@ algorithm in Section~\ref{sv32algorithm}, except that:
     replaced by $vpn[i][pte.napot\_bits-1:0]$.  If the encoding in $pte$ is
     {\em reserved} according to Table~\ref{ptenapot}, then a page-fault
     exception must be raised.
-  \item Implicit reads of NAPOT page table may create address-translation cache
+  \item Implicit reads of NAPOT page table entries may create address-translation cache
     entries mapping $a + va.vpn[j] \times \textrm{PTESIZE}$ to a copy of $pte$
     in which $pte.ppn[pte.napot\_bits-1:0]$ is replaced by
     $vpn[0][pte.napot\_bits-1:0]$, for any or all $j$ such that
@@ -2252,9 +2252,4 @@ algorithm in Section~\ref{sv32algorithm}, except that:
 
   Just as with normal PTEs, TLBs are permitted to cache NAPOT PTEs whose V
   (Valid) bit is clear.
-
-  Invalid NAPOT encodings were chosen to raise page-fault exceptions rather
-  than access-fault exceptions, following the convention that invalid PTE
-  configurations result in page-faults exceptions, while invalid access
-  types or accesses to invalid physical memory regions trigger page faults.
 \end{commentary}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2121,7 +2121,7 @@ equals 8.
 \chapter{``Svnapot'' Standard Extension for NAPOT Translation Contiguity, Version 0.1}
 \label{svnapot}
 
-In Sv39, Sv48, and Sv57, when Svnapot is enabled and a PTE has N=1, the PTE represents a
+In Sv39, Sv48, and Sv57, when a PTE has N=1, the PTE represents a
 translation that is part of a range of contiguous virtual-to-physical
 translations with the same values for PTE bits 5--0.  Such ranges must be of a
 naturally aligned power-of-2 (NAPOT) granularity larger than the base page
@@ -2140,44 +2140,44 @@ size.
 
 \begin{table*}[h!]
 \begin{center}
-\begin{tabular}{|c|c||c|c|}
+\begin{tabular}{|c|c||l|c|}
 \hline
-N & $pte.ppn[i]$      & $pte.napot\_bits$ & Meaning if $i=0$         \\
+i        & $pte.ppn[i]$      & Description              & $pte.napot\_bits$ \\
 \hline
-0 & {\tt y~yyyy~yyyy} & 0                 &  Non-NAPOT 4KiB PTE      \\
-1 & {\tt y~yyyy~1000} & 4                 &  64KiB contiguous region \\
-1 & {\em other}       & $-$               &  {\em Reserved for standard use} \\
+0        & {\tt x~xxxx~xxx1} & {\em Reserved}           & $-$ \\
+0        & {\tt x~xxxx~xx1x} & {\em Reserved}           & $-$ \\
+0        & {\tt x~xxxx~x1xx} & {\em Reserved}           & $-$ \\
+0        & {\tt x~xxxx~1000} & 64 KiB contiguous region & 4   \\
+0        & {\tt x~xxxx~0xxx} & {\em Reserved}           & $-$ \\
+$\geq 1$ & {\tt x~xxxx~xxxx} & {\em Reserved}           & $-$ \\
 \hline
-\multicolumn{4}{l}{{\tt y}: subset of PPN used for address translation} \\
 \end{tabular}
 \end{center}
-\caption{NAPOT Contiguous Translation Encodings}
+\caption{Page table entry encodings when $pte$.N=1}
 \label{ptenapot}
 \end{table*}
-
-The list of currently supported NAPOT PTE encodings and the definition of {\em
-napot\_bits} are shown in Table~\ref{ptenapot}.  Currently, NAPOT encodings are
-only supported for 4KiB leaf PTEs.
 
 \begin{commentary}
   Depending on need, the NAPOT scheme may be extended to other intermediate
   page sizes and/or to other levels of the page table in the future.  The
   encoding is designed to accommodate other NAPOT sizes should that need
-  arise.  For example, the addition of 16KiB and 256KiB support would look
-  as follows:
+  arise.  For example:
 
   \begin{center}\em
-  \begin{tabular}{|c|c||c|c|}
+  \begin{tabular}{|c|c||l|c|}
   \hline
-  N & $pte.ppn[i]$      & $pte.napot\_bits$ & Meaning if $i=0$         \\
+  i        & $pte.ppn[i]$      & Description                & $pte.napot\_bits$ \\
   \hline
-  0 & {\tt y~yyyy~yyyy} & 0                 &  Non-NAPOT 4KiB PTE      \\
-  1 & {\tt y~yyyy~yy10} & 2                 &  16KiB contiguous region \\
-  1 & {\tt y~yyyy~1000} & 4                 &  64KiB contiguous region \\
-  1 & {\tt y~yy10~0000} & 6                 &  256KiB contiguous region \\
-  1 & {\em other}       & $-$               &  {\em Reserved for future standard use} \\
+  0        & {\tt x~xxxx~xxx1} & 8 KiB contiguous region    & 1 \\
+  0        & {\tt x~xxxx~xx10} & 16 KiB contiguous region   & 2 \\
+  0        & {\tt x~xxxx~x100} & 32 KiB contiguous region   & 3 \\
+  0        & {\tt x~xxxx~1000} & 64 KiB contiguous region   & 4 \\
+  0        & {\tt x~xxx1~0000} & 128 KiB contiguous region  & 5 \\
+  ...      & ...               & ...                        & ... \\
+  1        & {\tt x~xxxx~xxx1} & 4 MiB contiguous region    & 1 \\
+  1        & {\tt x~xxxx~xx10} & 8 MiB contiguous region    & 2 \\
+  ...      & ...               & ...                        & ... \\
   \hline
-  \multicolumn{4}{l}{{\tt y}: subset of PPN used for address translation} \\
   \end{tabular}
   \end{center}
 
@@ -2200,9 +2200,9 @@ algorithm in Section~\ref{sv32algorithm}, except that:
   \item If the encoding in $pte$ is valid according to Table~\ref{ptenapot},
     then instead of returning the original value of $pte$, implicit reads of a
     NAPOT PTE return a copy of $pte$ in which $pte.ppn[pte.napot\_bits-1:0]$ is
-    replaced by $vpn[0][pte.napot\_bits-1:0]$
-  \item If the encoding in $pte$ is {\em reserved} according to
-    Table~\ref{ptenapot}, then a page-fault exception must be raised.
+    replaced by $vpn[i][pte.napot\_bits-1:0]$.  If the encoding in $pte$ is
+    {\em reserved} according to Table~\ref{ptenapot}, then a page-fault
+    exception must be raised.
   \item Implicit reads of NAPOT page table may create address-translation cache
     entries mapping $a + va.vpn[j] \times \textrm{PTESIZE}$ to a copy of $pte$
     in which $pte.ppn[pte.napot\_bits-1:0]$ is replaced by

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2210,7 +2210,7 @@ algorithm in Section~\ref{sv32algorithm}, except that:
     entries mapping $a + va.vpn[j] \times \textrm{PTESIZE}$ to a copy of $pte$
     in which $pte.ppn[pte.napot\_bits-1:0]$ is replaced by
     $vpn[0][pte.napot\_bits-1:0]$, for any or all $j$ such that
-    $j[9:napot\_bits]=i[9:napot\_bits]$, all for the address space identified
+    $j[8:napot\_bits]=i[8:napot\_bits]$, all for the address space identified
     in {\em satp} as loaded by step 0.
 \end{itemize}
 

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1748,9 +1748,10 @@ quickly distinguish user and supervisor address regions.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cY@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{ccY@{}Y@{}Y@{}Y@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbit{62} &
+\instbitrange{61}{54} &
 \instbitrange{53}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
@@ -1765,6 +1766,7 @@ quickly distinguish user and supervisor address regions.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{C} &
+\multicolumn{1}{c|}{N} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[2]} &
 \multicolumn{1}{c|}{PPN[1]} &
@@ -1779,7 +1781,7 @@ quickly distinguish user and supervisor address regions.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 1 & 8 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1798,24 +1800,29 @@ have the same meaning as for Sv32.
 
 \begin{table}[h]
 \begin{center}
-\begin{tabular}{|c||l|}
+\begin{tabular}{|c|c||l|}
 \hline
-C & Description \\
+C & N & Description \\
 \hline
-0 & The PTE follows standard address-translation rules \\
-1 & {\em Designated for custom use} \\
+0 & 0 & The PTE follows standard address-translation rules \\
+0 & 1 & The PTE follows the rules specified in the Svnapot extension \\
+1 & 0 & {\em Designated for custom use} \\
+1 & 1 & {\em Reserved for standard use} \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Meaning of PTE C bit in Sv39.}
+\caption{Meaning of PTE C and N bits in Sv39.}
 \label{tab:pte_cv_bits}
 \end{table}
 
-As shown in Table~\ref{tab:pte_cv_bits}, the C bit is used to indicate that a
-PTE uses a custom implementation-specific encoding in the remaining bits other
-than the V bit.
+The C and N bits are defined as shown in Table~\ref{tab:pte_cv_bits}.  The C
+bit is used to indicate that a PTE uses a custom implementation-specific
+encoding in the remaining bits other than the V bit.  The N bit indicates that
+the page represents a naturally-aligned power-of-two range of contiguous
+translations, as defined in the Svnapot extension in Chapter~\ref{svnapot}.
+Setting the C and N bits simultaneously is reserved for future standard use.
 
-Bits 62--54 are reserved
+Bits 61--54 are reserved
 for future standard use and must be zeroed by software for forward compatibility.
 If any of these bits are set, an access-fault exception is raised.
 
@@ -1922,9 +1929,10 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cF@{}F@{}F@{}F@{}F@{}Fcccccccc}
+\begin{tabular}{ccF@{}F@{}F@{}F@{}F@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbit{62} &
+\instbitrange{61}{54} &
 \instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
@@ -1940,6 +1948,7 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{C} &
+\multicolumn{1}{c|}{N} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[3]} &
 \multicolumn{1}{c|}{PPN[2]} &
@@ -1955,7 +1964,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 1 & 8 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -2061,9 +2070,10 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{c@{}Y@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{cc@{}F@{}F@{}F@{}F@{}F@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbit{62} &
+\instbitrange{61}{54} &
 \instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
@@ -2079,6 +2089,7 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{C} &
+\multicolumn{1}{c|}{N} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[3]} &
 \multicolumn{1}{c|}{PPN[2]} &
@@ -2094,7 +2105,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 8 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 1 & 8 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -2115,3 +2126,143 @@ insufficiently aligned.
 The algorithm for virtual-to-physical address translation is the same
 as in Section~\ref{sv32algorithm}, except LEVELS equals 5 and PTESIZE
 equals 8.
+
+\chapter{``Svnapot'' Standard Extension for NAPOT Translation Contiguity, Version 0.1}
+\label{svnapot}
+
+In Sv39, Sv48, and Sv57, when a PTE has C=0 and N=1, the PTE represents a
+translation that is part of a range of contiguous virtual-to-physical
+translations with the same values for PTE bits 5--0.  Such ranges must be of a
+naturally aligned power-of-2 (NAPOT) granularity larger than the base page
+size.
+
+\begin{commentary}
+  The motivation for a NAPOT PTE is that it can be cached in a TLB as one or
+  more entries representing the contiguous region as if it were a single
+  (large) page covered by a single translation.  This compaction can help
+  relieve TLB pressure in some scenarios.  The encoding is designed to fit
+  within the pre-existing Sv39, Sv48, and Sv57 PTE formats so as not to disrupt
+  existing implementations or designs that choose not to implement the scheme.
+  It is also designed so as not to complicate the definition of the
+  address-translation algorithm.
+\end{commentary}
+
+\begin{table*}[h!]
+\begin{center}
+\begin{tabular}{|c|c||c|c|}
+\hline
+N & $pte.ppn[i]$      & $pte.napot\_bits$ & Meaning if $i=0$         \\
+\hline
+0 & {\tt y~yyyy~yyyy} & 0                 &  Non-NAPOT 4KiB PTE      \\
+1 & {\tt y~yyyy~1000} & 4                 &  64KiB contiguous region \\
+1 & {\em other}       & $-$               &  {\em Reserved for standard use} \\
+\hline
+\multicolumn{4}{l}{{\tt y}: subset of PPN used for address translation} \\
+\end{tabular}
+\end{center}
+\caption{NAPOT Contiguous Translation Encodings}
+\label{ptenapot}
+\end{table*}
+
+The list of currently supported NAPOT PTE encodings and the definition of {\em
+napot\_bits} are shown in Table~\ref{ptenapot}.  Currently, NAPOT encodings are
+only supported for 4KiB leaf PTEs.
+
+\begin{commentary}
+  Depending on need, the NAPOT scheme may be extended to other intermediate
+  page sizes and/or to other levels of the page table in the future.  The
+  encoding is designed to accommodate other NAPOT sizes should that need
+  arise.  For example, the addition of 16KiB and 256KiB support would look
+  as follows:
+
+  \begin{center}\em
+  \begin{tabular}{|c|c||c|c|}
+  \hline
+  N & $pte.ppn[i]$      & $pte.napot\_bits$ & Meaning if $i=0$         \\
+  \hline
+  0 & {\tt y~yyyy~yyyy} & 0                 &  Non-NAPOT 4KiB PTE      \\
+  1 & {\tt y~yyyy~yy10} & 2                 &  16KiB contiguous region \\
+  1 & {\tt y~yyyy~1000} & 4                 &  64KiB contiguous region \\
+  1 & {\tt y~yy10~0000} & 6                 &  256KiB contiguous region \\
+  1 & {\em other}       & $-$               &  {\em Reserved for future standard use} \\
+  \hline
+  \multicolumn{4}{l}{{\tt y}: subset of PPN used for address translation} \\
+  \end{tabular}
+  \end{center}
+
+  In such a case, an implementation may or may not support all options, subject
+  to profile requirements.  The discoverability mechanism for this extension
+  would be extended to allow system software to determine which sizes are
+  supported.
+
+  Other sizes may remain deliberately excluded, so that PPN bits not being
+  used to indicate a valid NAPOT region size (e.g., the least-significant bit
+  of $pte.ppn[i]$) may be repurposed for other uses in the future.
+
+  However, in case finer-grained intermediate page size support prove not to
+  be useful, we have chosen to standardize only 64KiB support as a first step.
+\end{commentary}
+
+NAPOT PTEs behave just like non-NAPOT PTEs do within the address-translation
+algorithm in Section~\ref{sv32algorithm}, except that:
+\begin{itemize}
+  \item If the encoding in $pte$ is valid according to Table~\ref{ptenapot},
+    then instead of returning the original value of $pte$, implicit reads of a
+    NAPOT PTE return a copy of $pte$ in which $pte.ppn[pte.napot\_bits-1:0]$ is
+    replaced by $vpn[0][pte.napot\_bits-1:0]$
+  \item If the encoding in $pte$ is {\em reserved} according to
+    Table~\ref{ptenapot}, then a page-fault exception must be raised.
+  \item Implicit reads of NAPOT page table may create address-translation cache
+    entries mapping $a + va.vpn[j] \times \textrm{PTESIZE}$ to a copy of $pte$
+    in which $pte.ppn[pte.napot\_bits-1:0]$ is replaced by
+    $vpn[0][pte.napot\_bits-1:0]$, for any or all $j$ such that
+    $j[9:napot\_bits]=i[9:napot\_bits]$, all for the address space identified
+    in {\em satp} as loaded by step 0.
+\end{itemize}
+
+\begin{commentary}
+  This added step captures the behavior that would result from the creation
+  of a single TLB entry covering the entire NAPOT region.  It is also designed
+  to be consistent with implementations that support NAPOT PTEs by splitting
+  the NAPOT region into TLB entries covering any smaller power-of-two region
+  sizes.  For example, a 64KiB NAPOT PTE might trigger the creation of 16
+  standard 4KiB TLB entries, all with contents generated from the NAPOT PTE
+  (even if the PTEs for the other 4KiB regions have different contents).
+
+  In typical usage scenarios, NAPOT PTEs in the same region will have the same
+  attributes, same PPNs, and same values for bits 5--0.  RSW remains reserved
+  for supervisor software control.  It is the responsibility of the OS and/or
+  hypervisor to configure the page tables in such a way that there are no
+  inconsistencies between NAPOT PTEs and other NAPOT or non-NAPOT PTEs that
+  overlap the same address range.  If an update needs to be made, the OS
+  generally should first mark all of the PTEs invalid, then issue SFENCE.VMA
+  instruction(s) covering all 4KiB regions within the range (either via a
+  single SFENCE.VMA with {\em rs1}={\tt x0}, or with multiple SFENCE.VMA
+  instructions with {\em rs1}$\neq${\tt x0}), then update the PTE(s), as
+  described in Section~\ref{sec:sfence.vma}, unless any inconsistencies are
+  known to be benign.  If any inconsistencies do exist, then the effect is the
+  same as when SFENCE.VMA is used incorrectly: one of the translations will be
+  chosen, but the choice is unpredictable.
+
+  When updating a region of NAPOT PTEs all at once, it is recommended that
+  software continue to follow the idiom in Figure~\ref{consecutive_sfences}
+  in which no more than one add and one branch instruction is inserted between
+  consecutive SFENCE.VMA instructions.
+
+  If an implementation chooses to use a NAPOT PTE (or cached version thereof),
+  it might not consult the PTE directly specified by the algorithm in
+  Section~\ref{sv32algorithm} at all.  Therefore, the D and A bits may not be
+  identical across all mappings of the same address range even in typical use
+  cases  The operating system must query all NAPOT aliases of a page to
+  determine whether that page has been accessed and/or is dirty.  If the OS
+  manually sets the A and/or D bits for a page, it is recommended that the OS
+  also set the A and/or D bits for other NAPOT aliases as appropriate in order
+  to avoid unnecessary traps.
+
+  Just as with normal PTEs, TLBs are permitted to cache NAPOT PTEs whose V
+  (Valid) bit is clear.
+
+  Invalid NAPOT encodings were chosen to raise page-fault exceptions rather
+  than access-fault exceptions in order to match the behavior of misaligned
+  superpages.
+\end{commentary}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1814,27 +1814,26 @@ have the same meaning as for Sv32.
 
 \begin{table}[h]
 \begin{center}
-\begin{tabular}{|c|c||l|}
+\begin{tabular}{|c||l|}
 \hline
-C & N & Description \\
+C & Description \\
 \hline
-0 & 0 & The PTE follows standard address-translation rules \\
-0 & 1 & The PTE follows the rules specified in the Svnapot extension \\
-1 & 0 & {\em Designated for custom use} \\
-1 & 1 & {\em Reserved for standard use} \\
+0 & The PTE follows standard address-translation rules \\
+1 & {\em Designated for custom use} \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Meaning of PTE C and N bits in Sv39.}
+\caption{Meaning of PTE C bit in Sv39.}
 \label{tab:pte_cv_bits}
 \end{table}
 
-The C and N bits are defined as shown in Table~\ref{tab:pte_cv_bits}.  The C
-bit is used to indicate that a PTE uses a custom implementation-specific
-encoding in the remaining bits other than the V bit.  The N bit indicates that
-the page represents a naturally-aligned power-of-two range of contiguous
-translations, as defined in the Svnapot extension in Chapter~\ref{svnapot}.
-Setting the C and N bits simultaneously is reserved for future standard use.
+As shown in Table~\ref{tab:pte_cv_bits}, the C bit is used to indicate that a
+PTE uses a custom implementation-specific encoding in the remaining bits other
+than the V bit.
+
+If the C bit is not set, the N bit indicates that the page represents a
+naturally-aligned power-of-two range of contiguous translations, as defined in
+the Svnapot extension in Chapter~\ref{svnapot}.
 
 Bits 61--54 are reserved
 for future standard use and must be zeroed by software for forward compatibility.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2127,17 +2127,6 @@ translations with the same values for PTE bits 5--0.  Such ranges must be of a
 naturally aligned power-of-2 (NAPOT) granularity larger than the base page
 size.
 
-\begin{commentary}
-  The motivation for a NAPOT PTE is that it can be cached in a TLB as one or
-  more entries representing the contiguous region as if it were a single
-  (large) page covered by a single translation.  This compaction can help
-  relieve TLB pressure in some scenarios.  The encoding is designed to fit
-  within the pre-existing Sv39, Sv48, and Sv57 PTE formats so as not to disrupt
-  existing implementations or designs that choose not to implement the scheme.
-  It is also designed so as not to complicate the definition of the
-  address-translation algorithm.
-\end{commentary}
-
 \begin{table*}[h!]
 \begin{center}
 \begin{tabular}{|c|c||l|c|}
@@ -2157,62 +2146,34 @@ $\geq 1$ & {\tt x~xxxx~xxxx} & {\em Reserved}           & $-$ \\
 \label{ptenapot}
 \end{table*}
 
-\begin{commentary}
-  Depending on need, the NAPOT scheme may be extended to other intermediate
-  page sizes and/or to other levels of the page table in the future.  The
-  encoding is designed to accommodate other NAPOT sizes should that need
-  arise.  For example:
-
-  \begin{center}\em
-  \begin{tabular}{|c|c||l|c|}
-  \hline
-  i        & $pte.ppn[i]$      & Description                & $pte.napot\_bits$ \\
-  \hline
-  0        & {\tt x~xxxx~xxx1} & 8 KiB contiguous region    & 1 \\
-  0        & {\tt x~xxxx~xx10} & 16 KiB contiguous region   & 2 \\
-  0        & {\tt x~xxxx~x100} & 32 KiB contiguous region   & 3 \\
-  0        & {\tt x~xxxx~1000} & 64 KiB contiguous region   & 4 \\
-  0        & {\tt x~xxx1~0000} & 128 KiB contiguous region  & 5 \\
-  ...      & ...               & ...                        & ... \\
-  1        & {\tt x~xxxx~xxx1} & 4 MiB contiguous region    & 1 \\
-  1        & {\tt x~xxxx~xx10} & 8 MiB contiguous region    & 2 \\
-  ...      & ...               & ...                        & ... \\
-  \hline
-  \end{tabular}
-  \end{center}
-
-  In such a case, an implementation may or may not support all options, subject
-  to profile requirements.  The discoverability mechanism for this extension
-  would be extended to allow system software to determine which sizes are
-  supported.
-
-  Other sizes may remain deliberately excluded, so that PPN bits not being
-  used to indicate a valid NAPOT region size (e.g., the least-significant bit
-  of $pte.ppn[i]$) may be repurposed for other uses in the future.
-
-  However, in case finer-grained intermediate page size support prove not to
-  be useful, we have chosen to standardize only 64KiB support as a first step.
-\end{commentary}
-
-NAPOT PTEs behave just like non-NAPOT PTEs do within the address-translation
+NAPOT PTEs behave identically to non-NAPOT PTEs within the address-translation
 algorithm in Section~\ref{sv32algorithm}, except that:
 \begin{itemize}
   \item If the encoding in $pte$ is valid according to Table~\ref{ptenapot},
     then instead of returning the original value of $pte$, implicit reads of a
     NAPOT PTE return a copy of $pte$ in which $pte.ppn[pte.napot\_bits-1:0]$ is
     replaced by $vpn[i][pte.napot\_bits-1:0]$.  If the encoding in $pte$ is
-    {\em reserved} according to Table~\ref{ptenapot}, then a page-fault
-    exception must be raised.
+    reserved according to Table~\ref{ptenapot}, then a page-fault exception
+    must be raised.
   \item Implicit reads of NAPOT page table entries may create address-translation cache
     entries mapping $a + va.vpn[j] \times \textrm{PTESIZE}$ to a copy of $pte$
     in which $pte.ppn[pte.napot\_bits-1:0]$ is replaced by
     $vpn[0][pte.napot\_bits-1:0]$, for any or all $j$ such that
-    $j[8:napot\_bits]=i[8:napot\_bits]$, all for the address space identified
+    ${j[8:napot\_bits]}={i[8:napot\_bits]}$, all for the address space identified
     in {\em satp} as loaded by step 0.
 \end{itemize}
 
 \begin{commentary}
-  This added step captures the behavior that would result from the creation
+  The motivation for a NAPOT PTE is that it can be cached in a TLB as one or
+  more entries representing the contiguous region as if it were a single
+  (large) page covered by a single translation.  This compaction can help
+  relieve TLB pressure in some scenarios.  The encoding is designed to fit
+  within the pre-existing Sv39, Sv48, and Sv57 PTE formats so as not to disrupt
+  existing implementations or designs that choose not to implement the scheme.
+  It is also designed so as not to complicate the definition of the
+  address-translation algorithm.
+
+  The address translation cache abstraction captures the behavior that would result from the creation
   of a single TLB entry covering the entire NAPOT region.  It is also designed
   to be consistent with implementations that support NAPOT PTEs by splitting
   the NAPOT region into TLB entries covering any smaller power-of-two region
@@ -2252,4 +2213,38 @@ algorithm in Section~\ref{sv32algorithm}, except that:
 
   Just as with normal PTEs, TLBs are permitted to cache NAPOT PTEs whose V
   (Valid) bit is clear.
+
+  Depending on need, the NAPOT scheme may be extended to other intermediate
+  page sizes and/or to other levels of the page table in the future.  The
+  encoding is designed to accommodate other NAPOT sizes should that need
+  arise.  For example:
+
+  \begin{center}\em
+  \begin{tabular}{|c|c||l|c|}
+  \hline
+  i        & $pte.ppn[i]$      & Description                & $pte.napot\_bits$ \\
+  \hline
+  0        & {\tt x~xxxx~xxx1} & 8 KiB contiguous region    & 1 \\
+  0        & {\tt x~xxxx~xx10} & 16 KiB contiguous region   & 2 \\
+  0        & {\tt x~xxxx~x100} & 32 KiB contiguous region   & 3 \\
+  0        & {\tt x~xxxx~1000} & 64 KiB contiguous region   & 4 \\
+  0        & {\tt x~xxx1~0000} & 128 KiB contiguous region  & 5 \\
+  ...      & ...               & ...                        & ... \\
+  1        & {\tt x~xxxx~xxx1} & 4 MiB contiguous region    & 1 \\
+  1        & {\tt x~xxxx~xx10} & 8 MiB contiguous region    & 2 \\
+  ...      & ...               & ...                        & ... \\
+  \hline
+  \end{tabular}
+  \end{center}
+
+  In such a case, an implementation may or may not support all options.  The
+  discoverability mechanism for this extension would be extended to allow
+  system software to determine which sizes are supported.
+
+  Other sizes may remain deliberately excluded, so that PPN bits not being
+  used to indicate a valid NAPOT region size (e.g., the least-significant bit
+  of $pte.ppn[i]$) may be repurposed for other uses in the future.
+
+  However, in case finer-grained intermediate page size support proves not to
+  be useful, we have chosen to standardize only 64KiB support as a first step.
 \end{commentary}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1284,7 +1284,7 @@ to the number of physical address bits found in the implementation.
 
 \begin{commentary}
 For example, consider an RV32 system supporting 34 bits of physical
-address.  When the value of {\tt satp}.MODE us Sv32, a 34-bit physical
+address.  When the value of {\tt satp}.MODE is Sv32, a 34-bit physical
 address is produced directly, and therefore no zero-extension is needed.
 When the value of {\tt satp}.MODE is Bare, the 32-bit virtual address is
 translated (unmodified) into a 32-bit physical address, and then that
@@ -2276,6 +2276,7 @@ algorithm in Section~\ref{sv32algorithm}, except that:
   (Valid) bit is clear.
 
   Invalid NAPOT encodings were chosen to raise page-fault exceptions rather
-  than access-fault exceptions in order to match the behavior of misaligned
-  superpages.
+  than access-fault exceptions, following the convention that invalid PTE
+  configurations result in page-faults exceptions, while invalid access
+  types or accesses to invalid physical memory regions trigger page faults.
 \end{commentary}


### PR DESCRIPTION
This PR contains the Svnapot extension (formerly named Zsn) extension being developed by the RISC-V Virtual Memory Task Group.

This was previously part of #611, but we decided to separate it out into its own PR so that the Svnapot ratification timeline doesn't block the other assorted changes in #611.

This branch is still built off of #611, and therefore I'm creating this as a PR into #611 rather than master in order to highlight the Svnapot extension itself.  I can handle any conflicts with master later when it actually comes time to merge this.