### PR TITLE
Clarify that AMOs use the original address when rd == rs1

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -435,7 +435,7 @@ are encoded with an R-type instruction format.  These AMO instructions
 atomically load a data value from the address in {\em rs1}, place the
 value into register {\em rd}, apply a binary operator to the loaded
 value and the original value in {\em rs2}, then store the result back
-to the address in {\em rs1}. AMOs can either operate on 64-bit (RV64
+to the original address in {\em rs1}. AMOs can either operate on 64-bit (RV64
 only) or 32-bit words in memory.  For RV64, 32-bit AMOs always
 sign-extend the value placed in {\em rd}, and ignore the upper 32 bits
 of the original value of {\em rs2}.


### PR DESCRIPTION
Currently due to the sequential description in use it technically says that you should use the just-loaded value in that case, when that is of course not what's intended, nor what implementations do.
