### PR TITLE
SUM should be hardwired to 0 for cores without paging

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -719,7 +719,7 @@ in Figure~\ref{sv32pte}) will fault.  When SUM=1, these accesses are
 permitted.  SUM has no effect when page-based virtual memory is not in effect.
 Note that, while SUM is ordinarily ignored when not executing in S-mode, it
 {\em is} in effect when MPRV=1 and MPP=S.  SUM is hardwired to 0 if S-mode is
-not supported.
+not supported or if {\tt satp}.MODE is hardwired to 0.
 
 The MXR and SUM mechanisms only affect the interpretation of permissions
 encoded in page-table entries.  In particular, they have no impact on whether

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -216,6 +216,8 @@ SUM has no effect when page-based virtual memory is not in effect, nor when
 executing in U-mode.  Note that S-mode can never execute instructions from user
 pages, regardless of the state of SUM.
 
+SUM is hardwired to 0 if {\tt satp}.MODE is hardwired to 0.
+
 \begin{commentary}
 The SUM mechanism prevents supervisor software from inadvertently accessing
 user memory.  Operating systems can execute the majority of code with SUM clear;


### PR DESCRIPTION
Note that this change does not consider the forthcoming sPMP proposal.  We'll have to update the text to say that SUM should be hardwired to 0 if satp.MODE is hardwired to 0 and sPMP is not provided.

I proposed similar wording in the sPMP proposal: https://docs.google.com/document/d/1x7esOSBFfpcbDHaRPpe5NEWmav1_8der_nB25Hd5hqs/edit#
