### PR TITLE
Travis CI: Update build environment to Ubuntu 20.04 Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: focal
 before_install:
   - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: focal
 before_install:
   - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended


### PR DESCRIPTION
Updates the Travis CI build environment from Ubuntu 14.04 (Trusty Tahr), which is end-of-life, to to Ubuntu 20.04 (Focal Fossa).

Please also note that [travis-ci.org](https://travis-ci.org/) will be shutting down. See [Migrating repositories to travis-ci.com](https://docs.travis-ci.com/user/migrate/open-source-repository-migration).