### PR TITLE
Add Zfinx spec

### DIFF
--- a/src/riscv-spec.tex
+++ b/src/riscv-spec.tex
@@ -97,6 +97,7 @@ Andrew Waterman and Krste Asanovi\'{c}, RISC-V Foundation, \specmonthyear.
 \input{p}
 \input{v}
 \input{zam}
+\input{zfinx}
 \input{ztso}
 \input{gmaps}
 \input{extensions}

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -16,6 +16,7 @@ minimal implementation cost.
 By eliminating the {\tt f} registers, the Zfinx extension substantially
 reduces the cost of simple RISC-V implementations with floating-point
 instruction-set support.
+Zfinx also reduces context-switch effort.
 
 Unlike most RISC-V extensions, the addition of Zfinx is not backwards
 compatible: software that uses floating-point instructions but assumes the

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -100,6 +100,7 @@ Register moves need only a single FSGNJ.D instruction, however.
 \section{Zqinx}
 
 The Zqinx extension is defined analogously to the Zdinx extension.
+The Zqinx extension requires the Zdinx extension.
 For RV64, quad-precision operands require two-register alignment.
 For RV32, quad-precision operands require four-register alignment.
 

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -56,6 +56,20 @@ We retain the NaN-boxing of results to keep Zfinx as similar as possible and
 to ease debugging.
 \end{commentary}
 
+\section{Zhinx}
+
+The Zhinx extension provides analogous half-precision floating-point
+instructions.
+The Zhinx extension requires the Zfinx extension.
+
+The Zhinx extension adds all of the instructions that the Zfh extension
+adds, {\em except} for the transfer instructions FLH, FSH, FMV.H.X,
+and FMV.X.H.
+
+The Zhinx variants of these Zfh-extension instructions have the same semantics,
+except that whenever such an instruction would have accessed an {\tt f}
+register, it instead accesses the {\tt x} register with the same number.
+
 \section{Zdinx}
 
 The Zdinx extension provides analogous double-precision floating-point

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -85,7 +85,10 @@ bits, and the higher-numbered register holds the high-order bits: e.g., bits
 
 When a double-width floating-point result is written to {\tt x0}, the entire
 write takes no effect: e.g., for RV32Zdinx, writing a double-precision result
-to {\tt x0} preserves the contents of {\tt x1}.
+to {\tt x0} does not cause {\tt x1} to be written.
+
+When {\tt x0} is used as a double-width floating-point operand, the entire
+operand is zero---i.e., {\tt x1} is not accessed.
 
 \begin{commentary}
 Load-pair and store-pair instructions are not provided, so transferring

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -112,7 +112,7 @@ Register moves need only a single FSGNJ.D instruction, however.
 \end{commentary}
 
 \begin{commentary}
-In future, an RV64Zqinx quad-precision extension could be defined analogously
+In the future, an RV64Zqinx quad-precision extension could be defined analogously
 to RV32Zdinx.
 An RV32Zqinx extension could also be defined but would require
 quad-register groups.

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -106,3 +106,11 @@ In the standard privileged architecture defined in Volume II, the
 {\tt mstatus} field FS is hardwired to 0 if the Zfinx extension is
 implemented, and FS no longer affects the trapping behavior of
 floating-point instructions or {\tt fcsr} accesses.
+
+The {\tt misa} bits F, D, and Q are hardwired to 0 when the Zfinx
+extension is implemented.
+
+\begin{commentary}
+A future discoverability mechanism might be used to probe the existence
+of the Zfinx, Zhinx, Zdinx, and Zqinx extensions.
+\end{commentary}

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -130,5 +130,5 @@ extension is implemented.
 
 \begin{commentary}
 A future discoverability mechanism might be used to probe the existence
-of the Zfinx, Zhinx, Zdinx, and Zqinx extensions.
+of the Zfinx, Zhinx, and Zdinx extensions.
 \end{commentary}

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -112,12 +112,12 @@ two loads or stores.
 Register moves need only a single FSGNJ.D instruction, however.
 \end{commentary}
 
-\section{Zqinx}
-
-The Zqinx extension is defined analogously to the Zdinx extension.
-The Zqinx extension requires the Zdinx extension.
-For RV64, quad-precision operands require two-register alignment.
-For RV32, quad-precision operands require four-register alignment.
+\begin{commentary}
+In future, an RV64Zqinx quad-precision extension could be defined analogously
+to RV32Zdinx.
+An RV32Zqinx extension could also be defined but would require
+quad-register groups.
+\end{commentary}
 
 \section{Privileged Architecture Implications}
 

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -1,4 +1,4 @@
-\chapter{``Zfinx'' Standard Extension for Floating-Point in Integer Registers, Version 0.1}
+\chapter{``Zfinx'' Standard Extension for Floating-Point in Integer Registers, Version 0.41}
 \label{sec:zfinx}
 
 This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x''), which

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -16,12 +16,11 @@ minimal implementation cost.
 By eliminating the {\tt f} registers, the Zfinx extension substantially
 reduces the cost of simple RISC-V implementations with floating-point
 instruction-set support.
-Zfinx also reduces context-switch effort.
+Zfinx also reduces context-switch cost.
 
-Unlike most RISC-V extensions, the addition of Zfinx is not backwards
-compatible: software that uses floating-point instructions but assumes the
-absence of the Zfinx extension will not, in general, execute correctly on
-implementations with the Zfinx extension.
+In general, software that assumes the presence of the F extension
+is incompatible with software that assumes the presence of the Zfinx
+extension, and vice versa.
 \end{commentary}
 
 The Zfinx extension adds all of the instructions that the F extension

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -70,6 +70,17 @@ The Zhinx variants of these Zfh-extension instructions have the same semantics,
 except that whenever such an instruction would have accessed an {\tt f}
 register, it instead accesses the {\tt x} register with the same number.
 
+\section{Zhinxmin}
+
+The Zhinxmin extension provides minimal support for 16-bit half-precision
+floating-point instructions that operate on the {\tt x} registers.
+The Zhinxmin extension requires the Zfinx extension.
+
+The Zhinxmin extension includes the following instructions from the Zhinx
+extension: FCVT.S.H and FCVT.H.S.
+If the Zdinx extension is present, the FCVT.D.H and FCVT.H.D instructions are
+also included.
+
 \section{Zdinx}
 
 The Zdinx extension provides analogous double-precision floating-point

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -1,14 +1,17 @@
-\chapter{``Zfinx'' Standard Extension for Floating-Point in Integer Registers, Version 0.41}
+\chapter{``Zfinx'', ``Zdinx'', ``Zhinx'', ``Zhinxmin'': Standard Extensions for Floating-Point in Integer Registers, Version 0.41}
 \label{sec:zfinx}
 
-This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x''), which
-provides instructions similar to those in the standard floating-point
-extensions, but that operate on the {\tt x} registers instead of the {\tt f}
-registers.
+This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x'')
+that provides instructions similar to those in the standard
+floating-point F extension for single-precision floating-point
+instructions but which operate on the {\tt x} registers instead of the
+{\tt f} registers.  This chapter also defines the ``Zdinx'',
+``Zhinx'', and ``Zhinxmin'' extensions that provide similar
+instructions for other floating-point precisions.
 
 \begin{commentary}
 The F extension uses separate {\tt f} registers for floating-point
-computation, to reduce register pressure and simplifies the provision of
+computation, to reduce register pressure and simplify the provision of
 register-file ports for wide superscalars.
 However, the additional \wunits{128}{B} of architectural state increases the
 minimal implementation cost.
@@ -55,31 +58,6 @@ We retain the NaN-boxing of results to keep Zfinx as similar as possible and
 to ease debugging.
 \end{commentary}
 
-\section{Zhinx}
-
-The Zhinx extension provides analogous half-precision floating-point
-instructions.
-The Zhinx extension requires the Zfinx extension.
-
-The Zhinx extension adds all of the instructions that the Zfh extension
-adds, {\em except} for the transfer instructions FLH, FSH, FMV.H.X,
-and FMV.X.H.
-
-The Zhinx variants of these Zfh-extension instructions have the same semantics,
-except that whenever such an instruction would have accessed an {\tt f}
-register, it instead accesses the {\tt x} register with the same number.
-
-\section{Zhinxmin}
-
-The Zhinxmin extension provides minimal support for 16-bit half-precision
-floating-point instructions that operate on the {\tt x} registers.
-The Zhinxmin extension requires the Zfinx extension.
-
-The Zhinxmin extension includes the following instructions from the Zhinx
-extension: FCVT.S.H and FCVT.H.S.
-If the Zdinx extension is present, the FCVT.D.H and FCVT.H.D instructions are
-also included.
-
 \section{Zdinx}
 
 The Zdinx extension provides analogous double-precision floating-point
@@ -120,6 +98,31 @@ double-precision operands in RV32Zdinx from or to memory requires
 two loads or stores.
 Register moves need only a single FSGNJ.D instruction, however.
 \end{commentary}
+
+\section{Zhinx}
+
+The Zhinx extension provides analogous half-precision floating-point
+instructions.
+The Zhinx extension requires the Zfinx extension.
+
+The Zhinx extension adds all of the instructions that the Zfh extension
+adds, {\em except} for the transfer instructions FLH, FSH, FMV.H.X,
+and FMV.X.H.
+
+The Zhinx variants of these Zfh-extension instructions have the same semantics,
+except that whenever such an instruction would have accessed an {\tt f}
+register, it instead accesses the {\tt x} register with the same number.
+
+\section{Zhinxmin}
+
+The Zhinxmin extension provides minimal support for 16-bit half-precision
+floating-point instructions that operate on the {\tt x} registers.
+The Zhinxmin extension requires the Zfinx extension.
+
+The Zhinxmin extension includes the following instructions from the Zhinx
+extension: FCVT.S.H and FCVT.H.S.
+If the Zdinx extension is present, the FCVT.D.H and FCVT.H.D instructions are
+also included.
 
 \begin{commentary}
 In the future, an RV64Zqinx quad-precision extension could be defined analogously

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -1,0 +1,90 @@
+\chapter{``Zfinx'' Standard Extension for Floating-Point in Integer Registers, Version 0.1}
+\label{sec:zfinx}
+
+This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x''), which
+redefines the instructions in the standard floating-point extensions
+(including F, D, Q, and Zfh) to operate on the {\tt x} registers, rather than
+the {\tt f} registers.
+The Zfinx extension depends on the F extension.
+
+\begin{commentary}
+The baseline F extension uses separate {\tt f} registers for floating-point
+computation.
+This design reduces register pressure and simplifies the provision of
+register-file ports for wide superscalars.
+However, the additional \wunits{128}{B} of architectural state increases the
+minimal implementation cost.
+By eliminating the {\tt f} registers, the Zfinx extension substantially
+reduces the cost of simple RISC-V implementations.
+
+Unlike most RISC-V extensions, the addition of Zfinx is not backwards
+compatible: software that uses floating-point instructions but assumes the
+absence of the Zfinx extension will not, in general, execute correctly on
+implementations with the Zfinx extension.
+\end{commentary}
+
+The Zfinx extension {\em removes} the floating-point load, store, and
+integer-transfer instructions (FL[HWDQ], FS[HWDQ], FMV.[HWDQ].X and
+FMV.X.[HWDQ]) and corresponding C-extension instructions (C.FL[WD],
+C.FL[WD]SP, C.FS[WD], C.FS[WD]SP).
+The opcodes corresponding to the removed instructions are {\em reserved}.
+
+\begin{commentary}
+Zfinx software uses integer loads and stores to transfer floating-point values
+from and to memory.
+Transfers between registers use either integer arithmetic or floating-point
+sign-injection instructions.
+\end{commentary}
+
+The Zfinx extension {\em redefines} all instructions that access {\tt f}
+registers to instead access the {\tt x} register with the same number.
+
+In the standard privileged architecture defined in Volume II, the
+{\tt mstatus} field FS is hardwired to 0 if the Zfinx extension is
+implemented, and FS no longer affects the trapping behavior of
+floating-point instructions or {\tt fcsr} accesses.
+
+\section{NaN Boxing of Narrower Values}
+
+Floating-point operands of width \mbox{{\em w} $<$ XLEN bits} occupy bits
+\mbox{{\em w}-1:0} of an {\tt x} register.
+Floating-point operations on {\em w}-bit operands ignore operand bits
+\mbox{XLEN-1:{\em w}}.
+
+Floating-point operations that produce \mbox{{\em w} $<$ XLEN-bit} results
+fill bits \mbox{XLEN-1:{\em w}} of the result with ones.
+
+\begin{commentary}
+To avoid the need for dedicated floating-point load instructions that fill the
+MSBs of an {\tt x} register with ones, we abandon the usual NaN-boxing
+requirement for floating-point operands.
+We retain the NaN-boxing of results to keep Zfinx as similar as possible and
+to ease debugging.
+\end{commentary}
+
+\section{Processing of Wider Values}
+
+Double-precision operands in RV32DZfinx and quad-precision operands
+in RV64QZfinx are held in aligned {\tt x}-register pairs, i.e.,
+register numbers must be even.
+Use of misaligned (odd-numbered) registers for double-width floating-point
+operands is {\em reserved}.
+
+Regardless of endianness, the lower-numbered register holds the low-order
+bits, and the higher-numbered register holds the high-order bits: e.g., bits
+31:0 of a double-precision operand in RV32DZfinx might be held in register
+{\tt x14}, with bits 63:32 of that operand held in {\tt x15}.
+
+When a double-width floating-point result is written to {\tt x0}, the entire
+write takes no effect: e.g., for RV32DZfinx, writing a double-precision result
+to {\tt x0} preserves the contents of {\tt x1}.
+
+\begin{commentary}
+Load-pair and store-pair instructions are not provided, so transferring
+double-precision operands in RV32DZfinx from or to memory requires
+two loads or stores.
+Register moves need only a single FSGNJ.D instruction, however.
+\end{commentary}
+
+Quad-precision operands in RV32QZfinx are handled analogously, with
+a four-register alignment requirement.

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -7,9 +7,8 @@ extensions, but that operate on the {\tt x} registers instead of the {\tt f}
 registers.
 
 \begin{commentary}
-The baseline F extension uses separate {\tt f} registers for floating-point
-computation.
-This design reduces register pressure and simplifies the provision of
+The F extension uses separate {\tt f} registers for floating-point
+computation, to reduce register pressure and simplifies the provision of
 register-file ports for wide superscalars.
 However, the additional \wunits{128}{B} of architectural state increases the
 minimal implementation cost.

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -1,5 +1,10 @@
-\chapter{``Zfinx'', ``Zdinx'', ``Zhinx'', ``Zhinxmin'': Standard Extensions for Floating-Point in Integer Registers, Version 0.41}
+\chapter{``Zfinx'', ``Zdinx'', ``Zhinx'', ``Zhinxmin'': Standard Extensions for Floating-Point in Integer Registers, Version 1.0.0-rc}
 \label{sec:zfinx}
+
+This document is in the Frozen state. Change is extremely unlikely. A high threshold will be used, 
+and a change will only occur because of some truly critical issue being identified during the 
+public review cycle. Any other desired or needed changes can be the subject of a follow-on 
+new extension. For more info see: http://riscv.org/spec-state.
 
 This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x'')
 that provides instructions similar to those in the standard

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -40,7 +40,7 @@ The Zfinx variants of these F-extension instructions have the same semantics,
 except that whenever such an instruction would have accessed an {\tt f}
 register, it instead accesses the {\tt x} register with the same number.
 
-\section{NaN Boxing of Narrower Values}
+\section{Processing of Narrower Values}
 
 Floating-point operands of width \mbox{{\em w} $<$ XLEN bits} occupy bits
 \mbox{{\em w}-1:0} of an {\tt x} register.
@@ -48,14 +48,21 @@ Floating-point operations on {\em w}-bit operands ignore operand bits
 \mbox{XLEN-1:{\em w}}.
 
 Floating-point operations that produce \mbox{{\em w} $<$ XLEN-bit} results
-fill bits \mbox{XLEN-1:{\em w}} of the result with ones.
+fill bits \mbox{XLEN-1:{\em w}} with copies of bit \mbox{{\em w}-1} (the
+sign bit).
 
 \begin{commentary}
-To avoid the need for dedicated floating-point load instructions that fill the
-MSBs of an {\tt x} register with ones, we abandon the usual NaN-boxing
-requirement for floating-point operands.
-We retain the NaN-boxing of results to keep Zfinx as similar as possible and
-to ease debugging.
+The NaN-boxing scheme employed in the {\tt f} registers was designed to
+efficiently support recoded floating-point formats.
+Recoding is less practical for Zfinx, though, since the same registers
+hold both floating-point and integer operands.
+Hence, the need for NaN boxing is diminished.
+
+Sign-extending 32-bit floating-point numbers when held in RV64 {\tt x}
+registers matches the existing RV64 calling conventions, which require all
+32-bit types to be sign-extended when passed or returned in {\tt x} registers.
+To keep the architecture more regular, we extend this pattern to 16-bit
+floating-point numbers in both RV32 and RV64.
 \end{commentary}
 
 \section{Zdinx}

--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -2,10 +2,9 @@
 \label{sec:zfinx}
 
 This chapter defines the ``Zfinx'' extension (pronounced ``z-f-in-x''), which
-redefines the instructions in the standard floating-point extensions
-(including F, D, Q, and Zfh) to operate on the {\tt x} registers, rather than
-the {\tt f} registers.
-The Zfinx extension depends on the F extension.
+provides instructions similar to those in the standard floating-point
+extensions, but that operate on the {\tt x} registers instead of the {\tt f}
+registers.
 
 \begin{commentary}
 The baseline F extension uses separate {\tt f} registers for floating-point
@@ -15,7 +14,8 @@ register-file ports for wide superscalars.
 However, the additional \wunits{128}{B} of architectural state increases the
 minimal implementation cost.
 By eliminating the {\tt f} registers, the Zfinx extension substantially
-reduces the cost of simple RISC-V implementations.
+reduces the cost of simple RISC-V implementations with floating-point
+instruction-set support.
 
 Unlike most RISC-V extensions, the addition of Zfinx is not backwards
 compatible: software that uses floating-point instructions but assumes the
@@ -23,11 +23,9 @@ absence of the Zfinx extension will not, in general, execute correctly on
 implementations with the Zfinx extension.
 \end{commentary}
 
-The Zfinx extension {\em removes} the floating-point load, store, and
-integer-transfer instructions (FL[HWDQ], FS[HWDQ], FMV.[HWDQ].X and
-FMV.X.[HWDQ]) and corresponding C-extension instructions (C.FL[WD],
-C.FL[WD]SP, C.FS[WD], C.FS[WD]SP).
-The opcodes corresponding to the removed instructions are {\em reserved}.
+The Zfinx extension adds all of the instructions that the F extension
+adds, {\em except} for the transfer instructions FLW, FSW, FMV.W.X,
+FMV.X.W, C.FLW[SP], and C.FSW[SP].
 
 \begin{commentary}
 Zfinx software uses integer loads and stores to transfer floating-point values
@@ -36,13 +34,9 @@ Transfers between registers use either integer arithmetic or floating-point
 sign-injection instructions.
 \end{commentary}
 
-The Zfinx extension {\em redefines} all instructions that access {\tt f}
-registers to instead access the {\tt x} register with the same number.
-
-In the standard privileged architecture defined in Volume II, the
-{\tt mstatus} field FS is hardwired to 0 if the Zfinx extension is
-implemented, and FS no longer affects the trapping behavior of
-floating-point instructions or {\tt fcsr} accesses.
+The Zfinx variants of these F-extension instructions have the same semantics,
+except that whenever such an instruction would have accessed an {\tt f}
+register, it instead accesses the {\tt x} register with the same number.
 
 \section{NaN Boxing of Narrower Values}
 
@@ -62,29 +56,53 @@ We retain the NaN-boxing of results to keep Zfinx as similar as possible and
 to ease debugging.
 \end{commentary}
 
+\section{Zdinx}
+
+The Zdinx extension provides analogous double-precision floating-point
+instructions.
+The Zdinx extension requires the Zfinx extension.
+
+The Zdinx extension adds all of the instructions that the D extension
+adds, {\em except} for the transfer instructions FLD, FSD, FMV.D.X,
+FMV.X.D, C.FLD[SP], and C.FSD[SP].
+
+The Zdinx variants of these D-extension instructions have the same semantics,
+except that whenever such an instruction would have accessed an {\tt f}
+register, it instead accesses the {\tt x} register with the same number.
+
 \section{Processing of Wider Values}
 
-Double-precision operands in RV32DZfinx and quad-precision operands
-in RV64QZfinx are held in aligned {\tt x}-register pairs, i.e.,
+Double-precision operands in RV32Zdinx
+are held in aligned {\tt x}-register pairs, i.e.,
 register numbers must be even.
 Use of misaligned (odd-numbered) registers for double-width floating-point
 operands is {\em reserved}.
 
 Regardless of endianness, the lower-numbered register holds the low-order
 bits, and the higher-numbered register holds the high-order bits: e.g., bits
-31:0 of a double-precision operand in RV32DZfinx might be held in register
+31:0 of a double-precision operand in RV32Zdinx might be held in register
 {\tt x14}, with bits 63:32 of that operand held in {\tt x15}.
 
 When a double-width floating-point result is written to {\tt x0}, the entire
-write takes no effect: e.g., for RV32DZfinx, writing a double-precision result
+write takes no effect: e.g., for RV32Zdinx, writing a double-precision result
 to {\tt x0} preserves the contents of {\tt x1}.
 
 \begin{commentary}
 Load-pair and store-pair instructions are not provided, so transferring
-double-precision operands in RV32DZfinx from or to memory requires
+double-precision operands in RV32Zdinx from or to memory requires
 two loads or stores.
 Register moves need only a single FSGNJ.D instruction, however.
 \end{commentary}
 
-Quad-precision operands in RV32QZfinx are handled analogously, with
-a four-register alignment requirement.
+\section{Zqinx}
+
+The Zqinx extension is defined analogously to the Zdinx extension.
+For RV64, quad-precision operands require two-register alignment.
+For RV32, quad-precision operands require four-register alignment.
+
+\section{Privileged Architecture Implications}
+
+In the standard privileged architecture defined in Volume II, the
+{\tt mstatus} field FS is hardwired to 0 if the Zfinx extension is
+implemented, and FS no longer affects the trapping behavior of
+floating-point instructions or {\tt fcsr} accesses.


### PR DESCRIPTION
This PR contributes a new chapter to the unprivileged spec that describes the Zfinx, Zhinx, and Zdinx extensions, which add floating-point instructions that operate on the x-registers.