### PR TITLE
Change to use more common terms.

### DIFF
--- a/src/zihintntl.tex
+++ b/src/zihintntl.tex
@@ -1,23 +1,23 @@
 \chapter{``Zihintntl'' Non-Temporal Locality Hints, Version 0.1}
 \label{chap:zihintpause}
 
-The NTL instructions are HINTs that indicate that the immediately subsequent
-memory-access instruction exhibits poor temporal locality of reference.
+The NTL instructions are HINTs that indicate that the explicit memory accesses of the immediately subsequent
+instruction (henceforth "target instruction") exhibit poor temporal locality of reference.
 The NTL instructions do not change architectural state, nor do they alter the
-architecturally visible effects of the subsequent memory-access instruction.
+architecturally visible effects of the target instruction.
 Three variants are provided:
 
-The NTL.L1 instruction indicates that the subsequent memory-access instruction
+The NTL.L1 instruction indicates that the target instruction
 does not exhibit temporal locality within the capacity of the innermost level
 of cache in the memory hierarchy (e.g., an L1 cache).
 NTL.L1 is encoded as \mbox{ADD {\em x0, x0, x1}}.
 
-The NTL.L2 instruction indicates that the subsequent memory-access instruction
+The NTL.L2 instruction indicates that the target instruction
 does not exhibit temporal locality within the capacity of the next-innermost
 level of cache in the memory hierarchy (e.g., an L2 cache).
 NTL.L2 is encoded as \mbox{ADD {\em x0, x0, x2}}.
 
-The NTL.LLC instruction indicates that the subsequent memory-access
+The NTL.LLC instruction indicates that the target
 instruction does not exhibit temporal locality within the capacity of the last
 level of cache in the memory hierarchy.
 NTL.LLC is encoded as \mbox{ADD {\em x0, x0, x3}}.
@@ -81,20 +81,20 @@ instruction that does not explicitly access memory.
 Nonadherence to this recommendation might reduce performance but
 otherwise has no architecturally visible effect.
 
-In the event that a trap is taken on the instruction following an NTL,
+In the event that a trap is taken on the target instruction,
 implementations are discouraged from applying the NTL to the first instruction
 in the trap handler.
 Instead, implementations are recommended to ignore the HINT in this case.
 
 \begin{commentary}
 If an interrupt occurs between the execution of an NTL instruction and its
-subsequent memory-access instruction, execution will normally resume at the
-memory-access instruction.
+target instruction, execution will normally resume at the
+target instruction.
 That the NTL instruction is not reexecuted does not change the semantics of
 the program.
 
 Some implementations might prefer not to process the NTL instruction until the
-subsequent memory-access instruction is seen (e.g., so that the NTL can be
+target instruction is seen (e.g., so that the NTL can be
 fused with the memory access it modifies).
 Such implementations might preferentially take the interrupt before the NTL,
 rather than between the NTL and the memory access.


### PR DESCRIPTION
Locally define "target instruction" term as a shorthand for the
subsequent instruction to which the HINT applies.