### PR TITLE
State PMAs that are required for these mappings.

### DIFF
--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1230,6 +1230,16 @@ For example, the LR must also be made to respect any data dependencies that the 
 Likewise, the effect a FENCE~R,R elsewhere in the same hart must also be made to apply to the SC, which would not otherwise respect that fence.
 The emulator may achieve this effect by simply mapping AMOs onto {\tt lr.aq;~<op>;~sc.aqrl}, matching the mapping used elsewhere for fully ordered atomics.
 
+These C11/C++11 mappings require the platform to provide the following Physical Memory Attributes (as defined in the RISC-V Privileged ISA) for all memory:
+\begin{itemize}
+  \item main memory
+  \item coherent
+  \item AMOArithmetic
+  \item RsrvEventual
+  \item RVWMO
+\end{itemize}
+Platforms with different attributes may require different mappings, or require platform-specific SW (e.g., memory-mapped I/O).
+
 \section{Implementation Guidelines}
 
 The RVWMO and RVTSO memory models by no means preclude microarchitectures from employing sophisticated speculation techniques or other forms of optimization in order to deliver higher performance.


### PR DESCRIPTION
Explicitly state the PMAs required for this set of mappings to allow C
to run on RISC-V.