### PR TITLE
PMP RWX are collectively WARL, with R=0 W=1 being illegal

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -3254,9 +3254,10 @@ space, so the RV64 PMP address registers impose the same limit.
 Figure~\ref{pmpcfg} shows the layout of a PMP configuration register.  The R,
 W, and X bits, when set, indicate that the PMP entry permits read, write, and
 instruction execution, respectively.  When one of these bits is clear, the
-corresponding access type is denied.  The combination R=0 and W=1 is reserved
-for future use.  The remaining two fields, A and L, are
-described in the following sections.
+corresponding access type is denied.
+The R, W, and X fields form a collective \warl\ field for which the
+combinations with R=0 and W=1 are reserved.
+The remaining two fields, A and L, are described in the following sections.
 
 \begin{figure}[h!]
 {\footnotesize


### PR DESCRIPTION
This is technically a semantic change: we are strengthening the R=0 W=1 combination from being "reserved" to being invalid in the WARL sense.