### PR TITLE
Add marchid for XiangShan

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -42,3 +42,5 @@ CV32E40S      | OpenHW Group                    | [Arjan Bink](mailto:arjan.bink
 Ibex          | lowRISC                         | [lowRISC Hardware Team](mailto:hardware@lowrisc.org)        | 22                | https://github.com/lowRISC/ibex
 RudolV        | Jörg Mische                     | [Jörg Mische](mailto:bobbl@gmx.de)                          | 23                | https://github.com/bobbl/rudolv
 Steel Core    | Rafael Calcada                  | [Rafael Calcada](mailto:rafaelcalcada@gmail.com)            | 24                | https://github.com/rafaelcalcada/steel-core
+XiangShan     | ICT, CAS                        | [XiangShan Team](mailto:xiangshan-all@ict.ac.cn)            | 25                | https://github.com/OpenXiangShan/XiangShan
+


### PR DESCRIPTION
This PR requests the 25 marchid for XiangShan. It’s an open-source high-performance RISC-V processor maintained by Institute of Computing Technology, Chinese Academy of Sciences (ICT, CAS). 