### PR TITLE
Svpbmt: Page-Based Memory Types

### DIFF
--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -15,6 +15,7 @@ modules:
     \em Machine ISA       & \em 1.12 & \em Draft \\
     \em Supervisor ISA    & \em 1.12 & \em Draft \\
     \em Svnapot Extension & \em 0.1  & \em Draft \\
+    \em Svpbmt Extension  & \em 0.1  & \em Draft \\
     \em Hypervisor ISA    & \em 0.6  & \em Draft \\
     \em N Extension       & \em 1.1 & \em Draft \\
     \hline
@@ -68,6 +69,8 @@ Additionally, the following compatible changes have been made since version
 \item An additional 48 optional PMP registers have been defined.
 \item Added the Svnapot Standard Extension draft, along with the N bit in
   Sv39, Sv48, and Sv57 PTEs
+\item Added the Svpbmt Standard Extension draft, along with the PBMT bits
+  in Sv39, Sv48, and Sv57 PTEs.
 \item Described the behavior of address-translation caches a little more
   explicitly.
 \item Slightly relaxed the atomicity requirement for A and D bit updates

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1764,9 +1764,10 @@ quickly distinguish user and supervisor address regions.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cY@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{cF@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
 \instbitrange{53}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
@@ -1781,6 +1782,7 @@ quickly distinguish user and supervisor address regions.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[2]} &
 \multicolumn{1}{c|}{PPN[1]} &
@@ -1795,7 +1797,7 @@ quickly distinguish user and supervisor address regions.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1815,8 +1817,14 @@ have the same meaning as for Sv32.
 The N bit indicates that the page represents a
 naturally-aligned power-of-two range of contiguous translations, as defined in
 the Svnapot extension in Chapter~\ref{svnapot}.
+If the Svnapot extension is not implemented, the N bit must be zeroed by software,
+or else a page-fault exception is raised.
 
-Bits 62--54 are reserved
+Bits 62--61 indicate the page-based memory type, as defined in the Svpbmt extension in Chapter~\ref{svpbmt}.
+If the Svpbmt extension is not implemented, the PBMT bits must be zeroed by software,
+or else a page-fault exception is raised.
+
+Bits 60--54 are reserved
 for future standard use and must be zeroed by software for forward compatibility.
 If any of these bits are set, a page-fault exception is raised.
 
@@ -1923,9 +1931,10 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cF@{}F@{}F@{}F@{}F@{}Fcccccccc}
+\begin{tabular}{cF@{}F@{}F@{}F@{}F@{}F@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
 \instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
@@ -1941,6 +1950,7 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[3]} &
 \multicolumn{1}{c|}{PPN[2]} &
@@ -1956,7 +1966,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -2064,14 +2074,11 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{c@{}Y@{}F@{}F@{}F@{}F@{}F@{}Wcccccccc}
+\begin{tabular}{c@{}F@{}Y@{}T@{}Wcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
-\instbitrange{53}{46} &
-\instbitrange{45}{37} &
-\instbitrange{36}{28} &
-\instbitrange{27}{19} &
-\instbitrange{18}{10} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
+\instbitrange{53}{10} &
 \instbitrange{9}{8} &
 \instbit{7} &
 \instbit{6} &
@@ -2083,12 +2090,9 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
-\multicolumn{1}{c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{PPN} &
 \multicolumn{1}{c|}{RSW} &
 \multicolumn{1}{c|}{D} &
 \multicolumn{1}{c|}{A} &
@@ -2099,7 +2103,23 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 8 & 9 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 44 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+\end{tabular}
+
+\begin{tabular}{@{}F@{}F@{}F@{}F@{}F}
+\instbitrange{53}{46} &
+\instbitrange{45}{37} &
+\instbitrange{36}{28} &
+\instbitrange{27}{19} &
+\instbitrange{18}{10} \\
+\hline
+\multicolumn{1}{|c|}{PPN[4]} &
+\multicolumn{1}{c|}{PPN[3]} &
+\multicolumn{1}{c|}{PPN[2]} &
+\multicolumn{1}{c|}{PPN[1]} &
+\multicolumn{1}{c|}{PPN[0]} \\
+\hline
+8 & 9 & 9 & 9 & 9 \\
 \end{tabular}
 \end{center}
 }
@@ -2261,3 +2281,108 @@ algorithm in Section~\ref{sv32algorithm}, except that:
   configurations result in page-faults exceptions, while invalid access
   types or accesses to invalid physical memory regions trigger page faults.
 \end{commentary}
+
+\chapter{``Svpbmt'' Standard Extension for Page-Based Memory Attributes, Version 0.1}
+\label{svpbmt}
+
+{\bf Warning! This draft specification is likely to change before being
+accepted as standard by the RISC-V Foundation.}
+
+In Sv39, Sv48, and Sv57, bits 62--61 of the page table entry indicate the use
+of page-based memory types that override the PMA(s) for the associated memory
+pages.  The encoding for the PBMT bits is captured in Table~\ref{pbmt}.
+
+\begin{table*}[h!]
+\begin{center}
+\begin{tabular}{|r|l|}
+\hline
+Value  & Page-Based Memory Attributes \\
+\hline
+0      & None \\
+1      & Non-cacheable, idempotent, weakly-ordered (RVWMO or RVTSO), main memory \\
+2      & Non-cacheable, non-idempotent, strongly-ordered (channel 0), I/O \\
+3      & {\em Reserved for future standard use} \\
+\hline
+\end{tabular}
+\end{center}
+\caption{Encodings for the PBMT field in Sv39, Sv48, and Sv57 PTEs.  Attributes
+not mentioned are inherited from the PMA associated with the physical address.}
+\label{pbmt}
+\end{table*}
+
+\begin{commentary}
+Future extensions may provide more and/or finer-grained control over which PMAs
+can be overridden.
+\end{commentary}
+
+With Svpbmt enabled, it is possible for multiple virtual aliases of the same
+physical page to exist simultaneously with different memory attributes.
+It is also possible for a U-mode or S-mode mapping through a PTE with Svpbmt
+enabled to observe different memory attributes for a given region of
+physical memory than a concurrent access to the same page performed by M-mode
+or when {\tt satp}.MODE=Bare.  In such cases, each individual access observes
+the memory attributes associated with its own path; aliases are not considered
+when determining attributes.
+
+\begin{commentary}
+For example, a cacheable access may be issued at the same time as a
+non-cacheable access to the same physical memory address.  In this case,
+if the former is performed first in the global memory order, then it will
+be evicted from the cache by the latter.  If on the other hand the cacheable
+access appears after the non-cacheable access, then the former may remain
+cached as it normally would.
+
+Likewise, accesses performed under memory indicating the non-idempotent
+attribute must not be merged with idempotent accesses to the same region
+in flight at the same time, as the non-idempotency of the former must
+be respected.  This is not expected to be a common situation.
+
+Note that Svpbmt cannot be used to completely prevent speculative reads from
+being performed to a region of memory for which the PMAs indicate idempotence,
+as speculation can still be performed via M-mode or via Bare mappings, which do
+not use the PBMTs.
+\end{commentary}
+
+Memory accesses are ordered according to the effective memory type for the
+address in question.  A region of memory which is considered main memory by the
+PMAs but I/O by a PTE will obey channel 0 strong ordering, where for memory
+ordering purposes the ``I/O region'' is considered to be main memory.  In other
+words, each access to such a virtual address will appear in the global memory
+order after all prior operations from the same hart to main memory or to the
+same ``I/O region'', and it will appear earlier in the global memory order than
+all subsequent accesses from the same hart to main memory or to the same ``I/O
+region''.  Such operations are not guaranteed to remain ordered with respect to
+I/O operations to other I/O regions unless FENCEs are inserted by software.
+
+Likewise, a region of memory which is considered I/O by the PMAs but main
+memory by a PTE will obey RVWMO (or RVTSO if enabled) rather than I/O
+strong ordering rules, and accesses to such pages are considered main
+memory rather than I/O for the purposes of FENCE, {\em.aq}, and {\em.rl}.
+In such cases it is the responsibility of software to insert FENCEs
+or other ordering mechanisms if necessary.
+
+\begin{commentary}
+A device driver written to rely on I/O strong ordering rules will not
+operate correctly if the address range is mapped as main memory by the
+page-based memory types.  Operating systems and hypervisors must take
+care to apply such a combination only when strong ordering is not
+actually needed.
+
+In spite of the caveat above, it will often still be useful to map
+device memory regions in I/O as main memory so that write combining
+and speculative accesses can be performed, as such optimizations will
+likely improve performance when applied with adequate care.
+\end{commentary}
+
+The coherence PMA is not affected by Svpbmt.  Non-coherent I/O address ranges
+re-mapped by PBMTs into main memory must still rely on platform-specific
+mechanisms to enforce coherence with respect to external devices.  However,
+RVWMO and RVTSO still require eventual visibility of writes from one harts to
+other harts in the system.
+
+When two-level paging is enabled within the H extension, the page-based memory
+types are applied in two stages.  First, the G-stage PTE PBMT bits (if enabled)
+are applied to the attributes in the PMA to produce an intermediate set of
+attributes.  Second, the VS-stage PTE PBMT bits (if enabled) are applied to
+these intermediate attributes to produce the final set of attributes used by
+accesses to the page in question.


### PR DESCRIPTION
Opening a draft PR to enable discussion on the Svpbmt extension being discussed by the RISC-V virtual memory TG.

This extension is created as a branch off of #628 for convenience, and to avoid conflating Svpbmt discussion with other virtual memory TG discussions, but Svnapot and Svpbmt will be reviewed for ratification purposes as independent entities.

PDF versions of the specs are available on the virtual memory TG GitHub page:
https://github.com/riscv/virtual-memory/tree/main/specs