### PR TITLE
Add marchid for Hummingbirdv2 E203

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -43,4 +43,4 @@ Ibex          | lowRISC                         | [lowRISC Hardware Team](mailto
 RudolV        | Jörg Mische                     | [Jörg Mische](mailto:bobbl@gmx.de)                          | 23                | https://github.com/bobbl/rudolv
 Steel Core    | Rafael Calcada                  | [Rafael Calcada](mailto:rafaelcalcada@gmail.com)            | 24                | https://github.com/rafaelcalcada/steel-core
 XiangShan     | ICT, CAS                        | [XiangShan Team](mailto:xiangshan-all@ict.ac.cn)            | 25                | https://github.com/OpenXiangShan/XiangShan
-
+Hummingbirdv2 E203  | Nuclei System Technology  | [Can Hu](mailto:canhu@nucleisys.com), Nuclei System Technology  | 26            | https://github.com/riscv-mcu/e203_hbirdv2


### PR DESCRIPTION
This PR requests the 26 marchid for Hummingbirdv2 E203. 
It’s an open-source RISC-V processor Core and SoC, which developped and maintained by Nuclei System Technology.