### PR TITLE
Clarify the example of an I/O region.

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2694,8 +2694,8 @@ The most important characterization of a given memory address range is
 whether it holds regular main memory, or I/O devices, or is vacant.
 Regular main memory is required to have a number of properties,
 specified below, whereas I/O devices can have a much broader range of
-attributes.  Memory regions that do not fit into regular main
-memory, for example, device scratchpad RAMs, are categorized as I/O
+attributes.  Address regions that do not exhibit the properties of regular main
+memory, for example, ones containing device control registers, are categorized as I/O
 regions.  Vacant regions are also classified as I/O regions but with
 attributes specifying that no accesses are supported.
 


### PR DESCRIPTION
The previous example of a "device scratchpad RAM" was awkward, possibly
suggesting that such RAMs could not be classified as Memory.

The platform HSC is accommodating Memory across PCIe and so that instigated this cleanup.