### PR TITLE
First draft of Svinval

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -270,8 +270,8 @@ instruction exception.
 When VTW=1 (and assuming {\tt mstatus}.TW=0), an attempt in VS-mode to
 execute WFI raises a virtual instruction exception if the WFI does not
 complete within an implementation-specific, bounded time limit.
-When VTVM=1, an attempt in VS-mode to execute SFENCE.VMA or to access CSR
-{\tt satp} raises a virtual instruction exception.
+When VTVM=1, an attempt in VS-mode to execute SFENCE.VMA or SINVAL.VMA or to
+access CSR {\tt satp} raises a virtual instruction exception.
 
 The VGEIN (Virtual Guest External Interrupt Number) field selects a guest
 external interrupt source for VS-level external interrupts.
@@ -2043,8 +2043,8 @@ not in VS-mode.
 The TW field affects execution in all modes except M-mode.
 
 Setting TVM=1 prevents HS-mode from accessing {\tt hgatp} or executing
-HFENCE.GVMA, but has no effect on accesses to {\tt vsatp} or instruction
-HFENCE.VVMA.
+HFENCE.GVMA or HINVAL.GVMA, but has no effect on accesses to {\tt vsatp} or
+instructions HFENCE.VVMA or HINVAL.VVMA.
 
 The hypervisor extension changes the behavior of the the Modify Privilege
 field, MPRV, of {\tt mstatus}.
@@ -2696,8 +2696,8 @@ implementation-specific, bounded time;
 in VS-mode, attempts to execute SRET when {\tt hstatus}.VTSR=1; or
 
 \item
-in VS-mode, attempts to execute an SFENCE instruction or to access
-{\tt satp}, when {\tt hstatus}.VTVM=1.
+in VS-mode, attempts to execute an SFENCE.VMA or SINVAL.VMA instruction or to
+access {\tt satp}, when {\tt hstatus}.VTVM=1.
 
 \end{itemize}
 

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -818,8 +818,8 @@ example by swapping byte order after loads and before stores.
 
 The TVM (Trap Virtual Memory) bit is a \warl\ field that supports intercepting
 supervisor virtual-memory management operations.  When TVM=1,
-attempts to read or write the {\tt satp} CSR or execute the SFENCE.VMA
-instruction while executing in S-mode will raise an illegal instruction
+attempts to read or write the {\tt satp} CSR or execute an SFENCE.VMA or
+SINVAL.VMA instruction while executing in S-mode will raise an illegal instruction
 exception.  When TVM=0, these operations are permitted in S-mode.
 TVM is hard-wired to 0 when S-mode is not supported.
 
@@ -829,8 +829,8 @@ operating systems to execute in S-mode, rather than classically virtualizing
 them in U-mode.  This approach obviates the need to trap accesses to most
 S-mode CSRs.
 
-Trapping {\tt satp} accesses and the SFENCE.VMA instruction provides the
-hooks necessary to lazily populate shadow page tables.
+Trapping {\tt satp} accesses and the SFENCE.VMA and SINVAL.VMA instructions
+provides the hooks necessary to lazily populate shadow page tables.
 \end{commentary}
 
 The TW (Timeout Wait) bit is a \warl\ field that supports intercepting the WFI

--- a/src/priv-instr-table.tex
+++ b/src/priv-instr-table.tex
@@ -111,6 +111,36 @@
   
 
 &
+\multicolumn{4}{|c|}{0001011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SINVAL.VMA \\
+\cline{2-11}
+  
+
+&
+\multicolumn{4}{|c|}{0001100} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SFENCE.W.INVAL \\
+\cline{2-11}
+  
+
+&
+\multicolumn{4}{|c|}{0001101} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SFENCE.INVAL.IR \\
+\cline{2-11}
+  
+
+&
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf Hypervisor Memory-Management Instructions} & \\
@@ -134,6 +164,26 @@
 \multicolumn{1}{c|}{000} &
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & HFENCE.GVMA \\
+\cline{2-11}
+  
+
+&
+\multicolumn{4}{|c|}{0010011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & HINVAL.VVMA \\
+\cline{2-11}
+  
+
+&
+\multicolumn{4}{|c|}{0110011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & HINVAL.GVMA \\
 \cline{2-11}
   
 

--- a/src/priv-instr-table.tex
+++ b/src/priv-instr-table.tex
@@ -122,8 +122,8 @@
 
 &
 \multicolumn{4}{|c|}{0001100} &
-\multicolumn{2}{c|}{rs2} &
-\multicolumn{1}{c|}{rs1} &
+\multicolumn{2}{c|}{00000} &
+\multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{000} &
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & SFENCE.W.INVAL \\
@@ -131,9 +131,9 @@
   
 
 &
-\multicolumn{4}{|c|}{0001101} &
-\multicolumn{2}{c|}{rs2} &
-\multicolumn{1}{c|}{rs1} &
+\multicolumn{4}{|c|}{0001100} &
+\multicolumn{2}{c|}{00001} &
+\multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{000} &
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & SFENCE.INVAL.IR \\

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -15,6 +15,7 @@ modules:
     \em Machine ISA       & \em 1.12 & \em Draft \\
     \em Supervisor ISA    & \em 1.12 & \em Draft \\
     \em Svnapot Extension & \em 0.1  & \em Draft \\
+    \em Svpbmt Extension  & \em 0.1  & \em Draft \\
     \em Hypervisor ISA    & \em 0.6  & \em Draft \\
     \em N Extension       & \em 1.1 & \em Draft \\
     \hline
@@ -68,6 +69,8 @@ Additionally, the following compatible changes have been made since version
 \item An additional 48 optional PMP registers have been defined.
 \item Added the Svnapot Standard Extension draft, along with the N bit in
   Sv39, Sv48, and Sv57 PTEs
+\item Added the Svpbmt Standard Extension draft, along with the PBMT bits
+  in Sv39, Sv48, and Sv57 PTEs.
 \item Described the behavior of address-translation caches a little more
   explicitly.
 \item Slightly relaxed the atomicity requirement for A and D bit updates

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -16,6 +16,7 @@ modules:
     \em Supervisor ISA    & \em 1.12 & \em Draft \\
     \em Svnapot Extension & \em 0.1  & \em Draft \\
     \em Svpbmt Extension  & \em 0.1  & \em Draft \\
+    \em Svinval Extension & \em 0.1  & \em Draft \\
     \em Hypervisor ISA    & \em 0.6  & \em Draft \\
     \em N Extension       & \em 1.1 & \em Draft \\
     \hline
@@ -71,6 +72,7 @@ Additionally, the following compatible changes have been made since version
   Sv39, Sv48, and Sv57 PTEs
 \item Added the Svpbmt Standard Extension draft, along with the PBMT bits
   in Sv39, Sv48, and Sv57 PTEs.
+\item Added the Svinval Standard Extension draft
 \item Described the behavior of address-translation caches a little more
   explicitly.
 \item Slightly relaxed the atomicity requirement for A and D bit updates

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2376,9 +2376,6 @@ used as the final set of attributes.
 \chapter{``Svinval'' Standard Extension for Fine-Grained Address-Translation Cache Invalidation, Version 0.1}
 \label{svinval}
 
-{\bf Warning! This draft specification is likely to change before being
-accepted as standard by the RISC-V Foundation.}
-
 The Svinval extension splits SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA
 instructions into finer-grained invalidation and ordering operations that can
 be more efficiently batched or pipelined on certain classes of high-performance
@@ -2411,7 +2408,7 @@ The SINVAL.VMA instruction invalidates any address-translation cache entries
 that an SFENCE.VMA instruction with the same values of {\em rs1} and {\em rs2}
 would invalidate.  However, unlike SFENCE.VMA, SINVAL.VMA instructions are only
 ordered with respect to SFENCE.VMA, SFENCE.W.INVAL, and SFENCE.INVAL.IR
-instructions, defined below.
+instructions as defined below.
 
 \vspace{-0.2in}
 \begin{center}
@@ -2477,10 +2474,6 @@ a hypothetical SFENCE.VMA instruction in which:
   \item reads and writes following the SFENCE.INVAL.IR are considered to be
     those subsequent to the SFENCE.VMA.
 \end{itemize}
-
-The effect is the same if the SFENCE.W.INVAL instruction and/or the
-SFENCE.INVAL.IR instruction in the sequence is replaced by an SFENCE.VMA
-covering the same virtual address and (if provided) ASID as the SINVAL.VMA.
 
 \vspace{-0.2in}
 \begin{center}
@@ -2551,13 +2544,11 @@ the above in U-mode raises an illegal instruction exception.
   effects but no visible side effects.  Trapping of the SINVAL.VMA instruction
   is sufficient to enable emulation of the intended overall TLB maintenance
   functionality.
-\end{commentary}
 
-\begin{commentary}
   In typical usage, software will invalidate a range of virtual addresses in
-  the address-translation caches by issuing an SFENCE.W.INVAL instruction,
-  issuing a series of SINVAL.VMA, HINVAL.VVMA, or HINVAL.GVMA instructions to
-  the addresses (and optionally ASIDs or VMIDs) in question, and then issuing
+  the address-translation caches by executing an SFENCE.W.INVAL instruction,
+  executing a series of SINVAL.VMA, HINVAL.VVMA, or HINVAL.GVMA instructions to
+  the addresses (and optionally ASIDs or VMIDs) in question, and then executing
   an SFENCE.INVAL.IR instruction.
 
   High-performance implementations will be able to pipeline the

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2386,3 +2386,199 @@ are applied to the attributes in the PMA to produce an intermediate set of
 attributes.  Second, the VS-stage PTE PBMT bits (if enabled) are applied to
 these intermediate attributes to produce the final set of attributes used by
 accesses to the page in question.
+
+\chapter{``Svinval'' Standard Extension for Fine-Grained Address-Translation Cache Invalidation, Version 0.1}
+\label{svinval}
+
+{\bf Warning! This draft specification is likely to change before being
+accepted as standard by the RISC-V Foundation.}
+
+The Svinval extension splits SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA
+instructions into finer-grained invalidation and ordering operations that can
+be more efficiently batched or pipelined on certain classes of high-performance
+implementation.
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{O@{}R@{}R@{}F@{}R@{}S}
+\\
+\instbitrange{31}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct7} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{funct3} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+7 & 5 & 5 & 3 & 5 & 7 \\
+SINVAL.VMA & asid & vaddr & PRIV & 0 & SYSTEM \\
+\end{tabular}
+\end{center}
+
+The SINVAL.VMA instruction invalidates any address-translation cache entries
+that an SFENCE.VMA instruction with the same values of {\em rs1} and {\em rs2}
+would invalidate.  However, unlike SFENCE.VMA, SINVAL.VMA instructions are only
+ordered with respect to SFENCE.VMA, SFENCE.W.INVAL, and SFENCE.INVAL.IR
+instructions, defined below.
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{O@{}R@{}R@{}F@{}R@{}S}
+\\
+\instbitrange{31}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct7} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{funct3} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+7 & 5 & 5 & 3 & 5 & 7 \\
+SFENCE.W.INVAL & 0 & 0 & PRIV & 0 & SYSTEM \\
+\end{tabular}
+\end{center}
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{O@{}R@{}R@{}F@{}R@{}S}
+\\
+\instbitrange{31}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct7} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{funct3} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+7 & 5 & 5 & 3 & 5 & 7 \\
+SFENCE.INVAL.IR & 0 & 0 & PRIV & 0 & SYSTEM \\
+\end{tabular}
+\end{center}
+
+The SFENCE.W.INVAL instruction guarantees that any previous stores already
+visible to the curent RISC-V hart are ordered befure subsequent SINVAL.VMA
+instructions issued by the same hart.  The SFENCE.INVAL.IR instruction
+guarantees that any previous SINVAL.VMA instructions issued by the current hart
+are ordered before subsequent implicit references by that hart to the
+memory-management data structures.
+
+When issued in order (but not necessarily consecutively) by a single hart, the
+sequence SFENCE.W.INVAL, SINVAL.VMA, and SFENCE.INVAL.IR has the same effect as
+a hypothetical SFENCE.VMA instruction in which:
+\begin{itemize}
+  \item the values of {\em rs1} and {\em rs2} for the SFENCE.VMA are the same
+    as those used in the SINVAL.VMA,
+  \item reads and writes prior to the SFENCE.W.INVAL are considered to be those
+    prior to the SFENCE.VMA, and
+  \item reads and writes following to the SFENCE.INVAL.IR are considered to be
+    those subsequent to the SFENCE.VMA.
+\end{itemize}
+
+The effect is the same if the SFENCE.W.INVAL instruction and/or the
+SFENCE.INVAL.IR instruction in the sequence is replaced by an SFENCE.VMA
+covering the same virtual address and (if provided) ASID as the SINVAL.VMA.
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{O@{}R@{}R@{}F@{}R@{}S}
+\\
+\instbitrange{31}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct7} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{funct3} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+7 & 5 & 5 & 3 & 5 & 7 \\
+HINVAL.VVMA & asid & vaddr & PRIV & 0 & SYSTEM \\
+\end{tabular}
+\end{center}
+
+\vspace{-0.2in}
+\begin{center}
+\begin{tabular}{O@{}R@{}R@{}F@{}R@{}S}
+\\
+\instbitrange{31}{25} &
+\instbitrange{24}{20} &
+\instbitrange{19}{15} &
+\instbitrange{14}{12} &
+\instbitrange{11}{7} &
+\instbitrange{6}{0} \\
+\hline
+\multicolumn{1}{|c|}{funct7} &
+\multicolumn{1}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{funct3} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{opcode} \\
+\hline
+7 & 5 & 5 & 3 & 5 & 7 \\
+HINVAL.GVMA & vmid & gaddr & PRIV & 0 & SYSTEM \\
+\end{tabular}
+\end{center}
+
+If the hypervisor extension is enabled, the Svinval extension also provides two
+additional instructions: HINVAL.VVMA and HINVAL.GVMA.  These have the same
+semantics as SINVAL.VMA, except that they combine with SFENCE.W.INVAL and
+SFENCE.INVAL.IR to replace HFENCE.VVMA and HFENCE.GVMA, respectively, instead
+of SFENCE.VMA.
+
+SINVAL.VMA, HINVAL.VVMA, and HINVAL.GVMA require the same permissions and raise
+the same exceptions as SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA, respectively.
+In particular, an attempt to execute SINVAL.VMA when {\tt mstatus}.TVM=1 while
+executing in S-mode or HS-mode will raise an illegal instruction exception, and
+an attempt to execute SINVAL.VMA when {\tt hstatus}.VTVM=1 while executing in
+VS-mode raises a virtual instruction exception.  Likewise, an attempt to
+execute HINVAL.GVMA in HS-mode when {\tt mstatus}.TVM=1 raises an illegal
+instruction exception.  An attempt to execute HINVAL.VVMA or HINVAL.GVMA when
+V=1 raises a virtual instruction exception, and an attempt to execute any of
+the above in U-mode or VU-mode raises an illegal instruction exception.
+
+\begin{commentary}
+  SFENCE.W.INVAL and SFENCE.INVAL.IR instructions do not need to be trapped when
+  {\tt mstatus}.TVM=1 or when {\tt hstatus}.VTVM=1, as they only have ordering
+  effects but no visible side effects.  Trapping of the SINVAL.VMA instruction
+  is sufficient to enable emulation of the intended overall TLB maintenance
+  functionality.
+\end{commentary}
+
+\begin{commentary}
+  In typical usage, software will invalidate a range of virtual addresses in
+  the address-translation caches by issuing an SFENCE.W.INVAL instruction,
+  issuing a series of SINVAL.VMA, HINVAL.VVMA, or HINVAL.GVMA instructions to
+  the addresses (and optionally ASIDs) in question, and then issuing an
+  SFENCE.INVAL.IR instruction.
+
+  High-performance implementations will be able to pipeline the
+  address-translation cache invalidation operations, and will defer any
+  pipeline stalls or other memory ordering enforcement until an SFENCE.W.INVAL,
+  SFENCE.INVAL.IR, or SFENCE.VMA instruction is executed.
+
+  Simpler implementations may implement SINVAL.VMA identically to SFENCE.VMA
+  while implementing SFENCE.W.INVAL and SFENCE.INVAL.IR instructions as no-ops.
+\end{commentary}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2474,7 +2474,7 @@ SFENCE.INVAL.IR & 0 & 0 & PRIV & 0 & SYSTEM \\
 \end{center}
 
 The SFENCE.W.INVAL instruction guarantees that any previous stores already
-visible to the curent RISC-V hart are ordered befure subsequent SINVAL.VMA
+visible to the current RISC-V hart are ordered before subsequent SINVAL.VMA
 instructions issued by the same hart.  The SFENCE.INVAL.IR instruction
 guarantees that any previous SINVAL.VMA instructions issued by the current hart
 are ordered before subsequent implicit references by that hart to the
@@ -2488,7 +2488,7 @@ a hypothetical SFENCE.VMA instruction in which:
     as those used in the SINVAL.VMA,
   \item reads and writes prior to the SFENCE.W.INVAL are considered to be those
     prior to the SFENCE.VMA, and
-  \item reads and writes following to the SFENCE.INVAL.IR are considered to be
+  \item reads and writes following the SFENCE.INVAL.IR are considered to be
     those subsequent to the SFENCE.VMA.
 \end{itemize}
 

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2458,7 +2458,7 @@ SFENCE.W.INVAL & 0 & 0 & PRIV & 0 & SYSTEM \\
 \multicolumn{1}{c|}{opcode} \\
 \hline
 7 & 5 & 5 & 3 & 5 & 7 \\
-SFENCE.INVAL.IR & 0 & 0 & PRIV & 0 & SYSTEM \\
+SFENCE.INVAL.IR & 1 & 0 & PRIV & 0 & SYSTEM \\
 \end{tabular}
 \end{center}
 

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1764,9 +1764,10 @@ quickly distinguish user and supervisor address regions.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cY@{}Y@{}Y@{}Y@{}Fcccccccc}
+\begin{tabular}{cF@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
 \instbitrange{53}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
@@ -1781,6 +1782,7 @@ quickly distinguish user and supervisor address regions.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[2]} &
 \multicolumn{1}{c|}{PPN[1]} &
@@ -1795,7 +1797,7 @@ quickly distinguish user and supervisor address regions.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1815,8 +1817,14 @@ have the same meaning as for Sv32.
 The N bit indicates that the page represents a
 naturally-aligned power-of-two range of contiguous translations, as defined in
 the Svnapot extension in Chapter~\ref{svnapot}.
+If the Svnapot extension is not implemented, the N bit must be zeroed by software,
+or else a page-fault exception is raised.
 
-Bits 62--54 are reserved
+Bits 62--61 indicate the page-based memory type, as defined in the Svpbmt extension in Chapter~\ref{svpbmt}.
+If the Svpbmt extension is not implemented, the PBMT bits must be zeroed by software,
+or else a page-fault exception is raised.
+
+Bits 60--54 are reserved
 for future standard use and must be zeroed by software for forward compatibility.
 If any of these bits are set, a page-fault exception is raised.
 
@@ -1923,9 +1931,10 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{cF@{}F@{}F@{}F@{}F@{}Fcccccccc}
+\begin{tabular}{cF@{}F@{}F@{}F@{}F@{}F@{}Fcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
 \instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
@@ -1941,6 +1950,7 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
 \multicolumn{1}{c|}{PPN[3]} &
 \multicolumn{1}{c|}{PPN[2]} &
@@ -1956,7 +1966,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -2064,14 +2074,11 @@ is untranslated.
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{c@{}Y@{}F@{}F@{}F@{}F@{}F@{}Wcccccccc}
+\begin{tabular}{c@{}F@{}Y@{}T@{}Wcccccccc}
 \instbit{63} &
-\instbitrange{62}{54} &
-\instbitrange{53}{46} &
-\instbitrange{45}{37} &
-\instbitrange{36}{28} &
-\instbitrange{27}{19} &
-\instbitrange{18}{10} &
+\instbitrange{62}{61} &
+\instbitrange{60}{54} &
+\instbitrange{53}{10} &
 \instbitrange{9}{8} &
 \instbit{7} &
 \instbit{6} &
@@ -2083,12 +2090,9 @@ is untranslated.
 \instbit{0} \\
 \hline
 \multicolumn{1}{|c|}{N} &
+\multicolumn{1}{c|}{PBMT} &
 \multicolumn{1}{c|}{\it Reserved} &
-\multicolumn{1}{c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
+\multicolumn{1}{c|}{PPN} &
 \multicolumn{1}{c|}{RSW} &
 \multicolumn{1}{c|}{D} &
 \multicolumn{1}{c|}{A} &
@@ -2099,7 +2103,23 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-1 & 9 & 8 & 9 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+1 & 2 & 7 & 44 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+\end{tabular}
+
+\begin{tabular}{@{}F@{}F@{}F@{}F@{}F}
+\instbitrange{53}{46} &
+\instbitrange{45}{37} &
+\instbitrange{36}{28} &
+\instbitrange{27}{19} &
+\instbitrange{18}{10} \\
+\hline
+\multicolumn{1}{|c|}{PPN[4]} &
+\multicolumn{1}{c|}{PPN[3]} &
+\multicolumn{1}{c|}{PPN[2]} &
+\multicolumn{1}{c|}{PPN[1]} &
+\multicolumn{1}{c|}{PPN[0]} \\
+\hline
+8 & 9 & 9 & 9 & 9 \\
 \end{tabular}
 \end{center}
 }
@@ -2261,3 +2281,108 @@ algorithm in Section~\ref{sv32algorithm}, except that:
   configurations result in page-faults exceptions, while invalid access
   types or accesses to invalid physical memory regions trigger page faults.
 \end{commentary}
+
+\chapter{``Svpbmt'' Standard Extension for Page-Based Memory Attributes, Version 0.1}
+\label{svpbmt}
+
+{\bf Warning! This draft specification is likely to change before being
+accepted as standard by the RISC-V Foundation.}
+
+In Sv39, Sv48, and Sv57, bits 62--61 of the page table entry indicate the use
+of page-based memory types that override the PMA(s) for the associated memory
+pages.  The encoding for the PBMT bits is captured in Table~\ref{pbmt}.
+
+\begin{table*}[h!]
+\begin{center}
+\begin{tabular}{|r|l|}
+\hline
+Value  & Page-Based Memory Attributes \\
+\hline
+0      & None \\
+1      & Non-cacheable, idempotent, weakly-ordered (RVWMO or RVTSO), main memory \\
+2      & Non-cacheable, non-idempotent, strongly-ordered (channel 0), I/O \\
+3      & {\em Reserved for future standard use} \\
+\hline
+\end{tabular}
+\end{center}
+\caption{Encodings for the PBMT field in Sv39, Sv48, and Sv57 PTEs.  Attributes
+not mentioned are inherited from the PMA associated with the physical address.}
+\label{pbmt}
+\end{table*}
+
+\begin{commentary}
+Future extensions may provide more and/or finer-grained control over which PMAs
+can be overridden.
+\end{commentary}
+
+With Svpbmt enabled, it is possible for multiple virtual aliases of the same
+physical page to exist simultaneously with different memory attributes.
+It is also possible for a U-mode or S-mode mapping through a PTE with Svpbmt
+enabled to observe different memory attributes for a given region of
+physical memory than a concurrent access to the same page performed by M-mode
+or when {\tt satp}.MODE=Bare.  In such cases, each individual access observes
+the memory attributes associated with its own path; aliases are not considered
+when determining attributes.
+
+\begin{commentary}
+For example, a cacheable access may be issued at the same time as a
+non-cacheable access to the same physical memory address.  In this case,
+if the former is performed first in the global memory order, then it will
+be evicted from the cache by the latter.  If on the other hand the cacheable
+access appears after the non-cacheable access, then the former may remain
+cached as it normally would.
+
+Likewise, accesses performed under memory indicating the non-idempotent
+attribute must not be merged with idempotent accesses to the same region
+in flight at the same time, as the non-idempotency of the former must
+be respected.  This is not expected to be a common situation.
+
+Note that Svpbmt cannot be used to completely prevent speculative reads from
+being performed to a region of memory for which the PMAs indicate idempotence,
+as speculation can still be performed via M-mode or via Bare mappings, which do
+not use the PBMTs.
+\end{commentary}
+
+Memory accesses are ordered according to the effective memory type for the
+address in question.  A region of memory which is considered main memory by the
+PMAs but I/O by a PTE will obey channel 0 strong ordering, where for memory
+ordering purposes the ``I/O region'' is considered to be main memory.  In other
+words, each access to such a virtual address will appear in the global memory
+order after all prior operations from the same hart to main memory or to the
+same ``I/O region'', and it will appear earlier in the global memory order than
+all subsequent accesses from the same hart to main memory or to the same ``I/O
+region''.  Such operations are not guaranteed to remain ordered with respect to
+I/O operations to other I/O regions unless FENCEs are inserted by software.
+
+Likewise, a region of memory which is considered I/O by the PMAs but main
+memory by a PTE will obey RVWMO (or RVTSO if enabled) rather than I/O
+strong ordering rules, and accesses to such pages are considered main
+memory rather than I/O for the purposes of FENCE, {\em.aq}, and {\em.rl}.
+In such cases it is the responsibility of software to insert FENCEs
+or other ordering mechanisms if necessary.
+
+\begin{commentary}
+A device driver written to rely on I/O strong ordering rules will not
+operate correctly if the address range is mapped as main memory by the
+page-based memory types.  Operating systems and hypervisors must take
+care to apply such a combination only when strong ordering is not
+actually needed.
+
+In spite of the caveat above, it will often still be useful to map
+device memory regions in I/O as main memory so that write combining
+and speculative accesses can be performed, as such optimizations will
+likely improve performance when applied with adequate care.
+\end{commentary}
+
+The coherence PMA is not affected by Svpbmt.  Non-coherent I/O address ranges
+re-mapped by PBMTs into main memory must still rely on platform-specific
+mechanisms to enforce coherence with respect to external devices.  However,
+RVWMO and RVTSO still require eventual visibility of writes from one harts to
+other harts in the system.
+
+When two-level paging is enabled within the H extension, the page-based memory
+types are applied in two stages.  First, the G-stage PTE PBMT bits (if enabled)
+are applied to the attributes in the PMA to produce an intermediate set of
+attributes.  Second, the VS-stage PTE PBMT bits (if enabled) are applied to
+these intermediate attributes to produce the final set of attributes used by
+accesses to the page in question.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2536,7 +2536,7 @@ If the hypervisor extension is enabled, the Svinval extension also provides two
 additional instructions: HINVAL.VVMA and HINVAL.GVMA.  These have the same
 semantics as SINVAL.VMA, except that they combine with SFENCE.W.INVAL and
 SFENCE.INVAL.IR to replace HFENCE.VVMA and HFENCE.GVMA, respectively, instead
-of SFENCE.VMA.
+of SFENCE.VMA.  In addition, HINVAL.GVMA uses VMIDs instead of ASIDs.
 
 SINVAL.VMA, HINVAL.VVMA, and HINVAL.GVMA require the same permissions and raise
 the same exceptions as SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA, respectively.
@@ -2561,14 +2561,17 @@ the above in U-mode or VU-mode raises an illegal instruction exception.
   In typical usage, software will invalidate a range of virtual addresses in
   the address-translation caches by issuing an SFENCE.W.INVAL instruction,
   issuing a series of SINVAL.VMA, HINVAL.VVMA, or HINVAL.GVMA instructions to
-  the addresses (and optionally ASIDs) in question, and then issuing an
-  SFENCE.INVAL.IR instruction.
+  the addresses (and optionally ASIDs or VMIDs) in question, and then issuing
+  an SFENCE.INVAL.IR instruction.
 
   High-performance implementations will be able to pipeline the
   address-translation cache invalidation operations, and will defer any
   pipeline stalls or other memory ordering enforcement until an SFENCE.W.INVAL,
-  SFENCE.INVAL.IR, or SFENCE.VMA instruction is executed.
+  SFENCE.INVAL.IR, SFENCE.VMA, HFENCE.GVMA, or HFENCE.VVMA instruction is
+  executed.
 
-  Simpler implementations may implement SINVAL.VMA identically to SFENCE.VMA
-  while implementing SFENCE.W.INVAL and SFENCE.INVAL.IR instructions as no-ops.
+  Simpler implementations may implement SINVAL.VMA, HINVAL.VVMA, and
+  HINVAL.GVMA identically to SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA,
+  respectively, while implementing SFENCE.W.INVAL and SFENCE.INVAL.IR
+  instructions as no-ops.
 \end{commentary}

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2547,7 +2547,7 @@ VS-mode raises a virtual instruction exception.  Likewise, an attempt to
 execute HINVAL.GVMA in HS-mode when {\tt mstatus}.TVM=1 raises an illegal
 instruction exception.  An attempt to execute HINVAL.VVMA or HINVAL.GVMA when
 V=1 raises a virtual instruction exception, and an attempt to execute any of
-the above in U-mode or VU-mode raises an illegal instruction exception.
+the above in U-mode raises an illegal instruction exception.
 
 \begin{commentary}
   SFENCE.W.INVAL and SFENCE.INVAL.IR instructions do not need to be trapped when


### PR DESCRIPTION
Opening a draft PR to enable discussion on the Svinval extension being discussed by the RISC-V virtual memory TG.

This extension is created as a branch off of #663 for convenience, and to avoid conflating Svinval discussion with other virtual memory TG discussions, but Svnapot, Svpbmt, and Svinval will be reviewed for ratification purposes as independent entities.

PDF versions of the specs are available on the virtual memory TG GitHub page:
https://github.com/riscv/virtual-memory/tree/main/specs