### PR TITLE
CSR should have been used instead of field

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -222,7 +222,7 @@ codes in the Bank field, and encodes the final byte in the Offset field,
 discarding the parity bit.  For example, the JEDEC manufacturer ID
 {\tt 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x8a}
 (twelve continuation codes followed by {\tt 0x8a}) would be encoded in the
-{\tt mvendorid} field as {\tt 0x60a}.
+{\tt mvendorid} CSR as {\tt 0x60a}.
 
 \begin{commentary}
 In JEDEC's parlance, the bank number is one greater than the number of


### PR DESCRIPTION
It would be nice to use a fixed width font for fields too.

Are the reference names in the document or inside https://github.com/riscv/riscv-config/blob/master/riscv_config/schemas/schema_isa.yaml ?

There are probably a few fields starting with a capital letter in the documentation while they are lowercase in yaml.