### PR TITLE
mstatush is not optional in priv-1.12 for RV32

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -525,9 +525,6 @@ Bits 30:4 of {\tt mstatush} generally contain the same fields found in
 bits 62:36 of {\tt mstatus} for RV64.
 Fields SD, SXL, and UXL do not exist in {\tt mstatush}.
 
-The {\tt mstatush} register is not required to be implemented if every field
-would be hardwired to zero.
-
 \begin{figure*}[h!]
 {\footnotesize
 \begin{center}

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -51,8 +51,8 @@ Additionally, the following compatible changes have been made since version
   \parskip 0pt
   \itemsep 1pt
 \item Removed the N extension.
-\item Defined the RV32-only CSR {\tt mstatush}, which contains most of the
-  same fields as the upper 32 bits of RV64's {\tt mstatus}.
+\item Defined the mandatory RV32-only CSR {\tt mstatush}, which contains
+  most of the same fields as the upper 32 bits of RV64's {\tt mstatus}.
 \item Permitted the unconditional delegation of less-privileged interrupts.
 \item Added optional big-endian and bi-endian support.
 \item Made priority of load/store/AMO address-misaligned exceptions


### PR DESCRIPTION
But of course it can be hardwired to 0 in most implementations.

cc @jhauser-us