### PR TITLE
Improve labels of CSR categories

### DIFF
--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -10,10 +10,10 @@ The privileged architecture requires the Zicsr extension; which other
 privileged instructions are required depends on the privileged-architecture
 feature set.
 
-In addition to the user-level
+In addition to the unprivileged
 state described in Volume I of this manual, an implementation may
 contain additional CSRs, accessible by some subset of the privilege
-levels using the CSR instructions described in the user-level manual.
+levels using the CSR instructions described in Volume~I.
 In this chapter, we map out the CSR address space.  The following
 chapters describe the function of each of the CSRs according to
 privilege level, as well as the other privileged instructions which
@@ -52,7 +52,7 @@ less-privileged software.
 \multicolumn{3}{|c|}{CSR Address} & Hex & \multicolumn{1}{c|}{Use and Accessibility}\\ \cline{1-3}
 [11:10] & [9:8] & [7:4]                  &  & \\
 \hline
-\multicolumn{5}{|c|}{User CSRs}  \\
+\multicolumn{5}{|c|}{Unprivileged and User-Level CSRs}  \\
 \hline
 \tt   00   &\tt   00  &\tt   XXXX   & \tt 0x000-0x0FF & Standard read/write \\
 \tt   01   &\tt   00  &\tt   XXXX   & \tt 0x400-0x4FF & Standard read/write \\
@@ -61,7 +61,7 @@ less-privileged software.
 \tt   11   &\tt   00  &\tt   10XX   & \tt 0xC80-0xCBF & Standard read-only \\
 \tt   11   &\tt   00  &\tt   11XX   & \tt 0xCC0-0xCFF & Custom read-only \\
 \hline
-\multicolumn{5}{|c|}{Supervisor CSRs}  \\
+\multicolumn{5}{|c|}{Supervisor-Level CSRs}  \\
 \hline
 \tt   00   &\tt   01  &\tt   XXXX   & \tt 0x100-0x1FF & Standard read/write \\
 \tt   01   &\tt   01  &\tt   0XXX   & \tt 0x500-0x57F & Standard read/write \\
@@ -74,7 +74,7 @@ less-privileged software.
 \tt   11   &\tt   01  &\tt   10XX   & \tt 0xD80-0xDBF & Standard read-only \\
 \tt   11   &\tt   01  &\tt   11XX   & \tt 0xDC0-0xDFF & Custom read-only \\
 \hline
-\multicolumn{5}{|c|}{Hypervisor CSRs} \\
+\multicolumn{5}{|c|}{Hypervisor and VS CSRs} \\
 \hline
 \tt   00   &\tt   10  &\tt   XXXX   & \tt 0x200-0x2FF & Standard read/write \\
 \tt   01   &\tt   10  &\tt   0XXX   & \tt 0x600-0x67F & Standard read/write \\
@@ -87,7 +87,7 @@ less-privileged software.
 \tt   11   &\tt   10  &\tt   10XX   & \tt 0xE80-0xEBF & Standard read-only \\
 \tt   11   &\tt   10  &\tt   11XX   & \tt 0xEC0-0xEFF & Custom read-only \\
 \hline
-\multicolumn{5}{|c|}{Machine CSRs}  \\
+\multicolumn{5}{|c|}{Machine-Level CSRs}  \\
 \hline
 \tt   00   &\tt   11  &\tt   XXXX   & \tt 0x300-0x3FF & Standard read/write \\
 \tt   01   &\tt   11  &\tt   0XXX   & \tt 0x700-0x77F & Standard read/write \\
@@ -139,7 +139,7 @@ accesses.  Currently, the counters are the only shadowed CSRs.
 
 Tables~\ref{ucsrnames}--\ref{mcsrnames1} list the CSRs that have
 currently been allocated CSR addresses.  The timers, counters, and
-floating-point CSRs are standard user-level CSRs.
+floating-point CSRs are standard unprivileged CSRs.
 The other
 registers are used by privileged code, as described in the following
 chapters.  Note that not all registers are required on all
@@ -151,14 +151,14 @@ implementations.
 \hline
 Number    & Privilege & Name & Description \\
 \hline
-\multicolumn{4}{|c|}{User Floating-Point CSRs} \\
+\multicolumn{4}{|c|}{Unprivileged Floating-Point CSRs} \\
 \hline
 \tt 0x001 & URW  &\tt fflags     & Floating-Point Accrued Exceptions. \\
 \tt 0x002 & URW  &\tt frm        & Floating-Point Dynamic Rounding Mode. \\
 \tt 0x003 & URW  &\tt fcsr       & Floating-Point Control and Status
 Register ({\tt frm} + {\tt fflags}). \\
 \hline
-\multicolumn{4}{|c|}{User Counter/Timers} \\
+\multicolumn{4}{|c|}{Unprivileged Counter/Timers} \\
 \hline
 \tt 0xC00 & URO  &\tt cycle         & Cycle counter for RDCYCLE instruction. \\
 \tt 0xC01 & URO  &\tt time          & Timer for RDTIME instruction. \\
@@ -177,7 +177,7 @@ Register ({\tt frm} + {\tt fflags}). \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Currently allocated RISC-V user-level CSR addresses.}
+\caption{Currently allocated RISC-V unprivileged CSR addresses.}
 \label{ucsrnames}
 \end{table}
 
@@ -267,7 +267,7 @@ Number    & Privilege & Name & Description \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Currently allocated RISC-V hypervisor-level CSR addresses.}
+\caption{Currently allocated RISC-V hypervisor and VS CSR addresses.}
 \label{hcsrnames}
 \end{table}
 


### PR DESCRIPTION
In particular, relabel "user CSRs" to be "unprivileged and user CSRs".