### PR TITLE
Resolve contradiction in mtval definition

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -2123,8 +2123,10 @@ software in handling the trap.  Otherwise, {\tt mtval} is never written by the
 implementation, though it may be explicitly written by software.  The hardware
 platform will specify which exceptions must set {\tt mtval} informatively and
 which may unconditionally set it to zero.
+If the hardware platform specifies that no exceptions set {\tt mtval} to a
+nonzero value, then {\tt mtval} is hardwired to zero.
 
-When a breakpoint,
+If {\tt mtval} is not hardwired to zero, then when a breakpoint,
 address-misaligned, access-fault, or page-fault exception occurs
 on an instruction fetch, load, or store, {\tt
   mtval} is written with the faulting virtual address.  On an illegal
@@ -2168,9 +2170,12 @@ MXLEN \\
 
 For misaligned loads and stores that cause access-fault or page-fault exceptions,
 {\tt mtval} will contain the virtual address of the portion of the access that
-caused the fault.  For instruction access-fault or page-fault exceptions on
+caused the fault (unless {\tt mtval} is hardwired to zero).
+
+For instruction access-fault or page-fault exceptions on
 systems with variable-length instructions, {\tt mtval} will contain the
-virtual address of the portion of the instruction that caused the fault while
+virtual address of the portion of the instruction that caused the fault
+(unless {\tt mtval} is hardwired to zero).
 {\tt mepc} will point to the beginning of the instruction.
 
 The {\tt mtval} register can optionally also be used to return the
@@ -2213,10 +2218,9 @@ bits are cleared to zero.
   appropriate trap handling before runtime).
 \end{commentary}
 
-If the hardware platform specifies that no exceptions set {\tt mtval} to a
-nonzero value, then it may be hardwired to zero.  Otherwise,
-{\tt mtval} is a \warl\ register that must be able to hold all valid
-virtual addresses and the value 0.  It need not be capable of holding all
+If {\tt mtval} is not hardwired to zero, it is a \warl\ register that must be
+able to hold all valid virtual addresses and the value zero.
+It need not be capable of holding all
 possible invalid addresses.  Implementations may convert some invalid address
 patterns into other invalid addresses prior to writing them to {\tt mtval}.
 If the feature to return the faulting instruction bits is implemented, {\tt


### PR DESCRIPTION
The definition gives the implementation the flexibility of hardwiring mtval to 0, but also says that mtval is always written on certain exceptions.  This is, at a minimum, confusing since if mtval is hardwired to 0, those writes are fruitless.

Resolve by conditioning the sentence on whether mtval is hardwired to 0.

@jhauser-us -- this is not the resolution we discussed last night, but I think it does the trick, right?