### PR TITLE
Extension names

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -3096,7 +3096,7 @@ same kind.
 
 A future version of this standard may add information to the fields that
 are currently zeros.
-However, for backwards compatiblity, any such information will be for
+However, for backwards compatibility, any such information will be for
 performance purposes only and can safely be ignored.
 \end{commentary}
 

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -95,33 +95,40 @@ from other multi-letter extensions by an underscore, e.g.,
 
 \section{Supervisor-level Instruction-Set Extensions}
 
-Standard supervisor-level instruction-set extensions are defined in Volume II,
-but are named using ``S'' as a prefix, followed by an alphabetical name and an
-optional version number.  Supervisor-level extensions must be separated from
-other multi-letter extensions by an underscore.
+Standard extensions that extend the supervisor-level virtual-memory
+architecture are prefixed with the letters ``Sv'', followed by an alphabetical
+name and an optional version number.  Other standard extensions that extend
+the supervisor-level architecture are prefixed with the letters ``Ss'',
+followed by an alphabetical name and an optional version number.  Such
+extensions are defined in Volume II.
 
 Standard supervisor-level extensions should be listed after standard
 unprivileged extensions.  If multiple supervisor-level extensions are listed,
-they should be ordered alphabetically.
+they should be ordered alphabetically.  Supervisor-level extensions must be
+separated from other multi-letter extensions by an underscore.
 
-\section{Hypervisor-level Instruction-Set Extensions}
+\section{Hypervisor Instruction-Set Extensions}
 
-Standard hypervisor-level instruction-set extensions are named like
-supervisor-level extensions, but beginning with the letter ``H'' instead of
-the letter ``S''.
+Standard hypervisor instruction-set extensions are prefixed with the letter
+``H'', followed by an alphabetical name and an optional version number.
+Such extensions are defined in Volume II.
 
-Standard hypervisor-level extensions should be listed after standard
-lesser-privileged extensions.  If multiple hypervisor-level extensions are
-listed, they should be ordered alphabetically.
+Standard hypervisor extensions should be listed after standard unprivileged
+and supervisor-level extensions.  If multiple hypervisor extensions are
+listed, they should be ordered alphabetically.  Hypervisor extensions
+must be separated from other multi-letter extensions by an underscore.
 
 \section{Machine-level Instruction-Set Extensions}
 
-Standard machine-level instruction-set extensions are prefixed with the three
-letters ``Zxm''.
+Standard extensions that only extend the machine-level architecture are
+prefixed with the letters ``Sm'', followed by an alphabetical name and
+an optional version number.  Such extensions are defined in Volume
+II.
 
 Standard machine-level extensions should be listed after standard
 lesser-privileged extensions.  If multiple machine-level extensions are listed,
-they should be ordered alphabetically.
+they should be ordered alphabetically.  Machine-level extensions must be
+separated from other multi-letter extensions by an underscore.
 
 \section{Non-Standard Extension Names}
 

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -44,7 +44,7 @@ letters, e.g., ``Q'' for quad-precision floating-point, or
 ``C'' for the 16-bit compressed instruction format.
 
 Some ISA extensions depend on the presence of other extensions, e.g., ``D''
-depends on ``F'' and ``F'' depends on ``Zicsr''.  These dependences may be
+depends on ``F'' and ``F'' depends on ``Zicsr''.  These dependencies may be
 implicit in the ISA name: for example, RV32IF is equivalent to RV32IFZicsr,
 and RV32ID is equivalent to RV32IFD and RV32IFDZicsr.
 

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -185,7 +185,7 @@ Total Store Ordering & Ztso & \\
 \hline
 \multicolumn{3}{|c|}{Standard Supervisor-Level Extensions}\\
 \hline
-Supervisor-level extension ``def'' & Sdef & \\
+Supervisor-level extension ``def'' & Ssdef & \\
 \hline
 \hline
 \multicolumn{3}{|c|}{Standard Hypervisor-Level Extensions}\\
@@ -195,7 +195,7 @@ Hypervisor-level extension ``ghi'' & Hghi & \\
 \hline
 \multicolumn{3}{|c|}{Standard Machine-Level Extensions}\\
 \hline
-Machine-level extension ``jkl'' & Zxmjkl & \\
+Machine-level extension ``jkl'' & Smjkl & \\
 \hline
 \hline
 \multicolumn{3}{|c|}{Non-Standard Extensions}\\


### PR DESCRIPTION
- S-level extensions are Sv\* and Ss\*
- H extensions (which are not "H-level" since there is no such level in priv spec table 1.1) are H\*
- M-level extensions are Sm\*
- Extended the underscore requirement to these extensions so we don't end up with rv64gsvinvalsvnapot which likely cannot be parsed by machine and definitely cannot be parsed by humans
- Fixed a couple of typos
