### PR TITLE
Create separate PDF for the PLIC specification

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -8,19 +8,19 @@
 # build directory, copy the makefile there, and change the srcdir
 # variable accordingly.
 #
-# Note that the makefile assumes that the default dvips/ps2pdfwr 
-# commands "do the right thing" for fonts in pdfs. This is true on 
+# Note that the makefile assumes that the default dvips/ps2pdfwr
+# commands "do the right thing" for fonts in pdfs. This is true on
 # Athena/Linux and Fedora Core but is not true for older redhat installs ...
 #
 # At a minimum you should just change the main variable to be
-# the basename of your toplevel tex file. If you use a bibliography 
+# the basename of your toplevel tex file. If you use a bibliography
 # then you should set the bibfile variable to be the name of your
 # .bib file (assumed to be in the source directory).
 #
 
 srcdir  = ../src
 
-docs_with_bib = riscv-spec riscv-privileged 
+docs_with_bib = riscv-spec riscv-privileged riscv-plic
 docs_without_bib =
 
 srcs = $(wildcard $(srcdir)/*.tex)

--- a/src/riscv-plic.tex
+++ b/src/riscv-plic.tex
@@ -1,0 +1,58 @@
+%=======================================================================
+% riscv-plic.tex
+%-----------------------------------------------------------------------
+
+\documentclass[twoside,11pt]{book}
+
+% Fix copy/pasting of ligatures in Acrobat
+\input{glyphtounicode.tex}
+\pdfgentounicode=1 %
+
+\input{preamble}
+
+\newcommand{\privrev}{draft}
+\newcommand{\privmonthyear}{July 2021}
+
+\setcounter{secnumdepth}{3}
+\setcounter{tocdepth}{3}
+
+\begin{document}
+
+\title{\vspace{-0.7in}\Large {\bf The RISC-V PLIC} \\
+  Document Version \privrev
+  \vspace{-0.1in}}
+
+\date{}
+\maketitle
+
+This document is released under a Creative Commons Attribution 4.0
+International License.
+
+This document is a derivative of the
+RISC-V privileged specification version 1.9.1
+released under following license:
+\copyright \,2010--2017 Andrew Waterman, Yunsup Lee, Rimas Avi\v{z}ienis,
+David Patterson, Krste Asanovi\'{c}.
+Creative Commons Attribution 4.0 International License.
+
+
+\markboth{RISC-V PLIC V\privrev}
+{RISC-V PLIC V\privrev}
+\thispagestyle{empty}
+
+\frontmatter
+
+\input{priv-preface}
+
+{\hypersetup{linktoc=all,hidelinks}
+\tableofcontents
+}
+
+\mainmatter
+
+\input{plic.tex}
+
+\bibliographystyle{plain}
+\bibliography{riscv-spec}
+
+\end{document}


### PR DESCRIPTION
The PLIC section has been removed from the privileged ISA, build a separate PDF for it to make the content accessible while the still exist, so the content are not lost and accessible to interested readers. I'm not sure if and when https://github.com/riscv/riscv-plic-spec will take over here.