### PR TITLE
Improve description of interrupt traps

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -525,9 +525,6 @@ Registers {\tt hip} and {\tt hie} are HSXLEN-bit read/write registers
 that supplement HS-level's {\tt sip} and {\tt sie} respectively.
 The {\tt hip} register indicates pending VS-level and hypervisor-specific
 interrupts, while {\tt hie} contains enable bits for the same interrupts.
-As with {\tt sip} and {\tt sie}, an interrupt \textit{i} will be taken in
-HS-mode if bit~\textit{i} is set in both {\tt hip} and {\tt hie}, and if
-supervisor-level interrupts are globally enabled.
 
 \begin{figure}[h!]
 {\footnotesize
@@ -574,6 +571,15 @@ The active bits of {\tt hip} and {\tt hie} cannot be placed in HS-level's
 software to emulate the hypervisor extension on platforms that do not
 implement it in hardware.
 \end{commentary}
+
+An interrupt~\textit{i} will trap to HS-mode whenever all of the
+following are true:
+(a)~either the current operating mode is HS-mode and the SIE bit in the
+{\tt sstatus} register is set, or the current operating mode has less
+privilege than HS-mode;
+(b)~bit~\textit{i} is set in both {\tt sip} and {\tt sie}, or in both
+{\tt hip} and {\tt hie}; and
+(c)~bit~\textit{i} is not set in {\tt hideleg}.
 
 If bit~\textit{i} of {\tt sie} is hardwired to zero, the same bit in
 register {\tt hip} may be writable or may be read-only.

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1364,17 +1364,22 @@ MXLEN \\
 \label{miereg}
 \end{figure}
 
-An interrupt \textit{i} will be taken if bit \textit{i} is set in both
-{\tt mip} and {\tt mie}, and if interrupts are globally enabled.  By
-default, M-mode interrupts are globally enabled if the hart's current
-privilege mode is less than M, or if the current privilege mode is M
-and the MIE bit in the {\tt mstatus} register is set.  If bit \textit{i}
-in {\tt mideleg} is set, however, interrupts are considered to be
-globally enabled if the hart's current privilege mode equals the
-delegated privilege mode and that mode's interrupt enable
-bit (\textit{x}\/IE in {\tt mstatus} for mode~\textit{x}) is set,
-or if the current
-privilege mode is less than the delegated privilege mode.
+An interrupt~\textit{i} will trap to M-mode (causing the privilege mode
+to change to M-mode) if all of the following are true:
+(a)~either the current privilege mode is M and the MIE bit in the
+{\tt mstatus} register is set, or the current privilege mode has less
+privilege than M-mode;
+(b)~bit~\textit{i} is set in both {\tt mip} and {\tt mie}; and
+(c)~if register {\tt mideleg} exists, bit~\textit{i} is not set in
+{\tt mideleg}.
+
+These conditions for an interrupt trap to occur must be evaluated in a bounded
+amount of time from when an interrupt becomes pending in {\tt mip}, and must
+also be evaluated immediately following the execution of an {\em x}\/RET
+instruction or an explicit write to {\tt mip} or {\tt mie}.
+
+Interrupts to M-mode take priority over any interrupts to lower privilege
+modes.
 
 Each individual bit in register {\tt mip} may be writable or may be
 read-only.
@@ -1564,11 +1569,9 @@ using uncached I/O writes to memory-mapped control registers depending
 on the platform specification.
 \end{commentary}
 
-Multiple simultaneous interrupts destined for different privilege modes are
-handled in decreasing order of destined privilege mode.  Multiple simultaneous
-interrupts destined for the same privilege mode are handled in the following
+Multiple simultaneous
+interrupts destined for M-mode are handled in the following
 decreasing priority order: MEI, MSI, MTI, SEI, SSI, STI.
-Synchronous exceptions are of lower priority than all interrupts.
 
 \begin{commentary}
   The machine-level interrupt fixed-priority ordering rules were developed
@@ -1595,9 +1598,6 @@ Synchronous exceptions are of lower priority than all interrupts.
   Software interrupts are located in the lowest four bits of {\tt mip}
   as these are often written by software, and this position allows the
   use of a single CSR instruction with a five-bit immediate.
-
-  Synchronous exceptions are given the lowest priority to minimize
-  worst-case interrupt latency.
 \end{commentary}
 
 Restricted views of the {\tt mip} and {\tt mie} registers appear as

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -368,12 +368,20 @@ SXLEN \\
 \label{siereg}
 \end{figure}
 
-An interrupt \textit{i} will be taken if bit \textit{i} is set in both
-{\tt sip} and {\tt sie}, and if supervisor-level interrupts are globally
-enabled.
-Supervisor-level interrupts are globally enabled if the hart's current
-privilege mode is less than S, or if the current privilege mode is S
-and the SIE bit in the {\tt sstatus} register is set.
+An interrupt~\textit{i} will trap to S-mode if both of the
+following are true:
+(a)~either the current privilege mode is S and the SIE bit in the
+{\tt sstatus} register is set, or the current privilege mode has less
+privilege than S-mode; and
+(b)~bit~\textit{i} is set in both {\tt sip} and {\tt sie}.
+
+These conditions for an interrupt trap to occur must be evaluated in a bounded
+amount of time from when an interrupt becomes pending in {\tt sip}, and must
+also be evaluated immediately following the execution of an SRET instruction
+or an explicit write to {\tt sip} or {\tt sie}.
+
+Interrupts to S-mode take priority over any interrupts to lower privilege
+modes.
 
 Each individual bit in register {\tt sip} may be writable or may be
 read-only.
@@ -501,7 +509,6 @@ they are shown as hardwired to 0 in Figures~\ref{sipreg-standard} and
 Multiple simultaneous
 interrupts destined for supervisor mode are handled in the following
 decreasing priority order: SEI, SSI, STI.
-Synchronous exceptions are of lower priority than all interrupts.
 
 \subsection{Supervisor Timers and Performance Counters}
 


### PR DESCRIPTION
Supersedes #590

This version is much more relaxed but nevertheless covers the important bases of SRET and explicit toggling of xip/xie.