### PR TITLE
Generalize interrupt trap condition evaluation conditions

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1376,7 +1376,8 @@ privilege than M-mode;
 These conditions for an interrupt trap to occur must be evaluated in a bounded
 amount of time from when an interrupt becomes pending in {\tt mip}, and must
 also be evaluated immediately following the execution of an {\em x}\/RET
-instruction or an explicit write to {\tt mip} or {\tt mie}.
+instruction or an explicit write to a CSR on which the interrupt trap
+conditions depend.
 
 Interrupts to M-mode take priority over any interrupts to lower privilege
 modes.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -378,7 +378,7 @@ privilege than S-mode; and
 These conditions for an interrupt trap to occur must be evaluated in a bounded
 amount of time from when an interrupt becomes pending in {\tt sip}, and must
 also be evaluated immediately following the execution of an SRET instruction
-or an explicit write to {\tt sip} or {\tt sie}.
+or an explicit write to a CSR on which the interrupt trap conditions depend.
 
 Interrupts to S-mode take priority over any interrupts to lower privilege
 modes.


### PR DESCRIPTION
This approach is more extensible, and now implicitly includes writes to sstatus.SIE / mstatus.MIE, as it should.