### PR TITLE
Corrections to mstatus in hypervisor chapter

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -1894,7 +1894,7 @@ behavior of several existing {\tt mstatus} fields.
 Figure~\ref{hypervisor-mstatus} shows the modified {\tt mstatus} register
 when the hypervisor extension is implemented and MXLEN=64.
 When MXLEN=32, the hypervisor extension adds MPV and GVA not to {\tt mstatus}
-but to {\tt mstatush}, which must exist.
+but to {\tt mstatush}.
 Figure~\ref{hypervisor-mstatush} shows the {\tt mstatush} register when
 the hypervisor extension is implemented and MXLEN=32.
 
@@ -2023,7 +2023,7 @@ The format of {\tt mstatus} is unchanged for RV32.}
 
 The MPV bit (Machine Previous Virtualization Mode) is written by the implementation
 whenever a trap is taken into M-mode.
-Just as the MPP bit is set to the (nominal) privilege
+Just as the MPP field is set to the (nominal) privilege
 mode at the time of the trap, the MPV bit is set to the value of the virtualization
 mode V at the time of the trap.  When an MRET instruction is executed, the
 virtualization mode V is set to MPV, unless MPP=3, in which case V remains 0.


### PR DESCRIPTION
1. For RV32, mstatush is now always required to exist.
2. mstatus.MPP is not just one bit.