### PR TITLE
Relax the naming rule of extension name

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -77,10 +77,10 @@ a number.  For example, ``rv32i2p2'' means version 2.2 of RV32I, whereas
 \section{Additional Standard Extension Names}
 
 Standard extensions can also be named using a single ``Z'' followed by an
-alphabetical name and an optional version number.  For example,
-``Zifencei'' names the instruction-fetch fence extension described in
-Chapter~\ref{chap:zifencei}; ``Zifencei2'' and ``Zifencei2p0'' name version
-2.0 of same.
+alphanumeric name, the name must end with an alphabetical, and an optional
+version number.  For example, ``Zifencei'' names the instruction-fetch fence
+extension described in Chapter~\ref{chap:zifencei}; ``Zifencei2'' and
+``Zifencei2p0'' name version 2.0 of same.
 
 The first letter following the ``Z'' conventionally indicates the most closely
 related alphabetical extension category, IMAFDQLCBKJTPV.  For the ``Zam''
@@ -96,8 +96,9 @@ from other multi-letter extensions by an underscore, e.g.,
 \section{Supervisor-level Instruction-Set Extensions}
 
 Standard supervisor-level instruction-set extensions are defined in Volume II,
-but are named using ``S'' as a prefix, followed by an alphabetical name and an
-optional version number.  Supervisor-level extensions must be separated from
+but are named using ``S'' as a prefix, followed by an alphanumeric name, the
+name must end with an alphabetical, and an optional version number.
+Supervisor-level extensions must be separated from
 other multi-letter extensions by an underscore.
 
 Standard supervisor-level extensions should be listed after standard
@@ -126,7 +127,8 @@ they should be ordered alphabetically.
 \section{Non-Standard Extension Names}
 
 Non-standard extensions are named using a single ``X'' followed by an
-alphabetical name and an optional version number.
+alphanumeric name, the name must end with an alphabetical, and an optional
+version number.
 For example, ``Xhwacha'' names the Hwacha vector-fetch ISA extension;
 ``Xhwacha2'' and ``Xhwacha2p0'' name version 2.0 of same.
 

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -77,10 +77,11 @@ a number.  For example, ``rv32i2p2'' means version 2.2 of RV32I, whereas
 \section{Additional Standard Extension Names}
 
 Standard extensions can also be named using a single ``Z'' followed by an
-alphanumeric name, the name must end with an alphabetical, and an optional
-version number.  For example, ``Zifencei'' names the instruction-fetch fence
-extension described in Chapter~\ref{chap:zifencei}; ``Zifencei2'' and
-``Zifencei2p0'' name version 2.0 of same.
+alphanumeric name, the name must end with an alphabetical, an optional
+version number, and the second letter from the bottom cannot be a numeric if the
+last letter is ``p''.  For example, ``Zifencei'' names the instruction-fetch
+fence extension described in Chapter~\ref{chap:zifencei}; ``Zifencei2'' and
+``Zifencei2p0'' name version 2.0 are the same.
 
 The first letter following the ``Z'' conventionally indicates the most closely
 related alphabetical extension category, IMAFDQLCBKJTPV.  For the ``Zam''
@@ -97,7 +98,8 @@ from other multi-letter extensions by an underscore, e.g.,
 
 Standard supervisor-level instruction-set extensions are defined in Volume II,
 but are named using ``S'' as a prefix, followed by an alphanumeric name, the
-name must end with an alphabetical, and an optional version number.
+name must end with an alphabetical, an optional version number, and the second
+letter from the bottom cannot be a numeric if the last letter is ``p''.
 Supervisor-level extensions must be separated from
 other multi-letter extensions by an underscore.
 
@@ -127,8 +129,9 @@ they should be ordered alphabetically.
 \section{Non-Standard Extension Names}
 
 Non-standard extensions are named using a single ``X'' followed by an
-alphanumeric name, the name must end with an alphabetical, and an optional
-version number.
+alphanumeric name, the name must end with an alphabetical, an optional
+version number, and the second letter from the bottom cannot be a numeric if the
+last letter is ``p''.
 For example, ``Xhwacha'' names the Hwacha vector-fetch ISA extension;
 ``Xhwacha2'' and ``Xhwacha2p0'' name version 2.0 of same.
 


### PR DESCRIPTION
Current spec only allow alphabetical name, which means we can't use number in
the name, but we already defined serveral extension name with number,
like `zve32x`, `zvl128b`.

So this PR try to make the rule up to date and add one more rule to restrict the name must end with alphabetical to prevent ambiguous with version number.