### PR TITLE
Fix non-normative text about CSR ordering

### DIFF
--- a/src/csr.tex
+++ b/src/csr.tex
@@ -234,15 +234,18 @@ result, the order of CSR accesses with respect to all other accesses is
 constrained by the same mechanisms that constrain the order of memory-mapped
 I/O accesses to such a region.
 
-These CSR-ordering constraints are imposed primarily to support ordering main
-memory and memory-mapped I/O accesses with respect to reads of the {\tt time}
-CSR.  With the exception of the {\tt time}, {\tt cycle}, and {\tt mcycle} CSRs,
-the CSRs defined thus far in Volumes I and II of this specification are not
-directly accessible to other harts or devices and cause no side effects visible
-to other harts or devices.  Thus, accesses to CSRs other than the
-aforementioned three can be freely reordered in the global memory order
-with respect to FENCE instructions
-without violating this specification.
+These CSR-ordering constraints are imposed to support ordering main
+memory and memory-mapped I/O accesses with respect to CSR accesses that
+are visible to, or affected by, devices or other harts.
+Examples include the {\tt time}, {\tt cycle}, and {\tt mcycle}
+CSRs, in addition to CSRs that reflect pending interrupts, like {\tt mip} and
+{\tt sip}.
+Note that implicit reads of such CSRs (e.g., taking an interrupt because of
+a change in {\tt mip}) are also ordered as device input.
+
+Most CSRs (including, e.g., the {\tt fcsr}) are not visible to other harts;
+their accesses can be freely reordered in the global memory order with respect
+to FENCE instructions without violating this specification.
 \end{commentary}
 
 The hardware platform may define that accesses to certain CSRs are


### PR DESCRIPTION
The non-normative text erroneously suggested that only accesses to time/cycle/mcycle need be ordered by FENCEs.  In fact, other CSR accesses are also visible to other harts, including interrupt-pending CSRs.

(The preceding normative text has no such deficiency.)