### PR TITLE
Speculative implicit reads, v2

### DIFF
--- a/src/intro.tex
+++ b/src/intro.tex
@@ -422,8 +422,7 @@ Ordinarily, if an instruction attempts to access memory at an inaccessible
 address, an exception is raised for the instruction.
 Vacant locations in the address space are never accessible.
 
-Except when specified otherwise, implicit reads that do not raise an
-exception and that have no side effects
+Except when specified otherwise, implicit reads that do not raise an exception
 may occur arbitrarily early and speculatively, even before the machine could
 possibly prove that the read will be needed.  For instance, a valid
 implementation could attempt to read all of main memory at the earliest

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -3041,6 +3041,21 @@ misaligned access using multiple smaller accesses, which could cause
 unexpected side effects.
 \end{commentary}
 
+For non-idempotent regions, implicit reads and writes must not be performed
+early or speculatively, with the following exceptions.
+When a non-speculative implicit read is performed, an implementation is
+permitted to additionally read any of the bytes within a naturally aligned
+power-of-2 region containing the address of the non-speculative implicit read.
+Furthermore, when a non-speculative instruction fetch is performed, an
+implementation is permitted to additionally read any of the bytes within the
+{\em next} naturally aligned power-of-2 region of the same size (with the
+address of the region taken modulo $2^{\text{XLEN}}$).
+The results of these additional reads may be used to satisfy subsequent early
+or speculative implicit reads.
+The size of these naturally aligned power-of-2 regions is
+implementation-defined, but, for systems with page-based virtual memory, must
+not exceed the smallest supported page size.
+
 \section{Physical Memory Protection}
 \label{sec:pmp}
 

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -63,6 +63,8 @@ Additionally, the following compatible changes have been made since version
 \item Software breakpoint exceptions are permitted to write either 0
   or the PC to {\em x}\/{\tt tval}.
 \item Clarified that bare S-mode need not support the SFENCE.VMA instruction.
+\item Specified relaxed constraints for implicit reads of non-idempotent
+  regions.
 \end{itemize}
 
 Finally, the hypervisor architecture proposal has been extensively revised.


### PR DESCRIPTION
These constraints are better expressed as PMAs, and so we relax the unprivileged spec to always allow speculative implicit reads "unless otherwise specified", then move the constraints into the PMAs.

This proposal piggybacks on the non-idempotence PMA, constraining implicit reads to within a power-of-2 region of a non-speculative implicit read. Furthermore, speculative instruction fetch can also access the subsequent power-of-2 region.

No need to explicitly mention idempotent regions, because this construction implicitly allows speculative accesses to them.