### PR TITLE
Clarify widths of privileged CSRs

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -195,7 +195,7 @@ for tracking and controlling the exception behavior of a VS-mode guest.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Hypervisor status register ({\tt hstatus}) for RV32.}
+\caption{Hypervisor status register ({\tt hstatus}) when HSXLEN=32.}
 \label{hstatusreg-rv32}
 \end{figure*}
 
@@ -252,7 +252,7 @@ HSXLEN-34 & 2 & 9 & 1 & 1 & 1 & \\
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Hypervisor status register ({\tt hstatus}) for RV64.}
+\caption{Hypervisor status register ({\tt hstatus}) when HSXLEN=64.}
 \label{hstatusreg}
 \end{figure*}
 
@@ -1061,8 +1061,8 @@ in HS-mode will raise an illegal instruction exception.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV32 Hypervisor guest address translation and protection register
-{\tt hgatp}.}
+\caption{Hypervisor guest address translation and protection register
+{\tt hgatp} when HSXLEN=32.}
 \label{rv32hgatp}
 \end{figure}
 
@@ -1085,44 +1085,44 @@ in HS-mode will raise an illegal instruction exception.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV64 Hypervisor guest address translation and protection register
-{\tt hgatp}, for MODE values Bare, Sv39x4, and Sv48x4.}
+\caption{Hypervisor guest address translation and protection register
+{\tt hgatp} when HSXLEN=64, for MODE values Bare, Sv39x4, and Sv48x4.}
 \label{rv64hgatp}
 \end{figure}
 
-Table~\ref{tab:hgatp-mode} shows the encodings of the MODE field for RV32 and
-RV64.
+Table~\ref{tab:hgatp-mode} shows the encodings of the MODE field when HSXLEN=32 and
+HSXLEN=64.
 When MODE=Bare, guest physical addresses are equal to supervisor physical
 addresses, and there is no further memory protection for a guest virtual
 machine beyond the physical memory protection scheme described in
 Section~\ref{sec:pmp}.
 In this case, the remaining fields in {\tt hgatp} must be set to zeros.
 
-For RV32, the only other valid setting for MODE is Sv32x4, which is a
+When HSXLEN=32, the only other valid setting for MODE is Sv32x4, which is a
 modification of the usual Sv32 paged virtual-memory scheme, extended to support
 34-bit guest physical addresses.
-For RV64, modes Sv39x4 and Sv48x4 are defined as modifications of the Sv39 and
+When HSXLEN=64, modes Sv39x4 and Sv48x4 are defined as modifications of the Sv39 and
 Sv48 paged virtual-memory schemes.
 All of these paged virtual-memory schemes are described in
 Section~\ref{sec:guest-addr-translation}.
-An additional RV64 scheme, Sv57x4, may be defined in a later version of this
+An additional scheme for HSXLEN=64, Sv57x4, may be defined in a later version of this
 specification.
 
-The remaining MODE settings for RV64 are reserved for future use and may define
+The remaining MODE settings when HSXLEN=64 are reserved for future use and may define
 different interpretations of the other fields in {\tt hgatp}.
 
 \begin{table}[h]
 \begin{center}
 \begin{tabular}{|c|c|l|}
 \hline
-\multicolumn{3}{|c|}{RV32} \\
+\multicolumn{3}{|c|}{HSXLEN=32} \\
 \hline
 Value  & Name & Description \\
 \hline
 0      & Bare   & No translation or protection. \\
 1      & Sv32x4 & Page-based 34-bit virtual addressing (2-bit extension of Sv32). \\
 \hline \hline
-\multicolumn{3}{|c|}{RV64} \\
+\multicolumn{3}{|c|}{HSXLEN=64} \\
 \hline
 Value  & Name & Description \\
 \hline
@@ -1139,8 +1139,8 @@ Value  & Name & Description \\
 \label{tab:hgatp-mode}
 \end{table}
 
-RV64 implementations are not required to support all defined RV64 MODE
-settings.
+Implementations are not required to support all defined MODE
+settings when HSXLEN=64.
 
 A write to {\tt hgatp} with an unsupported MODE value is not ignored as it is
 for {\tt satp}.
@@ -1225,7 +1225,7 @@ instructions that normally read or modify {\tt sstatus} actually access
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Virtual supervisor status register ({\tt vsstatus}) for RV32.}
+\caption{Virtual supervisor status register ({\tt vsstatus}) when VSXLEN=32.}
 \label{vsstatusreg-rv32}
 \end{figure*}
 
@@ -1286,7 +1286,7 @@ instructions that normally read or modify {\tt sstatus} actually access
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Virtual supervisor status register ({\tt vsstatus}) for RV64.}
+\caption{Virtual supervisor status register ({\tt vsstatus}) when VSXLEN=64.}
 \label{vsstatusreg}
 \end{figure*}
 
@@ -1646,7 +1646,7 @@ Section~\ref{sec:two-stage-translation}).
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV32 virtual supervisor address translation and protection register {\tt vsatp}.}
+\caption{Virtual supervisor address translation and protection register {\tt vsatp} when VSXLEN=32.}
 \label{rv32vsatpreg}
 \end{figure}
 
@@ -1667,7 +1667,7 @@ Section~\ref{sec:two-stage-translation}).
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV64 virtual supervisor address translation and protection register {\tt vsatp}, for MODE
+\caption{Virtual supervisor address translation and protection register {\tt vsatp} when VSXLEN=64, for MODE
 values Bare, Sv39, and Sv48.}
 \label{rv64vsatpreg}
 \end{figure*}

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -254,7 +254,7 @@ Number    & Privilege & Name & Description \\
 \multicolumn{4}{|c|}{Hypervisor Counter/Timer Virtualization Registers} \\
 \hline
 \tt 0x605 & HRW  &\tt htimedelta   & Delta for VS/VU-mode timer. \\
-\tt 0x615 & HRW  &\tt htimedeltah  & Upper 32 bits of {\tt htimedelta}, RV32 only. \\
+\tt 0x615 & HRW  &\tt htimedeltah  & Upper 32 bits of {\tt htimedelta}, HSXLEN=32 only. \\
 \hline
 \multicolumn{4}{|c|}{Virtual Supervisor Registers} \\
 \hline

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -38,8 +38,8 @@ the supervisor-level CSR descriptions.
 
 
 The {\tt sstatus} register is an SXLEN-bit read/write register
-formatted as shown in Figure~\ref{sstatusreg-rv32} for RV32 and
-Figure~\ref{sstatusreg} for RV64.  The {\tt sstatus}
+formatted as shown in Figure~\ref{sstatusreg-rv32} when SXLEN=32 and
+Figure~\ref{sstatusreg} when SXLEN=64.  The {\tt sstatus}
 register keeps track of the processor's current operating state.
 
 \begin{figure*}[h!]
@@ -87,7 +87,7 @@ register keeps track of the processor's current operating state.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Supervisor-mode status register ({\tt sstatus}) for RV32.}
+\caption{Supervisor-mode status register ({\tt sstatus}) when SXLEN=32.}
 \label{sstatusreg-rv32}
 \end{figure*}
 
@@ -148,7 +148,7 @@ register keeps track of the processor's current operating state.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Supervisor-mode status register ({\tt sstatus}) for RV64.}
+\caption{Supervisor-mode status register ({\tt sstatus}) when SXLEN=64.}
 \label{sstatusreg}
 \end{figure*}
 
@@ -185,8 +185,8 @@ which may differ from the value of XLEN for S-mode, termed {\em SXLEN}.  The
 encoding of UXL is the same as that of the MXL field of {\tt misa}, shown in
 Table~\ref{misabase}.
 
-For RV32 systems, the UXL field does not exist, and UXLEN=32.  For RV64
-systems, it is a \warl\ field that encodes the current value of UXLEN.
+When SXLEN=32, the UXL field does not exist, and UXLEN=32.  When
+SXLEN=64, it is a \warl\ field that encodes the current value of UXLEN.
 In particular, an implementation may make UXL be a read-only field whose
 value always ensures that UXLEN=SXLEN.
 
@@ -830,7 +830,10 @@ register are described in Section~\ref{virt-control}.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV32 Supervisor address translation and protection register {\tt satp}.}
+\caption{%
+Supervisor address translation and protection register {\tt satp}
+when SXLEN=32.%
+}
 \label{rv32satp}
 \end{figure}
 
@@ -862,8 +865,10 @@ main memory be representable.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{RV64 Supervisor address translation and protection register {\tt satp}, for MODE
-values Bare, Sv39, and Sv48.}
+\caption{%
+Supervisor address translation and protection register {\tt satp}
+when SXLEN=64, for MODE values Bare, Sv39, and Sv48.%
+}
 \label{rv64satp}
 \end{figure}
 
@@ -875,21 +880,21 @@ translations, or vice-versa.  This approach also slightly reduces the cost of
 a context switch.
 \end{commentary}
 
-Table~\ref{tab:satp-mode} shows the encodings of the MODE field for RV32 and
-RV64.  When MODE=Bare, supervisor virtual addresses are equal to
+Table~\ref{tab:satp-mode} shows the encodings of the MODE field when SXLEN=32 and
+SXLEN=64.  When MODE=Bare, supervisor virtual addresses are equal to
 supervisor physical addresses, and there is no additional memory protection
 beyond the physical memory protection scheme described in
 Section~\ref{sec:pmp}.
 To select MODE=Bare, software must write zero to the remaining fields of
-{\tt satp} (bits 30--0 for RV32, or bits 59--0 for RV64).
+{\tt satp} (bits 30--0 when SXLEN=32, or bits 59--0 when SXLEN=64).
 Attempting to select MODE=Bare with a nonzero pattern in the remaining fields
 has an \unspecified\ effect on the value that the remaining fields assume
 and an \unspecified\ effect on address translation and protection behavior.
 
-For RV32, the {\tt satp} encodings corresponding to MODE=Bare and ASID[8:7]=3 are designated
+When SXLEN=32, the {\tt satp} encodings corresponding to MODE=Bare and ASID[8:7]=3 are designated
 for custom use, whereas the encodings corresponding to MODE=Bare and ASID[8:7]$\ne$3 are
 reserved for future standard use.
-For RV64, all {\tt satp} encodings corresponding to MODE=Bare are reserved for future
+When SXLEN=64, all {\tt satp} encodings corresponding to MODE=Bare are reserved for future
 standard use.
 
 \begin{commentary}
@@ -900,10 +905,10 @@ additional translation and protection modes, particularly in RV32, for which
 all patterns of the existing MODE field have already been allocated.
 \end{commentary}
 
-For RV32, the only other valid setting for MODE is Sv32, a paged
+When SXLEN=32, the only other valid setting for MODE is Sv32, a paged
 virtual-memory scheme described in Section~\ref{sec:sv32}.
 
-For RV64, two paged virtual-memory schemes are defined: Sv39 and Sv48,
+When SXLEN=64, two paged virtual-memory schemes are defined: Sv39 and Sv48,
 described in Sections~\ref{sec:sv39} and \ref{sec:sv48}, respectively.
 Two additional schemes, Sv57 and Sv64, will be defined in a later version
 of this specification.  The remaining MODE settings are reserved
@@ -918,14 +923,14 @@ no effect; no fields in {\tt satp} are modified.
 \begin{center}
 \begin{tabular}{|c|c|l|}
 \hline
-\multicolumn{3}{|c|}{RV32} \\
+\multicolumn{3}{|c|}{SXLEN=32} \\
 \hline
 Value  & Name & Description \\
 \hline
 0       & Bare  & No translation or protection. \\
 1       & Sv32  & Page-based 32-bit virtual addressing (see Section~\ref{sec:sv32}). \\
 \hline \hline
-\multicolumn{3}{|c|}{RV64} \\
+\multicolumn{3}{|c|}{SXLEN=64} \\
 \hline
 Value  & Name & Description \\
 \hline
@@ -1200,7 +1205,7 @@ When Sv32 is written to the MODE field in the {\tt satp} register (see
 Section~\ref{sec:satp}), the supervisor operates in a 32-bit paged
 virtual-memory system.  In this mode, supervisor and user virtual addresses
 are translated into supervisor physical addresses by traversing a radix-tree
-page table.  Sv32 is supported on RV32 systems and is designed to include
+page table.  Sv32 is supported when SXLEN=32 and is designed to include
 mechanisms sufficient for supporting modern Unix-based operating systems.
 
 \begin{commentary}
@@ -1516,8 +1521,8 @@ follows:
 \section{Sv39: Page-Based 39-bit Virtual-Memory System}
 \label{sec:sv39}
 
-This section describes a simple paged virtual-memory system designed
-for RV64 systems, which supports 39-bit virtual address spaces.  The
+This section describes a simple paged virtual-memory system
+for SXLEN=64, which supports 39-bit virtual address spaces.  The
 design of Sv39 follows the overall scheme of Sv32, and this section
 details only the differences between the schemes.
 
@@ -1672,8 +1677,8 @@ Section~\ref{sv32algorithm}, except LEVELS equals 3 and PTESIZE equals 8.
 \section{Sv48: Page-Based 48-bit Virtual-Memory System}
 \label{sec:sv48}
 
-This section describes a simple paged virtual-memory system designed
-for RV64 systems, which supports 48-bit virtual address spaces.  Sv48
+This section describes a simple paged virtual-memory system
+for SXLEN=64, which supports 48-bit virtual address spaces.  Sv48
 is intended for systems for which a 39-bit virtual address space is
 insufficient.  It closely follows the design of Sv39, simply adding an
 additional level of page table, and so this chapter only details the


### PR DESCRIPTION
When different privilege modes have different values for XLEN, the terms _RV32_ and _RV64_ are not sufficient to indicate the width of a privileged CSR that is accessed from a more-privileged mode (e.g. when 32-bit `vsatp` is accessed from 64-bit HS mode).  Where needed, replace "RV32" and "RV64" with more specific references to the correct XLEN.