### PR TITLE
Make virtual instruction exceptions more consistent for VU mode

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2635,7 +2635,7 @@ raised instead of an illegal instruction exception if the attempted
 instruction is \textit{HS-qualified}
 but is prevented from executing when V=1 due to
 insufficient privilege or because the instruction is expressly disabled
-by a hypervisor CSR such as {\tt hcounteren}.
+by a supervisor or hypervisor CSR such as {\tt scounteren} or {\tt hcounteren}.
 An instruction is \textit{HS-qualified} if it would be valid to execute
 in HS-mode (for some values of the instruction's register operands),
 assuming fields TSR and TVM of CSR {\tt mstatus} are both zero.
@@ -2670,14 +2670,24 @@ following cases:
 \begin{itemize}
 
 \item
-in VS-mode or VU-mode,
+in VS-mode,
 attempts to access a non-high-half counter CSR when the corresponding bit in
 {\tt hcounteren} is~0 and the same bit in {\tt mcounteren} is~1;
 
 \item
-in VS-mode or VU-mode, if XLEN=32, attempts to access a high-half
+in VS-mode, if XLEN=32, attempts to access a high-half
 counter CSR when the corresponding bit in {\tt hcounteren} is~0 and the
 same bit in {\tt mcounteren} is~1;
+
+\item
+in VU-mode, attempts to access a non-high-half counter CSR when the
+corresponding bit in either {\tt hcounteren} or {\tt scounteren} is~0
+and the same bit in {\tt mcounteren} is~1;
+
+\item
+in VU-mode, if XLEN=32, attempts to access a high-half counter CSR when
+the corresponding bit in either {\tt hcounteren} or {\tt scounteren}
+is~0 and the same bit in {\tt mcounteren} is~1;
 
 \item
 in VS-mode or VU-mode,


### PR DESCRIPTION
Raise a virtual instruction exception when V = 1 if an attempted instruction is HS-qualified but is explicitly blocked by either a hypervisor CSR or a supervisor CSR.  Previously, the document was inconsistent whether an illegal instruction or virtual instruction exception is raised when an instruction is blocked from executing in VU mode solely by a supervisor CSR such as `scounteren`.