### PR TITLE
riscv-isa-unpriv.adoc

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -3,7 +3,7 @@
 
 This document describes the RISC-V unprivileged architecture.
 
-The ISA modules marked Ratified have been ratified at this time. The
+The ISA modules marked *Ratified* have been ratified at this time. The
 modules marked _Frozen_ are not expected to change significantly before
 being put up for ratification. The modules marked _Draft_ are expected
 to change before ratification.
@@ -34,15 +34,22 @@ The document contains the following versions of the RISC-V ISA modules:
 |_V_ |_0.7_ |_Draft_
 |*Zicsr* |*2.0* |*Ratified*
 |*Zifencei* |*2.0* |*Ratified*
+|*Zihintpause* |*2.0* |*Ratified*
 |_Zam_ |_0.1_ |_Draft_
+|_Zfh_ |_0.1_ |_Draft_
+|_Zfhmin_ |_0.1_ |_Draft_
+|_Zfinx_ |_0.1_ |_Frozen_
+|_Zdinx_ |_1.0_ |_Frozen_
+|_Zhinx_ |_1.0_ |_Frozen_
+|_Zhinxmin_ |_1.0_ |_Frozen_
 |_Ztso_ |_0.1_ |_Frozen_
 |===
 
-_Preface to Document Version 20191213-Base-Ratified_
+*_Preface to Document Version 20191213-Base-Ratified_*
 
 This document describes the RISC-V unprivileged architecture.
 
-The ISA modules marked Ratified have been ratified at this time. The
+The ISA modules marked *Ratified* have been ratified at this time. The
 modules marked _Frozen_ are not expected to change significantly before
 being put up for ratification. The modules marked _Draft_ are expected
 to change before ratification.
@@ -85,12 +92,12 @@ December 2019.
 * Moved N extension for user-mode interrupts into Volume II.
 * Defined PAUSE hint instruction.
 
-_Preface to Document Version 20190608-Base-Ratified_
+*_Preface to Document Version 20190608-Base-Ratified_*
 
 This document describes the RISC-V unprivileged architecture.
 
 The RVWMO memory model has been ratified at this time. The ISA modules
-marked Ratified, have been ratified at this time. The modules marked
+marked *Ratified*, have been ratified at this time. The modules marked
 _Frozen_ are not expected to change significantly before being put up
 for ratification. The modules marked _Draft_ are expected to change
 before ratification.
@@ -190,7 +197,7 @@ group documents.
 * Removed text of V extension chapter as now superseded by separate
 vector extension draft document.
 
-_Preface to Document Version 2.2_
+*_Preface to Document Version 2.2_*
 
 This is version 2.2 of the document describing the RISC-V user-level
 architecture. The document contains the following versions of the RISC-V
@@ -256,7 +263,7 @@ integer registers.
 by the RISC-V ELF psABI Specification cite:[riscv-elf-psabi].
 * The C extension has been frozen and renumbered version 2.0.
 
-_Preface to Document Version 2.1_
+*_Preface to Document Version 2.1_*
 
 This is version 2.1 of the document describing the RISC-V user-level
 architecture. Note the frozen user-level ISA base and extensions IMAFDQ
@@ -288,7 +295,7 @@ supports MAC extensions.
 description of the RV32E calling convention.
 * A revised proposal for the C compressed extension, version 1.9 .
 
-_Preface to Version 2.0_
+*_Preface to Version 2.0_*
 
 This is the second release of the user ISA specification, and we intend
 the specification of the base user ISA plus general extensions (i.e.,

--- a/src/riscv-isa-unpriv.adoc
+++ b/src/riscv-isa-unpriv.adoc
@@ -65,6 +65,7 @@ This document is released under a Creative Commons Attribution 4.0 International
 This document is a derivative of “The RISC-V Instruction Set Manual, Volume I: User-Level ISA
 Version 2.1” released under the following license: ©2010–2017 Andrew Waterman, Yunsup Lee,
 David Patterson, Krste Asanovi'c. Creative Commons Attribution 4.0 International License.
+
 Please cite as: “The RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document
 Version 20191214-draft”, Editors Andrew Waterman and Krste Asanovi´c, RISC-V Foundation,
 December 2019.


### PR DESCRIPTION
 - fixed missing newline

colophon.adoc
 - fixed first table - missing entries
 - bolded section header and term "Ratified"