### PR TITLE
unpriv-chapter-12

### DIFF
--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -54,7 +54,7 @@ image::image_placeholder.png[]
 The `fcsr` register can be read and written with the FRCSR and FSCSR
 instructions, which are assembler pseudoinstructions built on the
 underlying CSR access instructions. FRCSR reads `fcsr` by copying it
-into integer register _rd_. FSCSR swaps the value in ` fcsr` by copying
+into integer register _rd_. FSCSR swaps the value in `fcsr` by copying
 the original value into integer register _rd_, and then writing a new
 value obtained from integer register _rs1_ into `fcsr`.
 
@@ -98,8 +98,7 @@ particular, with regard to decoding legal vs. reserved encodings).
 |100 |RMM |Round to Nearest, ties to Max Magnitude
 |101 | |_Reserved for future use._
 |110 | |_Reserved for future use._
-|111 |DYN |In instruction’s _rm_ field, selects dynamic rounding mode;
-| | |In Rounding Mode register, _reserved_.
+|111 |DYN |In instruction’s _rm_ field, selects dynamic rounding mode; In Rounding Mode register, _reserved_.
 |===
 
 [NOTE]
@@ -218,7 +217,7 @@ address is naturally aligned.
 FLW and FSW do not modify the bits being transferred; in particular, the
 payloads of non-canonical NaNs are preserved.
 
-As described in <<sp-ldst>>, the execution
+As described in <<ldst>>, the execution
 environment defines whether misaligned floating-point loads and stores
 are handled invisibly or raise a contained or fatal trap.
 
@@ -390,7 +389,7 @@ All floating-point conversion instructions set the Inexact exception
 flag if the rounded result differs from the operand value and the
 Invalid exception flag is not set.
 
-include::images/wavedrom/spfloat.adoc[]
+include::images/wavedrom/spfloat-cn-cmp.adoc[]
 [[fcvt]]
 .SP float convert and move
 image::image_placeholder.png[]
@@ -407,11 +406,6 @@ FSGNJN.S _rx, ry, ry_ moves the negation of _ry_ to _rx_ (assembler
 pseudoinstruction FNEG.S _rx, ry_); and FSGNJX.S _rx, ry, ry_ moves the
 absolute value of _ry_ to _rx_ (assembler pseudoinstruction FABS.S _rx,
 ry_).
-
-include::images/wavedrom/spfloat-cn-cmp.adoc[]
-[[spfloat-cn-cmp]]
-.SP floating point convert and compare
-image::image_placeholder.png[]
 
 [NOTE]
 ====

--- a/src/images/wavedrom/float-csr.adoc
+++ b/src/images/wavedrom/float-csr.adoc
@@ -7,11 +7,11 @@
 {reg: [
   {bits: 1,  name: 'NX'},
   {bits: 1,  name: 'UF'},
-  {bits: 1,  name: 'OF'},
+  {bits: 1,  name: 'OF', attr:["Accrued Exceptions","(fflags)"]},
   {bits: 1,  name: 'DZ'},
   {bits: 1,  name: 'NV'},
-  {bits: 3,  name: 'frm'},
-  {bits: 24},
+  {bits: 3,  name: 'frm', attr:["Rounding", "modes"]},
+  {bits: 24, name: "reserved"},
 ]}
 ....
 

--- a/src/images/wavedrom/sp-load-store.adoc
+++ b/src/images/wavedrom/sp-load-store.adoc
@@ -5,9 +5,9 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: 'LOAD-FP',  type: 8},
   {bits: 5,  name: 'rd',        attr: 'dest',     type: 2},
-  {bits: 3,  name: 'func3',     attr: 'width',    type: 8},
+  {bits: 3,  name: 'width',     attr: 'W',    type: 8},
   {bits: 5,  name: 'rs1',       attr: 'base',     type: 4},
-  {bits: 12, name: 'imm[11:0]', attr: 'offset',   type: 3},
+  {bits: 12, name: 'imm[11:0]', attr: 'offset[11:0]',   type: 3},
 ]}
 ....
 
@@ -15,11 +15,11 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: 'STORE-FP', type: 8},
-  {bits: 5,  name: 'imm[4:0]',  attr: 'offset',   type: 3},
-  {bits: 3,  name: 'func3',     attr: 'width',    type: 8},
+  {bits: 5,  name: 'imm[4:0]',  attr: 'offset[4:0]',   type: 3},
+  {bits: 3,  name: 'width',     attr: 'W',    type: 8},
   {bits: 5,  name: 'rs1',       attr: 'base',     type: 4},
   {bits: 5,  name: 'rs2',       attr: 'src',      type: 4},
-  {bits: 12, name: 'imm[11:5]', attr: 'offset',   type: 3},
+  {bits: 12, name: 'imm[11:5]', attr: 'offset[11:5]',   type: 3},
 ]}
 ....
 

--- a/src/images/wavedrom/spfloat-classify.adoc
+++ b/src/images/wavedrom/spfloat-classify.adoc
@@ -5,9 +5,9 @@
 {reg: [
   {bits: 7, name: 'opcode', attr: 'OP-FP',  type: 8},
   {bits: 5, name: 'rd',     attr: 'dest',   type: 2},
-  {bits: 3, name: 'rm',     attr: 1,        type: 8},
+  {bits: 3, name: 'rm',     attr: '001',        type: 8},
   {bits: 5, name: 'rs1',    attr: 'src',    type: 4},
-  {bits: 5, name: 'rs2',    attr: 0,        type: 8},
+  {bits: 5, name: 'rs2',    attr: '0',        type: 8},
   {bits: 2, name: 'fmt',    attr: 'S',      type: 8},
   {bits: 5, name: 'funct5', attr: 'FCLASS', type: 8},
 ]}

--- a/src/images/wavedrom/spfloat-cn-cmp.adoc
+++ b/src/images/wavedrom/spfloat-cn-cmp.adoc
@@ -3,13 +3,25 @@
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits: 7, name: 'opcode', attr: 'OP-FP',    type: 8},
-  {bits: 5, name: 'rd',     attr: 'dest',     type: 2},
-  {bits: 3, name: 'func3',  attr: 'RM',       type: 8},
-  {bits: 5, name: 'rs1',    attr: 'src',      type: 4},
-  {bits: 5, name: 0,                          type: 8},
-  {bits: 2, name: 'fmt',    attr: 'S',        type: 8},
-  {bits: 5, name: 'funct5', attr: 'FSQRT',    type: 8},
+  {bits: 7, name: 'opcode', attr: ['OP-FP','OP-FP'],    type: 8},
+  {bits: 5, name: 'rd',     attr: ['dest','dest'],     type: 2},
+  {bits: 3, name: 'rm',  attr: ['RM','RM'],       type: 8},
+  {bits: 5, name: 'rs1',    attr: ['src','src'],      type: 4},
+  {bits: 5, name: 'rs2',    attr: ['W[U]/L[U]', 'W[U]/L[U]'],     type: 8},
+  {bits: 2, name: 'fmt',    attr: ['S','S'],        type: 8},
+  {bits: 5, name: 'funct5', attr: ['FCVT.int.fmt', 'FCVT.fmt.int'],    type: 8},
 ]}
 ....
+....
+{reg: [
+  {bits: 7, name: 'opcode', attr: ['OP-FP'],    type: 8},
+  {bits: 5, name: 'rd',     attr: ['dest'],     type: 2},
+  {bits: 3, name: 'rm',  attr: ['J[N]/JX'],       type: 8},
+  {bits: 5, name: 'rs1',    attr: ['src1'],      type: 4},
+  {bits: 5, name: 'rs2',    attr: ['src2'],     type: 8},
+  {bits: 2, name: 'fmt',    attr: ['S'],        type: 8},
+  {bits: 5, name: 'funct5', attr: ['FSGNJ'],    type: 8},
+]}
+....
+
 

--- a/src/images/wavedrom/spfloat-comp.adoc
+++ b/src/images/wavedrom/spfloat-comp.adoc
@@ -5,7 +5,7 @@
 {reg: [
   {bits: 7, name: 'opcode', attr: 'OP-FP',  type: 8},
   {bits: 5, name: 'rd',     attr: 'dest',   type: 2},
-  {bits: 3, name: 'func3',  attr: ['EQ', 'LT', 'LE'], type: 8},
+  {bits: 3, name: 'rm',  attr: ['EQ', 'LT', 'LE'], type: 8},
   {bits: 5, name: 'rs1',    attr: 'src1',   type: 4},
   {bits: 5, name: 'rs2',    attr: 'src2',   type: 4},
   {bits: 2, name: 'fmt',    attr: 'S',      type: 8},

--- a/src/images/wavedrom/spfloat-mv.adoc
+++ b/src/images/wavedrom/spfloat-mv.adoc
@@ -3,13 +3,13 @@
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits: 7, name: 'opcode', attr: 'OP-FP',    type: 8},
-  {bits: 5, name: 'rd',     attr: 'dest',     type: 2},
-  {bits: 3, name: 'func3',  attr: ['MIN', 'MAX'], type: 8},
-  {bits: 5, name: 'rs1',    attr: 'src1',     type: 4},
-  {bits: 5, name: 'rs2',    attr: 'src2',     type: 4},
-  {bits: 2, name: 'fmt',    attr: 'S',        type: 8},
-  {bits: 5, name: 'funct5', attr: 'FMIN-MAX', type: 8},
+  {bits: 7, name: 'opcode', attr: ['OP-FP','OP-FP'],    type: 8},
+  {bits: 5, name: 'rd',     attr: ['dest','dest'],     type: 2},
+  {bits: 3, name: 'rm',     attr: ['000', '000'], type: 8},
+  {bits: 5, name: 'rs1',    attr: ['src','src'],     type: 4},
+  {bits: 5, name: 'rs2',    attr: ['0','0'],     type: 4},
+  {bits: 2, name: 'fmt',    attr: ['S','S'],        type: 8},
+  {bits: 5, name: 'funct5', attr: ['FMV.X.W','FMV.W.X'], type: 8},
 ]}
 ....
 

--- a/src/images/wavedrom/spfloat.adoc
+++ b/src/images/wavedrom/spfloat.adoc
@@ -3,13 +3,13 @@
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits: 7, name: 'opcode', attr: 'OP-FP',    type: 8},
-  {bits: 5, name: 'rd',     attr: 'dest',     type: 2},
-  {bits: 3, name: 'func3',  attr: 'RM',       type: 8},
-  {bits: 5, name: 'rs1',    attr: 'src1',     type: 4},
-  {bits: 5, name: 'rs2',    attr: 'src2',     type: 4},
-  {bits: 2, name: 'fmt',    attr: 'S',        type: 8},
-  {bits: 5, name: 'funct5', attr: ['FADD', 'FSUB', 'FMUL', 'FDIV'], type: 8},
+  {bits: 7, name: 'opcode', attr: ['OP-FP','OP-FP','OP-FP','OP-FP'],    type: 8},
+  {bits: 5, name: 'rd',     attr: ['dest','dest','dest','dest'],     type: 2},
+  {bits: 3, name: 'rm',  attr: ['RM', 'RM', 'RM', 'MIN/MAX'],       type: 8},
+  {bits: 5, name: 'rs1',    attr: ['src1', 'src1', 'src', 'src1'],     type: 4},
+  {bits: 5, name: 'rs2',    attr: ['src2', 'src2', '0', 'src2'],     type: 4},
+  {bits: 2, name: 'fmt',    attr: ['S', 'S', 'S', 'S'],        type: 8},
+  {bits: 5, name: 'funct5', attr: ['FADD/FSUB', 'FMUL/FDIV', 'FSQRT', 'FMIN-MAX'], type: 8},
 ]}
 ....
 


### PR DESCRIPTION
~~~~~~~~~~~~~
1. removed extra white space ahead of a fcsr instance
2. Removed extra row in Table 7
3. Corrected cross reference to point to Ld/St section chapter 2
4. Fixed wrong wavedrom file included in section 12.7

float-csr.adoc
~~~~~~~~~~~~~~
Add the labels back for fflags and frm

sp-load-store.adoc
~~~~~~~~~~~~~~~~~~
1. Fixed bitfield name that encodes width to denote width and not func3
2. Added bit range to offset.

spfloat-classify.adoc
~~~~~~~~~~~~~~~~~~~~~
1. Fixed attribute to be quoted to avoid repeating

spfloat-cn-cmp.adoc
~~~~~~~~~~~~~~~~~~~
1. Deleted wrongly include FSQRT and replaced with FCVT.int.fmt and FCVT.fmt.int
2. Added missing FSGNJ

spfloat-comp.doc
~~~~~~~~~~~~~~~~
1. Corrected bit field name func3 to rm

spfloat-mv.adoc
~~~~~~~~~~~~~~~
1. Deleted incorrect FMIN-FMAX
2. Added missing FMV.X.W and FMV.W.X

spfloat.adoc
1. Corrected the attributes
2. Added missing FSQRT and FMIN-MAX