### PR TITLE
Chapter 24 - Extending

### DIFF
--- a/src/extending.adoc
+++ b/src/extending.adoc
@@ -68,14 +68,16 @@ extensions into a single global encoding.
 
 [[encodingspaces]]
 .Suggested standard RISC-V instruction encoding space sizes.
-[cols="^,<,>,>,>,>",]
+[cols="^2,<12,>3,>3,>3,>3"]
 |===
-|Size |Usage |# Available in standard instruction length | | |
-
+|Size |Usage 
+4+^| # Available in standard instruction length
 | | |16-bit |32-bit |48-bit |64-bit
 
+6+|
 |14-bit |Quadrant of compressed 16-bit encoding |3 | | |
 
+6+|
 |22-bit |Minor opcode in base 32-bit encoding | |latexmath:[$2^{8}$]
 |latexmath:[$2^{20}$] |latexmath:[$2^{35}$]
 
@@ -85,6 +87,7 @@ extensions into a single global encoding.
 |30-bit |Quadrant of base 32-bit encoding | |1 |latexmath:[$2^{12}$]
 |latexmath:[$2^{27}$]
 
+6+|
 |32-bit |Minor opcode in 48-bit encoding | | |latexmath:[$2^{10}$]
 |latexmath:[$2^{25}$]
 
@@ -92,6 +95,7 @@ extensions into a single global encoding.
 
 |40-bit |Quadrant of 48-bit encoding | | |4 |latexmath:[$2^{17}$]
 
+6+|
 |45-bit |Sub-minor opcode in 64-bit encoding | | | |latexmath:[$2^{12}$]
 
 |48-bit |Minor opcode in 64-bit encoding | | | |latexmath:[$2^{9}$]
@@ -123,13 +127,13 @@ about conflicts at the prefix level, not within the encoding space
 itself.
 
 [[exttax]]
-.Two-dimensional characterization of standard instruction-set
-extensions.
+.Two-dimensional characterization of standard instruction-set extensions.
 [cols=">,^,^",options="header",]
+[%autowidth, align=center]
 |===
-| |Adds state |No new state
+|           |Adds state           |No new state
 |Greenfield |RV32I(30), RV64I(30) |A(25)
-|Brownfield |F(I), D(F), Q(D) |M(I)
+|Brownfield |F(I), D(F), Q(D)     |M(I)
 |===
 
 <<exttax>> shows the bases and standard extensions placed

--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -9,6 +9,8 @@ for the IMAFDZicsr_Zifencei combination of instruction-set extensions.
 This chapter presents opcode maps and instruction-set listings for RV32G
 and RV64G.
 
+[[opcodemap]]
+.RISC-V base opcode map, inst[1:0]=11
 [cols=">,^,^,^,^,^,^,^,^",]
 |===
 |inst[4:2] |000 |001 |010 |011 |100 |101 |110 |111


### PR DESCRIPTION
extending.adoc
- fixed table formating

rv-32-64g.adoc
- Added missing cross reference tag
- remove extra newline