### PR TITLE
remove word 'original' as this is confusing

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -428,14 +428,28 @@ AMOMIN[U].W/D & \multicolumn{2}{c}{ordering} & src & addr & width & dest & AMO  
 
 \vspace{-0.1in} The atomic memory operation (AMO) instructions perform
 read-modify-write operations for multiprocessor synchronization and
-are encoded with an R-type instruction format.  These AMO instructions
-atomically load a data value from the address in {\em rs1}, place the
-value into register {\em rd}, apply a binary operator to the loaded
-value and the original value in {\em rs2}, then store the result back
-to the original address in {\em rs1}. AMOs can either operate on 64-bit (RV64
-only) or 32-bit words in memory.  For RV64, 32-bit AMOs always
-sign-extend the value placed in {\em rd}, and ignore the upper 32 bits
-of the original value of {\em rs2}.
+are encoded with an R-type instruction format. A data value is atomically
+loaded from the address in {\em rs1} and placed into {\em rd}, then a
+binary operator is applied to the loaded value and the original value in
+{\em rs2}, finally the result is stored back to the original address.
+
+\begin{commentary}
+If {\em rs1} and {\em rd} refer to the same register, the address value
+in there is overwritten with the data value read from this address.
+However, this does not affect the address used for the final write
+operation, as AMOs always operate on a single memory address only.
+
+If {\em rs2} and {\em rd} refer to the same register, the original
+value in the register is used for the binary operation, before the
+register content is overwritten with the original memory content.
+
+At the and of the AMO, {\em rd} will hold the original memory content,
+unless it refers to {\tt x0}, then the original content is lost.
+\end{commentary}
+
+AMOs can either operate on 64-bit (RV64 only) or 32-bit words in memory.
+For RV64, 32-bit AMOs always sign-extend the value placed in {\em rd},
+and ignore the upper 32 bits of the original value of {\em rs2}.
 
 For AMOs, the A extension requires that the address held in {\em rs1}
 be naturally aligned to the size of the operand (i.e., eight-byte

--- a/src/a.tex
+++ b/src/a.tex
@@ -255,7 +255,7 @@ with both bits clear, but may result in lower performance.
 \begin{figure}[h!]
 \begin{center}
 \begin{verbatim}
-        # a0 holds address of memory location 
+        # a0 holds address of memory location
         # a1 holds expected value
         # a2 holds desired value
         # a0 holds return value, 0 if successful, !0 otherwise


### PR DESCRIPTION
The value in 'rs2' is not modified by the operation, thus the word "original" is confusing and implies there could be something besides the original value.
