### PR TITLE
Accesses to pages with mismatched attrs are I/O _and_ memory wrt FENCE

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2415,16 +2415,18 @@ accesses to such pages obey the memory ordering rules of the final effective
 attribute, as follows.
 
 If the underlying physical memory attribute for a page is I/O, and the page has
-PBMT=NC, then then accesses to that page obey RVWMO.  Accesses to such pages are
-considered main memory rather than I/O for the purposes of FENCE, {\em.aq}, and
-{\em.rl}.
+PBMT=NC, then accesses to that page obey RVWMO.
+However, accesses to such pages are
+considered to be {\em both} I/O and main memory accesses for the purposes of FENCE,
+{\em.aq}, and {\em.rl}.
 
 If the underlying physical memory attribute for a page is main memory, and the
 page has PBMT=IO, then accesses to that page obey strong channel 0 I/O ordering
 rules with respect to other accesses to physical main memory and to other
-accesses to pages with PBMT=IO.  Furthermore, accesses to such pages are
-considered I/O rather than main memory for the purposes of FENCE, {\em.aq}, and
-{\em.rl}.
+accesses to pages with PBMT=IO.
+However, accesses to such pages are
+considered to be {\em both} I/O and main memory accesses for the purposes of FENCE,
+{\em.aq}, and {\em.rl}.
 
 When Svpbmt is used with non-zero PBMT encodings,
 it is possible for multiple virtual aliases of the same


### PR DESCRIPTION
This is a strengthening of Svpbmt, in response to public-review feedback.