### PR TITLE
Memory access traps may write zero to stval

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -342,7 +342,8 @@ a guest virtual address to {\tt stval}, GVA is set to~1.
 For any other trap into HS-mode, GVA is set to~0.
 
 \begin{commentary}
-For breakpoint and memory access traps,
+For breakpoint and memory access traps
+that write a nonzero value to {\tt stval},
 GVA is redundant with field SPV (the two bits are set
 the same) except when the explicit memory access of an HLV, HLVX, or HSV
 instruction causes a fault.


### PR DESCRIPTION
Account for the fact that, once again, memory access traps may write zero to `stval`.