### PR TITLE
Clarify that implicit reads of CSRs return same value as explicit reads

### DIFF
--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -507,6 +507,15 @@ A change to the value of a CSR for this reason is not a write to the
 affected CSR and thus does not trigger any side effects specified for
 that CSR.
 
+\section{Implicit Reads of CSRs}
+
+Implementations sometimes perform {\em implicit} reads of CSRs.
+(For example, all S-mode instruction fetches implicitly read the {\tt satp}
+CSR.)
+Unless otherwise specified, the value returned by an implicit read of a CSR
+is the same value that would have been returned by an explicit read of the
+CSR, using a CSR-access instruction in a sufficient privilege mode.
+
 \section{CSR Width Modulation}
 \label{sec:csrwidthmodulation}
 


### PR DESCRIPTION
Seems like the kind of thing that could've gone without saying, but it has
come up in conversation a number of times---including wrt. the recent
CSR Field Modulation discussion in #782.

So, make it crystal clear.