### PR TITLE
Add Hazard3 to open-source marchid list

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -44,3 +44,4 @@ RudolV        | Jörg Mische                     | [Jörg Mische](mailto:bobbl@g
 Steel Core    | Rafael Calcada                  | [Rafael Calcada](mailto:rafaelcalcada@gmail.com)            | 24                | https://github.com/rafaelcalcada/steel-core
 XiangShan     | ICT, CAS                        | [XiangShan Team](mailto:xiangshan-all@ict.ac.cn)            | 25                | https://github.com/OpenXiangShan/XiangShan
 Hummingbirdv2 E203  | Nuclei System Technology  | [Can Hu](mailto:canhu@nucleisys.com), Nuclei System Technology  | 26            | https://github.com/riscv-mcu/e203_hbirdv2
+Hazard3       | Luke Wren                       | [Luke Wren](mailto:wren6991@gmail.com)                       | 27                | https://github.com/wren6991/hazard3


### PR DESCRIPTION
This is a 3-stage `RV32I` core, with optional support for `M`/`C`/`Zba`/`Zbb`/`Zbc`/`Zbs` and debug support. It passes the ISA compliance tests, riscv-formal, OpenOCD DM compliance tests and the end-to-end debug tests from riscv-tests/debug.

[Github](https://github.com/Wren6991/Hazard3)

[PDF documentation](https://github.com/Wren6991/Hazard3/blob/master/doc/hazard3.pdf)

The license is DWTFPLv3, which is effectively a public domain dedication.