### PR TITLE
Rework the description of exceptions for Svinval

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2663,14 +2663,15 @@ of SFENCE.VMA.  In addition, HINVAL.GVMA uses VMIDs instead of ASIDs.
 
 SINVAL.VMA, HINVAL.VVMA, and HINVAL.GVMA require the same permissions and raise
 the same exceptions as SFENCE.VMA, HFENCE.VVMA, and HFENCE.GVMA, respectively.
-In particular, an attempt to execute SINVAL.VMA when {\tt mstatus}.TVM=1 while
-executing in S-mode or HS-mode will raise an illegal instruction exception, and
-an attempt to execute SINVAL.VMA when {\tt hstatus}.VTVM=1 while executing in
-VS-mode raises a virtual instruction exception.  Likewise, an attempt to
-execute HINVAL.GVMA in HS-mode when {\tt mstatus}.TVM=1 raises an illegal
-instruction exception.  An attempt to execute HINVAL.VVMA or HINVAL.GVMA when
-V=1 raises a virtual instruction exception, and an attempt to execute any of
-the above in U-mode raises an illegal instruction exception.
+In particular, an attempt to execute any of these instructions in
+U-mode always raises an illegal instruction exception, and an attempt
+to execute SINVAL.VMA or HINVAL.GVMA in S-mode or HS-mode when
+{\tt mstatus}.TVM=1 also raises an illegal instruction exception.
+An attempt to execute HINVAL.VVMA or HINVAL.GVMA in VS-mode or VU-mode,
+or to execute SINVAL.VMA in VU-mode, raises a virtual instruction
+exception.
+When {\tt hstatus}.VTVM=1, an attempt to execute SINVAL.VMA in VS-mode
+also raises a virtual instruction exception.
 
 \begin{commentary}
   SFENCE.W.INVAL and SFENCE.INVAL.IR instructions do not need to be trapped when


### PR DESCRIPTION
Restructure the listing of exceptions raised for SINVAL.VMA, HINVAL.VVMA, and HINVAL.GVMA, as follows:

  - List exceptions that occur absent the hypervisor extension first.

  - Replace obscure "when V=1" with "in VS-mode or VU-mode".

  - Add that attempts to execute SINVAL.VMA in VU-mode raise a virtual instruction exception.