### PR TITLE
Change H extension to version 1.0

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -1,4 +1,4 @@
-\chapter{Hypervisor Extension, Version 1.0.0}
+\chapter{Hypervisor Extension, Version 1.0}
 \label{hypervisor}
 
 This chapter describes the RISC-V hypervisor extension, which virtualizes the


### PR DESCRIPTION
The hypervisor extension (H) was shown as version 1.0.0, but there is no need now for a third component to the version number.