### PR TITLE
Better clarify the effects of HFENCE.VVMA and HFENCE.GVMA

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -1950,9 +1950,8 @@ HFENCE.VVMA is valid only in M-mode or HS-mode.
 Its effect is much the
 same as temporarily entering VS-mode and executing SFENCE.VMA.
 Executing an HFENCE.VVMA guarantees that any previous stores already visible
-to the current hart are ordered before all subsequent implicit reads by that
-hart of the VS-level memory-management data structures, when those implicit
-reads are for instructions that
+to the current hart are ordered before all implicit reads by that
+hart done for VS-stage address translation for instructions that
 \begin{compactitem}
 \item
 are subsequent to the HFENCE.VVMA, and
@@ -1993,8 +1992,8 @@ trap.
 HFENCE.GVMA is valid only in HS-mode when {\tt mstatus}.TVM=0, or in
 M-mode (irrespective of {\tt mstatus}.TVM).
 Executing an HFENCE.GVMA instruction guarantees that any previous stores
-already visible to the current hart are ordered before all subsequent implicit
-reads by that hart of guest-physical memory-management data structures done for instructions
+already visible to the current hart are ordered before all implicit
+reads by that hart done for G-stage address translation for instructions
 that follow the HFENCE.GVMA.
 If operand {\em rs1}$\neq${\tt x0}, it specifies a single guest physical
 address, shifted right by 2~bits, and if operand {\em rs2}$\neq${\tt x0}, it


### PR DESCRIPTION
HFENCE.VVMA orders only those implicit reads done for VS-stage address translation, and HFENCE.GVMA orders only those implicit reads done for G-stage address translation.  Implicit reads that might access the same data for other reasons (due to sharing of page tables, for example) are not impacted.

Removed a couple instances of the word *subsequent* that were easily misinterpreted.