### PR TITLE
Hypervisor: use HFENCE.GVMA after PMP write to synchronize VS-enabled-G-disabled

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2786,16 +2786,11 @@ the virtual memory system.
 For HS-level address translation, this is accomplished by executing in M-mode
 an SFENCE.VMA instruction with {\em rs1}={\tt x0} and {\em rs2}={\tt x0}, after
 the PMP CSRs are written.
-If G-stage or VS-stage address translation is in use and is not Bare,
-synchronization with its data
-structures is also needed.
-When PMP settings are modified in a manner that affects the physical
-memory that holds guest-physical page tables, the physical memory to which
-guest-physical page tables point, or when G-stage translation MODE is Bare,
-the physical memory that holds VS-stage page tables or the physical memory to
-which VS-stage page tables point, then an HFENCE.GVMA instruction with
-{\em rs1}={\tt x0} and {\em rs2}={\tt x0} must be executed in M-mode after the
-PMP CSRs are written.
+Synchronization with G-stage and VS-stage data structures is also needed.
+Executing an HFENCE.GVMA instruction with {\em rs1}={\tt x0} and
+{\em rs2}={\tt x0} suffices to flush all G-stage or VS-stage
+address-translation cache entries that have cached PMP settings
+corresponding to the final translated supervisor physical address.
 An HFENCE.VVMA instruction is not required.
 
 \section{Traps}

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2789,9 +2789,11 @@ the PMP CSRs are written.
 If G-stage or VS-stage address translation is in use and is not Bare,
 synchronization with its data
 structures is also needed.
-When PMP settings are modified in a manner that affects either the physical
-memory that holds guest page tables or the physical memory to which
-guest page tables point, an HFENCE.GVMA instruction with
+When PMP settings are modified in a manner that affects the physical
+memory that holds guest-physical page tables, the physical memory to which
+guest-physical page tables point, or when G-stage translation MODE is Bare,
+the physical memory that holds VS-stage page tables or the physical memory to
+which VS-stage page tables point, then an HFENCE.GVMA instruction with
 {\em rs1}={\tt x0} and {\em rs2}={\tt x0} must be executed in M-mode after the
 PMP CSRs are written.
 An HFENCE.VVMA instruction is not required.

--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2786,12 +2786,12 @@ the virtual memory system.
 For HS-level address translation, this is accomplished by executing in M-mode
 an SFENCE.VMA instruction with {\em rs1}={\tt x0} and {\em rs2}={\tt x0}, after
 the PMP CSRs are written.
-If G-stage address translation is in use and is not Bare,
+If G-stage or VS-stage address translation is in use and is not Bare,
 synchronization with its data
 structures is also needed.
 When PMP settings are modified in a manner that affects either the physical
-memory that holds guest-physical page tables or the physical memory to which
-guest-physical page tables point, an HFENCE.GVMA instruction with
+memory that holds guest page tables or the physical memory to which
+guest page tables point, an HFENCE.GVMA instruction with
 {\em rs1}={\tt x0} and {\em rs2}={\tt x0} must be executed in M-mode after the
 PMP CSRs are written.
 An HFENCE.VVMA instruction is not required.


### PR DESCRIPTION
A HFENCE.GVMA is still required after changing PMPs affecting VS-stage translation when vsatp.mode=ON and hgatp.mode=BARE.