### PR TITLE
add dummy GitHub action

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,0 +1,9 @@
+name: Build Document PDF
+
+on:
+  workflow_dispatch:
+
+jobs:
+  DummyJob:
+    steps:
+      - name: DummyStep


### PR DESCRIPTION
In order to test the new build of the Asciidoc using a GitHub action off
the "convert2adoc" branch, the master branch must have a GitHub action
with the same name.

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>