### PR TITLE
hypervisor: fix typos

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2243,8 +2243,8 @@ This assumption does place some constraints on possible future
 efficiently.
 \end{commentary}
 
-The hypervisor extension changes the behavior of the the Modify Privilege
-field, MPRV, of {\tt mstatus}.
+The hypervisor extension changes the behavior of the Modify Privilege field,
+MPRV, of {\tt mstatus}.
 When MPRV=0, translation and protection behave as normal.
 When MPRV=1, explicit memory accesses are translated and protected, and
 endianness is applied, as though the current virtualization mode were set


### PR DESCRIPTION
Remove the duplicated "the".

Signed-off-by: Dong Du <Dd_nirvana@sjtu.edu.cn>