### PR TITLE
hypervisor: Add Sv57 to &x4 address witdth list

### DIFF
--- a/src/hypervisor.tex
+++ b/src/hypervisor.tex
@@ -2526,7 +2526,7 @@ Sv48x4, or Sv57x4, G-stage address translation is a variation on the usual
 page-based virtual address translation scheme of Sv32, Sv39, Sv48, or Sv57,
 respectively.
 In each case, the size of the incoming address is widened by 2~bits (to 34, 41,
-or 50 bits).
+50, or 59 bits).
 To accommodate the 2~extra bits, the root page table (only) is expanded by a
 factor of four to be 16~KiB instead of the usual 4~KiB.
 Matching its larger size, the root page table also must be aligned to a 16~KiB


### PR DESCRIPTION
The Sv57 example wasn't included in the list of expanded widths for the
*x4 modes.

Signed-off-by: Dylan Reid <dgreid@rivosinc.com>