### PR TITLE
Zihintntl: Fix number of hint instruction variants

### DIFF
--- a/src/zihintntl.tex
+++ b/src/zihintntl.tex
@@ -5,7 +5,7 @@ The NTL instructions are HINTs that indicate that the explicit memory accesses o
 instruction (henceforth ``target instruction'') exhibit poor temporal locality of reference.
 The NTL instructions do not change architectural state, nor do they alter the
 architecturally visible effects of the target instruction.
-Three variants are provided:
+Four variants are provided:
 
 The NTL.P1 instruction indicates that the target instruction
 does not exhibit temporal locality within the capacity of the innermost level


### PR DESCRIPTION
It seems too minor but this extension defines four hint variants, not three.

1. `NTL.P1` / `C.NTL.P1`
2. `NTL.PALL` / `C.NTL.PALL`
3. `NTL.S1` / `C.NTL.S1`
4. `NTL.ALL` / `C.NTL.ALL`

Possible old list of "three" hint instructions follow:

1. `NTL.L1`
2. `NTL.L2`
3. `NTL.LLC`