### PR TITLE
Refine HINT Instruction references (including tables)

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -1229,7 +1229,13 @@ HINTs will ever be defined in this subspace.
   C.LI                    & {\em rd}={\tt x0}                           & 64          & \\ \cline{1-3}
   C.LUI                   & {\em rd}={\tt x0}, {\em nzimm}$\neq$0       & 63          & \\ \cline{1-3}
   C.MV                    & {\em rd}={\tt x0}, {\em rs2}$\neq${\tt x0}  & 31          & \\ \cline{1-3}
-  C.ADD                   & {\em rd}={\tt x0}, {\em rs2}$\neq${\tt x0}  & 31          & \\ \hline \hline
+  C.ADD                   & {\em rd}={\tt x0}, {\em rs2}$\neq${\tt x0}, {\em rs2}$\neq${\tt x2}--{\tt x5} & 27   & \\ \hline
+  \multirow{4}{*}{C.ADD}  & \multirow{4}{*}{{\em rd}={\tt x0}, {\em rs2}={\tt x2}--{\tt x5}}
+                                                                        & \multirow{4}{*}{$4$}
+                                                                                      & ({\em rs2}={\tt x2}) C.NTL.P1 \\
+                          &                                             &             & ({\em rs2}={\tt x3}) C.NTL.PALL \\
+                          &                                             &             & ({\em rs2}={\tt x4}) C.NTL.S1 \\
+                          &                                             &             & ({\em rs2}={\tt x5}) C.NTL.ALL \\ \hline
   \multirow{2}{*}{C.SLLI} & \multirow{2}{*}{{\em rd}={\tt x0}, {\em nzimm}$\neq$0} & 31 (RV32)   & \multirow{6}{*}{\em Designated for custom use} \\
                           &                                             & 63 (RV64/128) & \\ \cline{1-3}
   C.SLLI64                & {\em rd}={\tt x0}                           & 1           & \\ \cline{1-3}

--- a/src/c.tex
+++ b/src/c.tex
@@ -1216,7 +1216,7 @@ amenable to macro-op fusion.
 
 Table~\ref{tab:rvc-hints} lists all RVC HINT code points.  For RV32C, 78\% of
 the HINT space is reserved for standard HINTs, but none are presently defined.
-The remainder of the HINT space is designated for custom HINTs; no standard
+The remainder of the HINT space is designated for custom HINTs: no standard
 HINTs will ever be defined in this subspace.
 
 \begin{table}[hbt]

--- a/src/c.tex
+++ b/src/c.tex
@@ -1215,7 +1215,7 @@ amenable to macro-op fusion.
 \end{commentary}
 
 Table~\ref{tab:rvc-hints} lists all RVC HINT code points.  For RV32C, 78\% of
-the HINT space is reserved for standard HINTs, but none are presently defined.
+the HINT space is reserved for standard HINTs.
 The remainder of the HINT space is designated for custom HINTs: no standard
 HINTs will ever be defined in this subspace.
 

--- a/src/c.tex
+++ b/src/c.tex
@@ -1202,8 +1202,8 @@ instruction that happens not to mutate the architectural state.
 \end{commentary}
 
 RVC HINTs do not necessarily expand to their RVI HINT counterparts.  For
-example, \mbox{C.ADD {\em x0}, {\em t0}} might not encode the same HINT
-as \mbox{ADD {\em x0}, {\em x0}, {\em t0}}.
+example, \mbox{C.ADD {\em x0}, {\em a0}} might not encode the same HINT
+as \mbox{ADD {\em x0}, {\em x0}, {\em a0}}.
 
 \begin{commentary}
 The primary reason to not require an RVC HINT to expand to an RVI HINT

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1448,15 +1448,22 @@ simulation/emulation.
 \begin{tabular}{|l|l|c|l|}
   \hline
   Instruction           & Constraints                                 & Code Points & Purpose \\ \hline \hline
-  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{25}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{10}{*}{\em Reserved for future standard use} \\ \cline{1-3}
   AUIPC                 & {\em rd}={\tt x0}                           & $2^{20}$                    & \\ \cline{1-3}
   \multirow{2}{*}{ADDI} & {\em rd}={\tt x0}, and either               & \multirow{2}{*}{$2^{17}-1$} & \\
                         & {\em rs1}$\neq${\tt x0} or {\em imm}$\neq$0 &                             & \\ \cline{1-3}
   ANDI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   ORI                   & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   XORI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
-  ADD                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
-  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
+  ADD                   & {\em rd}={\tt x0}, {\em rs1}$\neq${\tt x0}  & $2^{10}-32$                 & \\ \cline{1-3}
+  \multirow{2}{*}{ADD}  & {\em rd}={\tt x0}, {\em rs1}={\tt x0},      & \multirow{2}{*}{$28$}       & \\
+                        & {\em rs2}$\neq${\tt x2}--{\tt x5}           &                             & \\ \hline
+  \multirow{4}{*}{ADD}  & \multirow{4}{*}{\shortstack[l]{{\em rd}={\tt x0}, {\em rs1}={\tt x0}, \\{\em rs2}={\tt x2}--{\tt x5}}}
+                                                                      & \multirow{4}{*}{$4$}        & ({\em rs2}={\tt x2}) NTL.P1 \\
+                        &                                             &                             & ({\em rs2}={\tt x3}) NTL.PALL \\
+                        &                                             &                             & ({\em rs2}={\tt x4}) NTL.S1 \\
+                        &                                             &                             & ({\em rs2}={\tt x5}) NTL.ALL \\ \hline
+  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{17}{*}{\em Reserved for future standard use} \\ \cline{1-3}
   AND                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   OR                    & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   XOR                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -274,7 +274,7 @@ will ever be defined in this subspace.
 \begin{tabular}{|l|l|c|l|}
   \hline
   Instruction           & Constraints                                 & Code Points & Purpose \\ \hline \hline
-  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{32}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{11}{*}{\em Reserved for future standard use} \\ \cline{1-3}
   AUIPC                 & {\em rd}={\tt x0}                           & $2^{20}$                    & \\ \cline{1-3}
   \multirow{2}{*}{ADDI} & {\em rd}={\tt x0}, and either               & \multirow{2}{*}{$2^{17}-1$} & \\
                         & {\em rs1}$\neq${\tt x0} or {\em imm}$\neq$0 &                             & \\ \cline{1-3}
@@ -282,8 +282,15 @@ will ever be defined in this subspace.
   ORI                   & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   XORI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   ADDIW                 & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
-  ADD                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
-  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
+  ADD                   & {\em rd}={\tt x0}, {\em rs1}$\neq${\tt x0}  & $2^{10}-32$                 & \\ \cline{1-3}
+  \multirow{2}{*}{ADD}  & {\em rd}={\tt x0}, {\em rs1}={\tt x0},      & \multirow{2}{*}{$28$}       & \\
+                        & {\em rs2}$\neq${\tt x2}--{\tt x5}           &                             & \\ \hline
+  \multirow{4}{*}{ADD}  & \multirow{4}{*}{\shortstack[l]{{\em rd}={\tt x0}, {\em rs1}={\tt x0}, \\{\em rs2}={\tt x2}--{\tt x5}}}
+                                                                      & \multirow{4}{*}{$4$}        & ({\em rs2}={\tt x2}) NTL.P1 \\
+                        &                                             &                             & ({\em rs2}={\tt x3}) NTL.PALL \\
+                        &                                             &                             & ({\em rs2}={\tt x4}) NTL.S1 \\
+                        &                                             &                             & ({\em rs2}={\tt x5}) NTL.ALL \\ \hline
+  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{22}{*}{\em Reserved for future standard use} \\ \cline{1-3}
   AND                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   OR                    & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   XOR                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
@@ -306,7 +313,7 @@ will ever be defined in this subspace.
   \multirow{2}{*}{FENCE}& {\em rd}={\em rs1}={\tt x0}, {\em fm}=0,    & \multirow{2}{*}{15}         & \\
                         & {\em pred}$\neq$W, {\em succ}=0             &                             & \\ \hline
   \multirow{2}{*}{FENCE}& {\em rd}={\em rs1}={\tt x0}, {\em fm}=0,    & \multirow{2}{*}{1}          & \multirow{2}{*}{PAUSE} \\
-                        & {\em pred}=W, {\em succ}=0                  &                             & \\ \hline \hline
+                        & {\em pred}=W, {\em succ}=0                  &                             & \\ \hline
   SLTI                  & {\em rd}={\tt x0}                           & $2^{17}$                    & \multirow{10}{*}{\em Designated for custom use} \\ \cline{1-3}
   SLTIU                 & {\em rd}={\tt x0}                           & $2^{17}$                    & \\ \cline{1-3}
   SLLI                  & {\em rd}={\tt x0}                           & $2^{11}$                    & \\ \cline{1-3}

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -265,8 +265,8 @@ additional computational instructions in RV64I expand both the standard and
 custom HINT encoding spaces.
 
 Table~\ref{tab:rv64i-hints} lists all RV64I HINT code points.  91\% of the HINT
-space is reserved for standard HINTs, but none are presently defined.  The
-remainder of the HINT space is designated for custom HINTs; no standard HINTs
+space is reserved for standard HINTs.  The
+remainder of the HINT space is designated for custom HINTs: no standard HINTs
 will ever be defined in this subspace.
 
 \begin{table}[hbt]


### PR DESCRIPTION
Assuming Zihintntl extension to be frozen, ratified and merged, this pull request changes refines various locations related to HINT instructions.  Note that there are some changes *not* involving Zihintntl extension.

## Commit 1,2: Reflect "PAUSE" instruction and formatting

Commit ea9410a6a5ea by @aswaterman added "PAUSE" instruction and changed semicolon to colon.
Commit 1 and 2 ports this change to RV64I and RVC (RV64I change is a must).

## Commit 3: Change compressed hint example

From section 18.7 "HINT Instructions" (RVC):

> RVC HINTs do not necessarily expand to their RVI HINT counterparts. For example, `C.ADD x0, t0` might not encode the same HINT as `ADD x0, x0, t0`.

However, Zihintntl extension actually defines `C.NTL.ALL = C.ADD x0, t0[x5]`, which encodes the same hint as `NTL.ALL = ADD x0, x0, t0[x5]`.  This commit changes `t0[x5]` to `a0[x10]` to use unused encoding space available (suitable for an example).

## Commit 4,5: Add Zihintntl hints

I used new compressed format in the tables for a good reason.  Because it can cause various problems when a table exceeds the size of one page (and need major changes to the table design), I chose that design (in commit 4) to avoid using new package (`longtable` for example).

I hope new AsciiDoc documentation avoids this problem by design.

Commit 5 removes "no hints are defined" text in RVC, reflecting added Zihintntl hints.  This change is separate from commit 2 so that we can easily decide whether or not to merge Zihintntl-related changes.

# TODO 1: "RV32/64G Instruction Set Listings" (Chapter 26)

I didn't change "RV32/64G Instruction Set Listings" because it's based on output from [riscv-opcodes](https://github.com/riscv/riscv-opcodes).

# TODO 2: Zicbop HINT instructions

Recently ratified Zicbop HINT instructions (`ORI`-based) are not in the table (because it's not in the ISA Manual). If CMO instructions are to be added in the ISA Manual, they must be included later.  For this, [riscv-opcodes](https://github.com/riscv/riscv-opcodes) changes are not required because I already made changes.

However, do not replace `instr-table.tex` from riscv-opcodes yet because it lacks Zfh extension support.