### PR TITLE
Update Instruction Tables based on riscv-opcodes

### DIFF
--- a/src/instr-table.tex
+++ b/src/instr-table.tex
@@ -78,28 +78,28 @@
 &
 \multicolumn{10}{c}{\bf RV32I Base Instruction Set} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{8}{|c|}{imm[31:12]} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110111} & LUI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{8}{|c|}{imm[31:12]} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010111} & AUIPC \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{8}{|c|}{imm[20$\vert$10:1$\vert$11$\vert$19:12]} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1101111} & JAL \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -108,7 +108,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1100111} & JALR \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -118,7 +118,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BEQ \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -128,7 +128,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BNE \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -138,7 +138,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BLT \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -148,7 +148,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BGE \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -158,7 +158,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BLTU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[12$\vert$10:5]} &
@@ -168,7 +168,7 @@
 \multicolumn{1}{c|}{imm[4:1$\vert$11]} &
 \multicolumn{1}{c|}{1100011} & BGEU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -177,7 +177,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LB \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -186,7 +186,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LH \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -195,7 +195,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -204,7 +204,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LBU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -213,7 +213,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LHU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -223,7 +223,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100011} & SB \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -233,7 +233,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100011} & SH \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -243,7 +243,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100011} & SW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -252,7 +252,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & ADDI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -261,7 +261,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SLTI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -270,7 +270,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SLTIU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -279,7 +279,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & XORI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -288,7 +288,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & ORI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -297,7 +297,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & ANDI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -307,7 +307,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SLLI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -317,7 +317,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SRLI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -327,7 +327,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SRAI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -337,7 +337,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & ADD \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -347,7 +347,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SUB \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -357,7 +357,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SLL \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -367,7 +367,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SLT \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -377,7 +377,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SLTU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -387,7 +387,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & XOR \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -397,7 +397,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SRL \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -407,7 +407,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & SRA \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -417,7 +417,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & OR \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -427,7 +427,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & AND \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{fm} &
@@ -438,7 +438,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0001111} & FENCE \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{1000} &
@@ -449,7 +449,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{0001111} & FENCE.TSO \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{0000} &
@@ -460,7 +460,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{0001111} & PAUSE \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{000000000000} &
@@ -469,7 +469,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & ECALL \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{000000000001} &
@@ -478,14 +478,14 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & EBREAK \\
 \cline{2-11}
-  
+
 
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-  
+
 
 \newpage
 
@@ -542,7 +542,7 @@
 &
 \multicolumn{10}{c}{\bf RV64I Base Instruction Set (in addition to RV32I)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -551,7 +551,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LWU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -560,7 +560,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000011} & LD \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -570,7 +570,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100011} & SD \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{3}{|c|}{000000} &
@@ -580,7 +580,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SLLI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{3}{|c|}{000000} &
@@ -590,7 +590,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SRLI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{3}{|c|}{010000} &
@@ -600,7 +600,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0010011} & SRAI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -609,7 +609,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0011011} & ADDIW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -619,7 +619,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0011011} & SLLIW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -629,7 +629,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0011011} & SRLIW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -639,7 +639,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0011011} & SRAIW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -649,7 +649,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & ADDW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -659,7 +659,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & SUBW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -669,7 +669,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & SLLW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -679,7 +679,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & SRLW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -689,14 +689,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & SRAW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV32/RV64 \emph{Zifencei} Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -705,14 +705,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0001111} & FENCE.I \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV32/RV64 \emph{Zicsr} Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -721,7 +721,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -730,7 +730,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRS \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -739,7 +739,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRC \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -748,7 +748,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRWI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -757,7 +757,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRSI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{csr} &
@@ -766,14 +766,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRCI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV32M Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -783,7 +783,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & MUL \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -793,7 +793,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & MULH \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -803,7 +803,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & MULHSU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -813,7 +813,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & MULHU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -823,7 +823,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & DIV \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -833,7 +833,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & DIVU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -843,7 +843,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & REM \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -853,14 +853,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0110011} & REMU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV64M Standard Extension (in addition to RV32M)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -870,7 +870,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & MULW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -880,7 +880,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & DIVW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -890,7 +890,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & DIVUW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -900,7 +900,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & REMW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -910,14 +910,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0111011} & REMUW \\
 \cline{2-11}
-  
+
 
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-  
+
 
 \newpage
 
@@ -955,7 +955,7 @@
 &
 \multicolumn{10}{c}{\bf RV32A Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00010} &
@@ -967,7 +967,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & LR.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00011} &
@@ -979,7 +979,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & SC.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00001} &
@@ -991,7 +991,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOSWAP.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00000} &
@@ -1003,7 +1003,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOADD.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00100} &
@@ -1015,7 +1015,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOXOR.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{01100} &
@@ -1027,7 +1027,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOAND.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{01000} &
@@ -1039,7 +1039,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOOR.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{10000} &
@@ -1051,7 +1051,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMIN.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{10100} &
@@ -1063,7 +1063,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMAX.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{11000} &
@@ -1075,7 +1075,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMINU.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{11100} &
@@ -1087,14 +1087,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMAXU.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV64A Standard Extension (in addition to RV32A)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00010} &
@@ -1106,7 +1106,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & LR.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00011} &
@@ -1118,7 +1118,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & SC.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00001} &
@@ -1130,7 +1130,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOSWAP.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00000} &
@@ -1142,7 +1142,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOADD.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{00100} &
@@ -1154,7 +1154,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOXOR.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{01100} &
@@ -1166,7 +1166,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOAND.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{01000} &
@@ -1178,7 +1178,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOOR.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{10000} &
@@ -1190,7 +1190,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMIN.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{10100} &
@@ -1202,7 +1202,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMAX.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{11000} &
@@ -1214,7 +1214,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMINU.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{11100} &
@@ -1226,14 +1226,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0101111} & AMOMAXU.D \\
 \cline{2-11}
-  
+
 
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-  
+
 
 \newpage
 
@@ -1275,7 +1275,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{opcode} & R4-type \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -1301,7 +1301,7 @@
 &
 \multicolumn{10}{c}{\bf RV32F Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -1310,7 +1310,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000111} & FLW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -1320,7 +1320,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100111} & FSW \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1331,7 +1331,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000011} & FMADD.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1342,7 +1342,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000111} & FMSUB.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1353,7 +1353,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001011} & FNMSUB.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1364,7 +1364,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001111} & FNMADD.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000000} &
@@ -1374,7 +1374,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FADD.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000100} &
@@ -1384,7 +1384,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSUB.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001000} &
@@ -1394,7 +1394,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMUL.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001100} &
@@ -1404,7 +1404,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FDIV.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0101100} &
@@ -1414,7 +1414,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSQRT.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010000} &
@@ -1424,7 +1424,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJ.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010000} &
@@ -1434,7 +1434,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJN.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010000} &
@@ -1444,7 +1444,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJX.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010100} &
@@ -1454,7 +1454,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMIN.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010100} &
@@ -1464,7 +1464,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMAX.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100000} &
@@ -1474,7 +1474,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.W.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100000} &
@@ -1484,7 +1484,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.WU.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1110000} &
@@ -1494,7 +1494,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMV.X.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010000} &
@@ -1504,7 +1504,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FEQ.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010000} &
@@ -1514,7 +1514,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLT.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010000} &
@@ -1524,7 +1524,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLE.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1110000} &
@@ -1534,7 +1534,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCLASS.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101000} &
@@ -1544,7 +1544,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101000} &
@@ -1554,7 +1554,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.WU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1111000} &
@@ -1564,14 +1564,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMV.W.X \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV64F Standard Extension (in addition to RV32F)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100000} &
@@ -1581,7 +1581,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.L.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100000} &
@@ -1591,7 +1591,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.LU.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101000} &
@@ -1601,7 +1601,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.L \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101000} &
@@ -1611,14 +1611,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.LU \\
 \cline{2-11}
-  
+
 
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-  
+
 
 \newpage
 
@@ -1660,7 +1660,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{opcode} & R4-type \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -1686,7 +1686,7 @@
 &
 \multicolumn{10}{c}{\bf RV32D Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -1695,7 +1695,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000111} & FLD \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -1705,7 +1705,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100111} & FSD \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1716,7 +1716,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000011} & FMADD.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1727,7 +1727,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000111} & FMSUB.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1738,7 +1738,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001011} & FNMSUB.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -1749,7 +1749,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001111} & FNMADD.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000001} &
@@ -1759,7 +1759,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FADD.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000101} &
@@ -1769,7 +1769,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSUB.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001001} &
@@ -1779,7 +1779,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMUL.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001101} &
@@ -1789,7 +1789,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FDIV.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0101101} &
@@ -1799,7 +1799,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSQRT.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010001} &
@@ -1809,7 +1809,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJ.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010001} &
@@ -1819,7 +1819,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJN.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010001} &
@@ -1829,7 +1829,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJX.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010101} &
@@ -1839,7 +1839,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMIN.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010101} &
@@ -1849,7 +1849,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMAX.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -1859,7 +1859,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100001} &
@@ -1869,7 +1869,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010001} &
@@ -1879,7 +1879,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FEQ.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010001} &
@@ -1889,7 +1889,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLT.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010001} &
@@ -1899,7 +1899,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLE.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1110001} &
@@ -1909,7 +1909,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCLASS.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100001} &
@@ -1919,7 +1919,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.W.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100001} &
@@ -1929,7 +1929,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.WU.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101001} &
@@ -1939,7 +1939,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101001} &
@@ -1949,14 +1949,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.WU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV64D Standard Extension (in addition to RV32D)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100001} &
@@ -1966,7 +1966,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.L.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100001} &
@@ -1976,7 +1976,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.LU.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1110001} &
@@ -1986,7 +1986,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMV.X.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101001} &
@@ -1996,7 +1996,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.L \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101001} &
@@ -2006,7 +2006,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.LU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1111001} &
@@ -2016,14 +2016,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMV.D.X \\
 \cline{2-11}
-  
+
 
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-  
+
 
 \newpage
 
@@ -2065,7 +2065,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{opcode} & R4-type \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -2091,7 +2091,7 @@
 &
 \multicolumn{10}{c}{\bf RV32Q Standard Extension} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{6}{|c|}{imm[11:0]} &
@@ -2100,7 +2100,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{0000111} & FLQ \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{imm[11:5]} &
@@ -2110,7 +2110,7 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{0100111} & FSQ \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -2121,7 +2121,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000011} & FMADD.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -2132,7 +2132,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1000111} & FMSUB.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -2143,7 +2143,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001011} & FNMSUB.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{2}{|c|}{rs3} &
@@ -2154,7 +2154,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1001111} & FNMADD.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000011} &
@@ -2164,7 +2164,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FADD.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0000111} &
@@ -2174,7 +2174,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSUB.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001011} &
@@ -2184,7 +2184,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMUL.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001111} &
@@ -2194,7 +2194,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FDIV.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0101111} &
@@ -2204,7 +2204,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSQRT.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010011} &
@@ -2214,7 +2214,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJ.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010011} &
@@ -2224,7 +2224,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJN.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010011} &
@@ -2234,7 +2234,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FSGNJX.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010111} &
@@ -2244,7 +2244,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMIN.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010111} &
@@ -2254,7 +2254,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FMAX.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100000} &
@@ -2264,7 +2264,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.S.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100011} &
@@ -2274,7 +2274,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.Q.S \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100001} &
@@ -2284,7 +2284,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0100011} &
@@ -2294,7 +2294,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.Q.D \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010011} &
@@ -2304,7 +2304,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FEQ.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010011} &
@@ -2314,7 +2314,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLT.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1010011} &
@@ -2324,7 +2324,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FLE.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1110011} &
@@ -2334,7 +2334,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCLASS.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100011} &
@@ -2344,7 +2344,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.W.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100011} &
@@ -2354,7 +2354,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.WU.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101011} &
@@ -2364,7 +2364,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.Q.W \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101011} &
@@ -2374,14 +2374,14 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.Q.WU \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf RV64Q Standard Extension (in addition to RV32Q)} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100011} &
@@ -2391,7 +2391,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.L.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1100011} &
@@ -2401,7 +2401,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.LU.Q \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101011} &
@@ -2411,7 +2411,7 @@
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.Q.L \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{1101011} &
@@ -2422,12 +2422,12 @@
 \multicolumn{1}{c|}{1010011} & FCVT.Q.LU \\
 \cline{2-11}
 
+
 \end{tabular}
 \end{center}
 \end{small}
 
 \end{table}
-
 
 
 \newpage
@@ -2489,7 +2489,6 @@
 \multicolumn{1}{c|}{imm[4:0]} &
 \multicolumn{1}{c|}{opcode} & S-type \\
 \cline{2-11}
-
 
 
 &
@@ -2673,12 +2672,32 @@
 
 
 &
+\multicolumn{4}{|c|}{0100010} &
+\multicolumn{2}{c|}{00000} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{rm} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{1010011} & FCVT.H.S \\
+\cline{2-11}
+
+
+&
 \multicolumn{4}{|c|}{0100001} &
 \multicolumn{2}{c|}{00010} &
 \multicolumn{1}{c|}{rs1} &
 \multicolumn{1}{c|}{rm} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.D.H \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0100010} &
+\multicolumn{2}{c|}{00001} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{rm} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{1010011} & FCVT.H.D \\
 \cline{2-11}
 
 
@@ -2694,41 +2713,11 @@
 
 &
 \multicolumn{4}{|c|}{0100010} &
-\multicolumn{2}{c|}{00000} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{rm} &
-\multicolumn{1}{c|}{rd} &
-\multicolumn{1}{c|}{1010011} & FCVT.H.S \\
-\cline{2-11}
-
-
-&
-\multicolumn{4}{|c|}{0100010} &
-\multicolumn{2}{c|}{00001} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{rm} &
-\multicolumn{1}{c|}{rd} &
-\multicolumn{1}{c|}{1010011} & FCVT.H.D \\
-\cline{2-11}
-
-
-&
-\multicolumn{4}{|c|}{0100010} &
 \multicolumn{2}{c|}{00011} &
 \multicolumn{1}{c|}{rs1} &
 \multicolumn{1}{c|}{rm} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.H.Q \\
-\cline{2-11}
-
-
-&
-\multicolumn{4}{|c|}{1110010} &
-\multicolumn{2}{c|}{00000} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{rd} &
-\multicolumn{1}{c|}{1010011} & FMV.X.H \\
 \cline{2-11}
 
 
@@ -2789,6 +2778,16 @@
 \multicolumn{1}{c|}{rm} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1010011} & FCVT.WU.H \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{1110010} &
+\multicolumn{2}{c|}{00000} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{1010011} & FMV.X.H \\
 \cline{2-11}
 
 

--- a/src/priv-instr-table.tex
+++ b/src/priv-instr-table.tex
@@ -54,7 +54,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & SRET \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0011000} &
@@ -64,14 +64,14 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & MRET \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf Interrupt-Management Instructions} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001000} &
@@ -81,14 +81,14 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & WFI \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf Supervisor Memory-Management Instructions} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0001001} &
@@ -98,44 +98,14 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & SFENCE.VMA \\
 \cline{2-11}
-  
 
-&
-\multicolumn{4}{|c|}{0001011} &
-\multicolumn{2}{c|}{rs2} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{1110011} & SINVAL.VMA \\
-\cline{2-11}
-  
-
-&
-\multicolumn{4}{|c|}{0001100} &
-\multicolumn{2}{c|}{00000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{1110011} & SFENCE.W.INVAL \\
-\cline{2-11}
-  
-
-&
-\multicolumn{4}{|c|}{0001100} &
-\multicolumn{2}{c|}{00001} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{1110011} & SFENCE.INVAL.IR \\
-\cline{2-11}
-  
 
 &
 \multicolumn{10}{c}{} & \\
 &
 \multicolumn{10}{c}{\bf Hypervisor Memory-Management Instructions} & \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0010001} &
@@ -145,7 +115,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & HFENCE.VVMA \\
 \cline{2-11}
-  
+
 
 &
 \multicolumn{4}{|c|}{0110001} &
@@ -155,27 +125,7 @@
 \multicolumn{1}{c|}{00000} &
 \multicolumn{1}{c|}{1110011} & HFENCE.GVMA \\
 \cline{2-11}
-  
 
-&
-\multicolumn{4}{|c|}{0010011} &
-\multicolumn{2}{c|}{rs2} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{1110011} & HINVAL.VVMA \\
-\cline{2-11}
-  
-
-&
-\multicolumn{4}{|c|}{0110011} &
-\multicolumn{2}{c|}{rs2} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{000} &
-\multicolumn{1}{c|}{00000} &
-\multicolumn{1}{c|}{1110011} & HINVAL.GVMA \\
-\cline{2-11}
-  
 
 &
 \multicolumn{10}{c}{} & \\
@@ -225,22 +175,22 @@
 
 
 &
-\multicolumn{4}{|c|}{0110010} &
-\multicolumn{2}{c|}{00011} &
-\multicolumn{1}{c|}{rs1} &
-\multicolumn{1}{c|}{100} &
-\multicolumn{1}{c|}{rd} &
-\multicolumn{1}{c|}{1110011} & HLVX.HU \\
-\cline{2-11}
-
-
-&
 \multicolumn{4}{|c|}{0110100} &
 \multicolumn{2}{c|}{00000} &
 \multicolumn{1}{c|}{rs1} &
 \multicolumn{1}{c|}{100} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & HLV.W \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0110010} &
+\multicolumn{2}{c|}{00011} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{100} &
+\multicolumn{1}{c|}{rd} &
+\multicolumn{1}{c|}{1110011} & HLVX.HU \\
 \cline{2-11}
 
 
@@ -321,9 +271,66 @@
 \cline{2-11}
 
 
+&
+\multicolumn{10}{c}{} & \\
+&
+\multicolumn{10}{c}{\bf \emph{Svinval} Memory-Management Extension} & \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0001011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SINVAL.VMA \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0001100} &
+\multicolumn{2}{c|}{00000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SFENCE.W.INVAL \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0001100} &
+\multicolumn{2}{c|}{00001} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & SFENCE.INVAL.IR \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0010011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & HINVAL.VVMA \\
+\cline{2-11}
+
+
+&
+\multicolumn{4}{|c|}{0110011} &
+\multicolumn{2}{c|}{rs2} &
+\multicolumn{1}{c|}{rs1} &
+\multicolumn{1}{c|}{000} &
+\multicolumn{1}{c|}{00000} &
+\multicolumn{1}{c|}{1110011} & HINVAL.GVMA \\
+\cline{2-11}
+
+
 \end{tabular}
 \end{center}
 \end{small}
 \caption{RISC-V Privileged Instructions}
 \end{table}
-  
+


### PR DESCRIPTION
Now, the entire instruction tables are generated by [riscv-opcodes](https://github.com/riscv/riscv-opcodes).

Related: riscv/riscv-opcodes#99

But CMO instructions are manually deleted because they are not in the ISA Manual yet.

Relatively large diff came from removing trailing spaces (riscv/riscv-opcodes#98). Others are came from slight instruction order modifications (on Zfh, hypervisor and Svinval instructions).