### PR TITLE
Zihintntl: fix chapter label

### DIFF
--- a/src/zihintntl.tex
+++ b/src/zihintntl.tex
@@ -1,5 +1,5 @@
 \chapter{``Zihintntl'' Non-Temporal Locality Hints, Version 0.2}
-\label{chap:zihintpause}
+\label{chap:zihintntl}
 
 The NTL instructions are HINTs that indicate that the explicit memory accesses of the immediately subsequent
 instruction (henceforth ``target instruction'') exhibit poor temporal locality of reference.


### PR DESCRIPTION
LaTeX produces this during build process:
```
  LaTeX Warning: Label `chap:zihintpause' multiply defined
```
It looks like the `chap:zihintpause' label was copy-pasted
from Zihintpause chapter.

The commit sets appropriate label for the Zihintntl chapter.