### PR TITLE
Add "N" to extension category list again

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -83,7 +83,7 @@ Chapter~\ref{chap:zifencei}; ``Zifencei2'' and ``Zifencei2p0'' name version
 2.0 of same.
 
 The first letter following the ``Z'' conventionally indicates the most closely
-related alphabetical extension category, IMAFDQLCBKJTPV.  For the ``Zam''
+related alphabetical extension category, IMAFDQLCBKJTPVN.  For the ``Zam''
 extension for misaligned atomics, for example, the letter ``a'' indicates the
 extension is related to the ``A'' standard extension.  If multiple ``Z''
 extensions are named, they should be ordered first by category, then


### PR DESCRIPTION
Despite that "N" extension itself is dropped (and no Zn* extensions are neither ratified nor proposed), canonical extension order should keep "N" to avoid future incompatibilities.

It effectively reverts half of commit f8d27f805b65 ("Remove or downgrade more references to N extension (#674)").