### PR TITLE
Strict single-letter extensions on Table 28.1 (Standard ISA extension names)

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -166,7 +166,7 @@ General & G & IMADZifencei \\
 Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\
 Packed-SIMD Extensions & P & \\
-Vector Extensions & V & \\
+Vector Extension & V & \\
 Control and Status Register Access & Zicsr & \\
 Instruction-Fetch Fence & Zifencei & \\
 Misaligned Atomics & Zam & A \\

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -165,9 +165,6 @@ General & G & IMADZifencei \\
 \hline
 Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\
-Bit Manipulation & B & \\
-Cryptography Extensions & K & \\
-Dynamic Languages & J & \\
 Packed-SIMD Extensions & P & \\
 Vector Extensions & V & \\
 Control and Status Register Access & Zicsr & \\


### PR DESCRIPTION
This branch resolves two issues on Table 28.1 (Standard ISA extension names):

1. `B`, `K` and `J` are not going to be single-letter extensions, making those appearance in the Table 28.1 unnecessary (or even misleading and harmful).  
   Those letters are referred in the section 28.6 (Additional Standard Extension Names) and Table 28.1 does not need them.
2. `V` is plural (actually `V` is [*an extension*](https://github.com/riscv/riscv-v-spec/releases/tag/v1.0) with some variable parameters such as vector length).

See commit c1c77c4902d5e7c58613d725d09d66a2a743da1c for background of this proposal for `B` and `J`.

For `K`, those might be helpful:
1. https://github.com/riscv/riscv-crypto/releases/tag/v0.9.3-scalar (with `misa.K`)
2. https://github.com/riscv/riscv-crypto/releases/tag/v0.9.4-scalar (WITHOUT `misa.K`)
3. https://github.com/riscv/riscv-crypto/releases/tag/v1.0.0-scalar (ratified; WITHOUT `misa.K`)

And how Ben Marshall responded in https://lists.riscv.org/g/tech-crypto-ext/topic/riscv_k_in_misa_risc_v/85354476 :
> > It says that misa.K bit is no more used. Does this mean that -misa=rv32gk is no more acceptable?
>
> Indeed. There is no longer a single letter which enables the entire extension. You should use one of the Zk* architecture strings to enable support in the compiler.