### PR TITLE
Draft: Proposal for 'H'-extension ordering

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -83,7 +83,7 @@ Chapter~\ref{chap:zifencei}; ``Zifencei2'' and ``Zifencei2p0'' name version
 2.0 of same.
 
 The first letter following the ``Z'' conventionally indicates the most closely
-related alphabetical extension category, IMAFDQLCBKJTPV.  For the ``Zam''
+related alphabetical extension category, IMAFDQLCBKJTPVH.  For the ``Zam''
 extension for misaligned atomics, for example, the letter ``a'' indicates the
 extension is related to the ``A'' standard extension.  If multiple ``Z''
 extensions are named, they should be ordered first by category, then
@@ -157,6 +157,7 @@ Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\
 Packed-SIMD Extensions & P & \\
 Vector Extension & V & D \\
+Hypervisor Extension & H & \\
 Control and Status Register Access & Zicsr & \\
 Instruction-Fetch Fence & Zifencei & \\
 Misaligned Atomics & Zam & A \\

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -104,16 +104,6 @@ Standard supervisor-level extensions should be listed after standard
 unprivileged extensions.  If multiple supervisor-level extensions are listed,
 they should be ordered alphabetically.
 
-\section{Hypervisor-level Instruction-Set Extensions}
-
-Standard hypervisor-level instruction-set extensions are named like
-supervisor-level extensions, but beginning with the letter ``H'' instead of
-the letter ``S''.
-
-Standard hypervisor-level extensions should be listed after standard
-lesser-privileged extensions.  If multiple hypervisor-level extensions are
-listed, they should be ordered alphabetically.
-
 \section{Machine-level Instruction-Set Extensions}
 
 Standard machine-level instruction-set extensions are prefixed with the three
@@ -176,11 +166,6 @@ Total Store Ordering & Ztso & \\
 \multicolumn{3}{|c|}{Standard Supervisor-Level Extensions}\\
 \hline
 Supervisor-level extension ``def'' & Sdef & \\
-\hline
-\hline
-\multicolumn{3}{|c|}{Standard Hypervisor-Level Extensions}\\
-\hline
-Hypervisor-level extension ``ghi'' & Hghi & \\
 \hline
 \hline
 \multicolumn{3}{|c|}{Standard Machine-Level Extensions}\\


### PR DESCRIPTION
Related: #837
PDF file (Chapter 28 only): https://github.com/a4lg/riscv-isa-manual/releases/tag/a4lg%2Fsnapshots%2F2022-04-23%2Fnaming-ext-ordering-pvnh.3

I hope this helps understanding outline of my proposal.