### PR TITLE
D extension is implied by V extension

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -166,7 +166,7 @@ General & G & IMADZifencei \\
 Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\
 Packed-SIMD Extensions & P & \\
-Vector Extension & V & \\
+Vector Extension & V & D \\
 Control and Status Register Access & Zicsr & \\
 Instruction-Fetch Fence & Zifencei & \\
 Misaligned Atomics & Zam & A \\


### PR DESCRIPTION
... as commented by Andrew Waterman:
https://github.com/riscv/riscv-isa-manual/pull/838#issuecomment-1107473631

Related: #838