### PR TITLE
M-mode's next implemented privilege mode should be "next-lower"

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1773,7 +1773,7 @@ counter, and writes change only bits 63--32.
 
 The counter-enable register {\tt mcounteren} is a 32-bit register that
 controls the availability of the hardware performance-monitoring counters to
-the next-lowest privileged mode.
+the next-lower privileged mode.
 
 \begin{figure*}[h!]
 {\footnotesize


### PR DESCRIPTION
M-mode's next implemented privilege mode should be "next-lower" instead of "next-lowest" mode.

From the content, the mcounteren controls the availability to the next implemented privilege mode (S-mode if implemented, otherwise U-mode).  The "next-lowest" does not match the concept, and the "next-lower" makes more sense, as shown below.
##############################
Implemented modes |  MSU   |  MU
     next-lowest  | S-mode | M-mode
     next-lower   | S-mode | U-mode
##############################
![Screenshot 2022-05-05 133823](https://user-images.githubusercontent.com/39526191/166868470-b0d762bd-324b-46d3-8bf8-ad7bc7f40fec.png)

