### PR TITLE
Make base ISA text generic with respect to IALIGN

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -147,10 +147,12 @@ RV32E subset, which only has 16 registers (Chapter~\ref{rv32e}).
 
 In the base RV32I ISA, there are four core instruction formats
 (R/I/S/U), as shown in Figure~\ref{fig:baseinstformats}.  All are a
-fixed 32 bits in length and must be aligned on a four-byte boundary in
-memory.  An instruction-address-misaligned exception is generated on a
-taken branch or unconditional jump if the target address is not
-four-byte aligned.  This exception is reported on the branch or jump
+fixed 32 bits in length.
+The base ISA has IALIGN=32, meaning that instructions must be aligned on
+a four-byte boundary in memory.
+An instruction-address-misaligned exception is generated on a taken branch or
+unconditional jump if the target address is not IALIGN-bit aligned.
+This exception is reported on the branch or jump
 instruction, not on the target instruction.  No
 instruction-address-misaligned exception is generated for a
 conditional branch that is not taken.
@@ -812,11 +814,11 @@ elsewhere in the address space.
 
 The JAL and JALR instructions will generate an
 instruction-address-misaligned exception if the target address is not
-aligned to a four-byte boundary.
+aligned to an IALIGN-bit boundary.
 
 \begin{commentary}
 Instruction-address-misaligned exceptions are not possible on machines
-that support extensions with 16-bit aligned instructions, such as the
+with IALIGN=16, such as those that support the
 compressed instruction-set extension, C.
 \end{commentary}
 
@@ -988,13 +990,13 @@ speculatively and out-of-order with respect to other code~\cite{ibmpower7}.
 
 The conditional branch instructions will generate an
 instruction-address-misaligned exception if the target address is not
-aligned to a four-byte boundary and the branch condition evaluates
+aligned to an IALIGN-bit boundary and the branch condition evaluates
 to true.  If the branch condition evaluates to false, the
 instruction-address-misaligned exception will not be raised.
 
 \begin{commentary}
 Instruction-address-misaligned exceptions are not possible on machines
-that support extensions with 16-bit aligned instructions, such as the
+with IALIGN=16, such as those that support the
 compressed instruction-set extension, C.
 \end{commentary}
 


### PR DESCRIPTION
The previous text explicitly required four-byte alignment, which is not the case in the presence of extensions that reduce IALIGN.