### PR TITLE
Remove a defunct commentary on reservation set sizes

### DIFF
--- a/src/a.tex
+++ b/src/a.tex
@@ -206,9 +206,6 @@ reservation set.
 
 A platform specification may constrain the size and shape of the reservation
 set.
-For example, the Unix platform is expected to require of main memory that the
-reservation set be of fixed size, contiguous, naturally aligned, and no
-greater than the virtual memory page size.
 \end{commentary}
 
 \begin{commentary}


### PR DESCRIPTION
As of f6fe734 ("More LR/SC updates") these rules are in the privileged
spec, thy're not in the platforms specs.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>