### PR TITLE
Add OP-V to base opcode map

### DIFF
--- a/src/opcode-map.tex
+++ b/src/opcode-map.tex
@@ -10,7 +10,7 @@
   inst[6:5] &        &          &                &          &        &                &                      & \cellcolor{gray}($>32b$)  \\ \hline
          00 & LOAD   & LOAD-FP  & {\em custom-0} & MISC-MEM & OP-IMM & AUIPC          & OP-IMM-32            & \cellcolor{gray} $48b$\\ \hline
          01 & STORE  & STORE-FP & {\em custom-1} & AMO      & OP     & LUI            & OP-32                & \cellcolor{gray} $64b$ \\ \hline
-         10 & MADD   & MSUB     & NMSUB          & NMADD    & OP-FP  & {\em reserved} & {\em custom-2/rv128} & \cellcolor{gray} $48b$\\ \hline
+         10 & MADD   & MSUB     & NMSUB          & NMADD    & OP-FP  & OP-V           & {\em custom-2/rv128} & \cellcolor{gray} $48b$\\ \hline
          11 & BRANCH & JALR     & {\em reserved} & JAL      & SYSTEM & {\em reserved} & {\em custom-3/rv128} & \cellcolor{gray} $\geq80b$\\ \hline
 
  \end{tabular}


### PR DESCRIPTION
`V` extension corresponding new base opcode OP-V (`0b1010111`) is now ratified and this table is updated.

Although vector instructions are not listed in Chapter 26, noting that this base opcode is used seems good to me. If `Zp*` extensions are ratified, OP-P (`0b1110111`) can be listed here, too.