### PR TITLE
Clarify that time CSR one-tick constraint is not merely user-level

### DIFF
--- a/src/counters.tex
+++ b/src/counters.tex
@@ -63,7 +63,7 @@ to read these CSRs.
 \end{commentary}
 
 For base ISAs with XLEN=32, the Zicntr extension enables the three
-64-bit read-only user-level counters to be accessed in 32-bit pieces.
+64-bit read-only counters to be accessed in 32-bit pieces.
 The RDCYCLE, RDTIME, and RDINSTRET pseudoinstructions provide the lower 32
 bits, and the RDCYCLEH, RDTIMEH, and RDINSTRETH pseudoinstructions provide
 the upper 32 bits of the respective counters.
@@ -165,7 +165,7 @@ wide variety of possible implementation platforms.  The maximum error
 bound should be set based on the requirements of the platform.
 \end{commentary}
 
-The real-time clocks of all harts in a single user application
+The real-time clocks of all harts
 must be synchronized to within one tick of the real-time clock.
 
 \begin{commentary}


### PR DESCRIPTION
It's effectively an unprivileged constraint, not just user-level.