### PR TITLE
Svpbmt: leaf PTE reserved value=3 page fault

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -2432,6 +2432,10 @@ For non-leaf PTEs, bits 62--61 are reserved for future standard use.  Until
 their use is defined by a standard extension, they must be cleared by software
 for forward compatibility, or else a page-fault exception is raised.
 
+For leaf PTEs, bits 62–-61 value=3 is reserved for future standard use. Until
+this value is defined by a standard extension, using this reserved value in a
+leaf PTE raises a page-fault exception.
+
 If the underlying physical memory attribute for a page is vacant, the PBMT settings do not override that.
 
 When PBMT settings override a main memory page into I/O or vice versa, memory


### PR DESCRIPTION
@gfavor pointed out that this is already stated elsewhere:

> fundamentally, the tablewalk pseudo code says "if any bits or encodings that are reserved for future standard use are set within pte, stop and raise a page-fault exception corresponding to the original access type."

https://github.com/riscv/riscv-isa-manual/blob/f518c259c008f926eba4aba67804f62531b6e94b/src/supervisor.tex#L1677-L1679

Nevertheless, I think this clarification would be equally as helpful here as the existing adjacent statement for non-leaf PTEs.