### PR TITLE
Updating 'G' definition

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -151,7 +151,7 @@ Atomics & A & \\
 Single-Precision Floating-Point & F & Zicsr \\
 Double-Precision Floating-Point & D & F \\
 \hline
-General & G & IMADZifencei \\
+General & G & IMAFDZicsr_Zifencei \\
 \hline
 Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\


### PR DESCRIPTION
Updating 'G' definition to match the definitions in section 28.3 and the beginning of chapter 26 to avoid confusion for casual readers (although technically all three are equivalent based on D implying F implying Zicsr).
