### PR TITLE
Fix missing backslash

### DIFF
--- a/src/naming.tex
+++ b/src/naming.tex
@@ -151,7 +151,7 @@ Atomics & A & \\
 Single-Precision Floating-Point & F & Zicsr \\
 Double-Precision Floating-Point & D & F \\
 \hline
-General & G & IMAFDZicsr_Zifencei \\
+General & G & IMAFDZicsr\_Zifencei \\
 \hline
 Quad-Precision Floating-Point & Q & D\\
 16-bit Compressed Instructions & C & \\


### PR DESCRIPTION
Signed-off-by: John Zaitseff <J.Zaitseff@zap.org.au>

Fixes bug #875