### PR TITLE
Standardize on {\tt pc}, rather than PC

### DIFF
--- a/src/c.tex
+++ b/src/c.tex
@@ -697,7 +697,7 @@ with $\textit{rs1}{=}\texttt{x0}$ corresponds to the C.EBREAK instruction.
 
 \begin{commentary}
 Strictly speaking, C.JALR does not expand exactly to a base RVI
-instruction as the value added to the PC to form the link address is 2
+instruction as the value added to the {\tt pc} to form the link address is 2
 rather than 4 as in the base ISA, but supporting both offsets of 2 and
 4 bytes is only a very minor change to the base microarchitecture.
 \end{commentary}

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1159,7 +1159,7 @@ extension to further reduce context save and restore overhead.
 The SD bit is read-only and is set when either the FS, VS, or XS bits
 encode a Dirty state (i.e., SD=((FS==11) OR (XS==11) OR (VS==11))).  This allows
 privileged code to quickly determine when no additional context save is
-required beyond the integer register set and PC.
+required beyond the integer register set and {\tt pc}.
 
 The floating-point unit state is always initialized, saved, and
 restored using standard instructions (F, D, and/or Q), and privileged

--- a/src/preface.tex
+++ b/src/preface.tex
@@ -384,8 +384,8 @@ specification.
 \item An AMO for fetch-and-XOR (AMOXOR) has been added, and the
   encoding for AMOSWAP has been changed to make room.
 \item The AUIPC instruction, which adds a 20-bit upper immediate to
-  the PC, replaces the RDNPC instruction, which only read the current
-  PC value.  This results in significant savings for position-independent
+  the {\tt pc}, replaces the RDNPC instruction, which only read the current
+  {\tt pc} value.  This results in significant savings for position-independent
   code.
 \item The JAL instruction has now moved to the U-Type format with an
   explicit destination register, and the J instruction has been

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -392,7 +392,7 @@ Number    & Privilege & Name & Description \\
 \multicolumn{4}{|c|}{Debug Mode Registers } \\
 \hline
 \tt 0x7B0 & DRW &\tt dcsr & Debug control and status register. \\
-\tt 0x7B1 & DRW &\tt dpc & Debug PC. \\
+\tt 0x7B1 & DRW &\tt dpc & Debug program counter. \\
 \tt 0x7B2 & DRW &\tt dscratch0 & Debug scratch register 0. \\
 \tt 0x7B3 & DRW &\tt dscratch1 & Debug scratch register 1. \\
 \hline

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -107,7 +107,7 @@ Additionally, the following compatible changes have been made since version
 \item Clarify the architectural behavior of address-translation caches
 \item Added Sv57 and Sv57x4 address translation modes.
 \item Software breakpoint exceptions are permitted to write either 0
-  or the PC to {\em x}\/{\tt tval}.
+  or the {\tt pc} to {\em x}\/{\tt tval}.
 \item Clarified that bare S-mode need not support the SFENCE.VMA instruction.
 \item Specified relaxed constraints for implicit reads of non-idempotent
   regions.

--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -589,15 +589,15 @@ The assembly syntax for {\tt lui} and {\tt auipc} does not represent the lower
 12 bits of the U-immediate, which are always zero.
 
 The AUIPC instruction supports two-instruction sequences to access
-arbitrary offsets from the PC for both control-flow transfers and data
+arbitrary offsets from the {\tt pc} for both control-flow transfers and data
 accesses.  The combination of an AUIPC and the 12-bit immediate in a
-JALR can transfer control to any 32-bit PC-relative address, while an
+JALR can transfer control to any 32-bit {\tt pc}-relative address, while an
 AUIPC plus the 12-bit immediate offset in regular load or store
-instructions can access any 32-bit PC-relative data address.
+instructions can access any 32-bit {\tt pc}-relative data address.
 
-The current PC can be obtained by setting the U-immediate to 0.
+The current {\tt pc} can be obtained by setting the U-immediate to 0.
 Although a JAL +4 instruction could also be used to obtain the local
-PC (of the instruction following the JAL), it might cause pipeline
+{\tt pc} (of the instruction following the JAL), it might cause pipeline
 breaks in simpler microarchitectures or pollute branch-target buffer
 structures in more complex microarchitectures.
 \end{commentary}
@@ -782,7 +782,7 @@ offset[11:0] & base & 0 & dest & JALR \\
 \end{center}
 
 \begin{commentary}
-The unconditional jump instructions all use PC-relative addressing to
+The unconditional jump instructions all use {\tt pc}-relative addressing to
 help support position-independent code.  The JALR instruction was
 defined to enable a two-instruction sequence to jump anywhere in a
 32-bit absolute address range.  A LUI instruction can first load {\em
@@ -926,7 +926,7 @@ learn any predictable branch behavior.
 Unlike some other architectures, the RISC-V jump (JAL with {\em
   rd}={\tt x0}) instruction should always be used for unconditional
 branches instead of a conditional branch instruction with an
-always-true condition.  RISC-V jumps are also PC-relative and support
+always-true condition.  RISC-V jumps are also {\tt pc}-relative and support
 a much wider offset range than branches, and will not pollute
 conditional-branch prediction tables.
 


### PR DESCRIPTION
We were using a mix of the two, with a bias towards the former.

Resolves #887