### PR TITLE
Add RISu064 to open-source marchid list

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -47,3 +47,4 @@ Hummingbirdv2 E203  | Nuclei System Technology  | [Can Hu](mailto:canhu@nucleisy
 Hazard3       | Luke Wren                       | [Luke Wren](mailto:wren6991@gmail.com)                       | 27                | https://github.com/wren6991/hazard3
 CV32E41P      | OpenHW Group                    | [Mark Hill](mailto:mark.hill@huawei.com), OpenHW Group        | 28            | https://github.com/openhwgroup/cv32e41p
 Rift          | Jianhu Lab, WUT                 | [Ruige Lee](mailto:295054118@whut.edu.cn)                     | 29            | [RiftCore](https://github.com/whutddk/RiftCore), [Rift2Core](https://github.com/whutddk/Rift2Core)
+RISu064       | Wenting Zhang                   | [Wenting Zhang](mailto:zephray@outlook.com)                 | 30                | https://github.com/zephray/RISu064


### PR DESCRIPTION
This is a 7-stage 2-way superscalar RV64I core, with optional support for M extension/ MMU and S/U mode support. It has been submitted to tapeout at efabless MPW-7 shuttle.