### PR TITLE
Add additional information for upper integer registers in commentary 

### DIFF
--- a/src/rv32e.tex
+++ b/src/rv32e.tex
@@ -26,7 +26,8 @@ dedicated zero register.
 
 \begin{commentary}
 We have found that in the small RV32I core implementations, the upper
-16 registers consume around one quarter of the total area of the core
+16 integer registers (general-purpose registers {\tt x16}--{\tt x31}) 
+consume around one quarter of the total area of the core
 excluding memories, thus their removal saves around 25\% core area
 with a corresponding core power reduction.
 \end{commentary}


### PR DESCRIPTION
This pull request is regarding the public review of RV32E/RV64E.

Giving more details regarding *upper registers* would help readers to understand better in this context, where *integer registers*, *general-purpose registers*, *upper registers* are all mentioned. 