### PR TITLE
satp.mode is not WARL

### DIFF
--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -977,7 +977,7 @@ main memory be representable.
 \instbitrange{59}{44} &
 \instbitrange{43}{0} \\
 \hline
-\multicolumn{1}{|c|}{{\tt MODE} (\warl)} &
+\multicolumn{1}{|c|}{{\tt MODE} (see below)} &
 \multicolumn{1}{|c|}{{\tt ASID} (\warl)} &
 \multicolumn{1}{|c|}{{\tt PPN}  (\warl)} \\
 \hline


### PR DESCRIPTION
satp.mode was described as WARL in the table, but has specific behavior defined by the text of the specification: it requires writes to the whole CSR to be avoided when the MODE field is invalid (and WARL is defined on fields, not CSRs).

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>

---

I don't really care which behavior is desired, but my guess is that the more verbose language ended up there on purpose.