### PR TITLE
Mark the PMP R, W, and X bits as a single field

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -3615,9 +3615,9 @@ The remaining two fields, A and L, are described in the following sections.
 \multicolumn{1}{|c|}{L (\warl)} &
 \multicolumn{1}{c|}{0 (\warl)} &
 \multicolumn{1}{c|}{A (\warl)} &
-\multicolumn{1}{c|}{X (\warl)} &
-\multicolumn{1}{c|}{W (\warl)} &
-\multicolumn{1}{c|}{R (\warl)}
+\multicolumn{1}{c|}{X} &
+\multicolumn{1}{c|}{W} &
+\multicolumn{1}{c|}{R}
 \\
 \hline
 1 & 2 & 2 & 1 & 1 & 1 \\


### PR DESCRIPTION
As pointed out in
https://github.com/riscv/riscv-isa-manual/pull/908#issuecomment-1301159028 , these are defined as a single WARL field in the text but per-bit fields in the CSR encoding.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>

---

I haven't built this, so not sure if it's broken the table.