### PR TITLE
Add marchid for Fraunhofer-IMS AIRISC

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -48,3 +48,4 @@ Hazard3       | Luke Wren                       | [Luke Wren](mailto:wren6991@gm
 CV32E41P      | OpenHW Group                    | [Mark Hill](mailto:mark.hill@huawei.com), OpenHW Group        | 28            | https://github.com/openhwgroup/cv32e41p
 Rift          | Jianhu Lab, WUT                 | [Ruige Lee](mailto:295054118@whut.edu.cn)                     | 29            | [RiftCore](https://github.com/whutddk/RiftCore), [Rift2Core](https://github.com/whutddk/Rift2Core)
 RISu064       | Wenting Zhang                   | [Wenting Zhang](mailto:zephray@outlook.com)                 | 30                | https://github.com/zephray/RISu064
+AIRISC        | Fraunhofer IMS                  | [AIRISC Support](mailto:airisc@ims.fraunhofer.de)           | 31               | https://github.com/Fraunhofer-IMS/airisc_core_complex


### PR DESCRIPTION
We would like to add the AIRISC processor to the `marchid` list and thus request an official architecture ID for the core.

The AIRISC is an ASIC- and FPGA-proven processor system targeting embedded AI and developed by the Fraunhofer Society.

- GitHub Repository: [github.com/Fraunhofer-IMS/airisc_core_complex](https://github.com/Fraunhofer-IMS/airisc_core_complex)
- Offical webpage: [www.airisc.de](https://www.airisc.de/)