### PR TITLE
Riscv isa asciidoc

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -75,5 +75,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.NAME }}.pdf
-        path: ${{ env.NAME }}.pdf
+        path: ./build/${{ env.NAME }}.pdf
         retention-days: 7

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,20 +9,40 @@ on:
   pull_request:
     branches: [ riscv-isa-asciidoc ]
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      name:
+        description: "The base name of the pdf file (without .pdf extensions)"
+        value: ${{ jobs.build.outputs.name }}
+      pdf-name:
+        description: "The name of the pdf file (with .pdf extensions)"
+        value: ${{ jobs.build.outputs.pdf-name }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
+      NAME: unpriv-isa-asciidoc
       APT_PACKAGES_FILE: ${{ github.workspace }}/dependencies/apt_packages.txt
       BUNDLE_GEMFILE: ${{ github.workspace }}/dependencies/Gemfile
       BUNDLE_BIN: ${{ github.workspace }}/bin
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
-      PDF_RESULT: unpriv-isa-asciidoc.pdf
+    outputs:
+      name: ${{ steps.step1.outputs.name }}
+      pdf-name: ${{ steps.step2.outputs.pdf-name }}
     if: contains(github.ref, 'riscv-isa-asciidoc')
     steps:
-    - uses: actions/checkout@v2
+    - name: Set outputs.name
+      id: step1
+      run: echo "name=$NAME" >> $GITHUB_OUTPUT
+    - name: Set outputs.pdf-name
+      id: step2
+      run: echo "pdf-name=$NAME.pdf" >> $GITHUB_OUTPUT
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        submodules: 'true'
     - name: Install Ubuntu packages
       run: |
         sudo apt-get update
@@ -34,16 +54,16 @@ jobs:
         ruby-version: "2.6"
         bundler-cache: true
     # Node.js for wavedrom
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install Node.js dependencies
       run: npm install ${NPM_PACKAGE_FOLDER}
     - name: Generate PDF
@@ -52,8 +72,8 @@ jobs:
         PATH=${PATH}:${BUNDLE_BIN}:$(npm bin) \
         make
     - name: Archive PDF result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: ${{ env.PDF_RESULT }}
-        path: ./build/${{ env.PDF_RESULT }}
+        name: ${{ env.NAME }}.pdf
+        path: ${{ env.NAME }}.pdf
         retention-days: 7

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,55 @@
+# This work flow includes source and PDF in Release.  It relies on the build-pdf workflow to create the PDF.
+#
+# NOTE: At this time it only runs manually.
+
+name: Create Document Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. X.Y.Z:'
+        required: true
+        type: string
+      prerelease:
+        description: 'Tag as a pre-release?'
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: 'Create release as a draft?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-pdf.yml
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: ${{ github.event.inputs.draft }}
+        prerelease: ${{ github.event.inputs.prerelease }}
+    - name: Download Artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.build.outputs.pdf-name }}
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path:  ${{ needs.build.outputs.pdf-name }}
+        asset_name:  ${{ needs.build.outputs.name }}_${{ github.event.inputs.version }}.pdf
+        asset_content_type: application/pdf


### PR DESCRIPTION
This PR does 3 things:

1. Upgrades the build-pdf.yml workflow to be Node 16 and remove the deprecated messages.
2. Make build-pdf.yml workflow callable from other flows
3. Adds a create-release.yml workflow for building releases and including the PDF asset (thus the need to make build-pdf callable).

Note: The new create-release.yml workflow still has some warnings (3) about deprecated Node 12 APIs.  More work is needed to figure out how to handle the non-maintained create-release and upload-release-assets workflows.  However, for now, the new flow is beneficial.