### PR TITLE
Fixed mid table header highlighting and quotes.

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -378,7 +378,7 @@ corresponding _aq_ or _rl_ bit set.
 
 An example code sequence for a critical section guarded by a
 test-and-test-and-set spinlock is shown in
-Figure link:#critical[[critical]]. Note the first AMO is marked _aq_ to
+Figure link:#critical[[critical]]. Note the first AMO is marked _aq_ to
 order the lock acquisition before the critical section, and the second
 AMO is marked _rl_ to order the critical section before the lock
 relinquishment.

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -18,7 +18,9 @@ The document contains the following versions of the RISC-V ISA modules:
 |*RV64I* |*2.1* |*Ratified*
 |_RV32E_ |_1.9_ |_Draft_
 |_RV128I_ |_1.7_ |_Draft_
-|Extension |Version |Status
+
+h|Extension h|Version h|Status
+
 |*M* |*2.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
 |*F* |*2.2* |*Ratified*
@@ -64,7 +66,7 @@ The document contains the following versions of the RISC-V ISA modules:
 |*RV64I* |*2.1* |*Ratified*
 |_RV32E_ |_1.9_ |_Draft_
 |_RV128I_ |_1.7_ |_Draft_
-|Extension |Version |Status
+h|Extension h|Version h|Status
 |*M* |*2.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
 |*F* |*2.2* |*Ratified*
@@ -112,7 +114,7 @@ The document contains the following versions of the RISC-V ISA modules:
 |*RV64I* |*2.1* |*Ratified*
 |_RV32E_ |_1.9_ |_Draft_
 |_RV128I_ |_1.7_ |_Draft_
-|Extension |Version |Status
+h|Extension h|Version h|Status
 |*Zifencei* |*2.0* |*Ratified*
 |*Zicsr* |*2.0* |*Ratified*
 |*M* |*2.0* |*Ratified*
@@ -148,7 +150,7 @@ ISA.
 reflecting that version 2.1 changed the canonical NaN, and version 2.2
 defined the NaN-boxing scheme and changed the definition of the FMIN and
 FMAX instructions.
-* Changed name of document to refer to ``unprivileged`` instructions as
+* Changed name of document to refer to "unprivileged" instructions as
 part of move to separate ISA specifications from platform profile
 mandates.
 * Added clearer and more precise definitions of execution environments,
@@ -185,9 +187,9 @@ changed their behavior on signaling-NaN inputs to conform to the
 minimumNumber and maximumNumber operations in the proposed IEEE 754-201x
 specification.
 * The memory consistency model, RVWMO, has been defined.
-* The ``Zam`` extension, which permits misaligned AMOs and specifies
+* The "Zam" extension, which permits misaligned AMOs and specifies
 their semantics, has been defined.
-* The ``Ztso`` extension, which enforces a stricter memory consistency
+* The "Ztso" extension, which enforces a stricter memory consistency
 model than RVWMO, has been defined.
 * Improvements to the description and commentary.
 * Defined the term IALIGN as shorthand to describe the
@@ -210,7 +212,7 @@ ISA modules:
 |RV32E |1.9 |N
 |RV64I |2.0 |Y
 |RV128I |1.7 |N
-|Extension |Version |Frozen?
+h|Extension h|Version h|Frozen?
 |M |2.0 |Y
 |A |2.0 |Y
 |F |2.0 |Y
@@ -227,7 +229,7 @@ ISA modules:
 |===
 
 To date, no parts of the standard have been officially ratified by the
-RISC-V Foundation, but the components labeled ``frozen`` above are not
+RISC-V Foundation, but the components labeled "frozen" above are not
 expected to change during the ratification process beyond resolving
 ambiguities and holes in the specification.
 
@@ -244,7 +246,7 @@ macro-op fusion of LUI/JALR and AUIPC/JALR pairs.
 * Clarification of constraints on load-reserved/store-conditional
 sequences.
 * A new table of control and status register (CSR) mappings.
-* Clarified purpose and behavior of high-order bits of `fcsr`.
+* Clarified purpose and behavior of high-order bits of *fcsr*.
 * Corrected the description of the FNMADD._fmt_ and FNMSUB._fmt_
 instructions, which had suggested the incorrect sign of a zero result.
 * Instructions FMV.S.X and FMV.X.S were renamed to FMV.W.X and FMV.X.W
@@ -300,7 +302,7 @@ description of the RV32E calling convention.
 This is the second release of the user ISA specification, and we intend
 the specification of the base user ISA plus general extensions (i.e.,
 IMAFD) to remain fixed for future development. The following changes
-have been made since Version 1.0 cite:[openriscarch] of this ISA specification.
+have been made since Version 1.0 cite:[] of this ISA specification.
 
 * The ISA has been divided into an integer base with several standard
 extensions.

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -207,7 +207,7 @@ ISA modules:
 
 [cols="^,<,^",options="header",]
 |===
-|Base |_Version_ |_Draft Frozen?_
+h|Base h|_Version_ h|_Draft Frozen?_
 |RV32I |2.0 |Y
 |RV32E |1.9 |N
 |RV64I |2.0 |Y
@@ -321,7 +321,7 @@ replaces the RDNPC instruction, which only read the current PC value.
 This results in significant savings for position-independent code.
 * The JAL instruction has now moved to the U-Type format with an
 explicit destination register, and the J instruction has been dropped
-being replaced by JAL with _rd_=`x0`. This removes the only instruction
+being replaced by JAL with _rd_='x0'. This removes the only instruction
 with an implicit destination register and removes the J-Type instruction
 format from the base ISA. There is an accompanying reduction in JAL
 reach, but a significant reduction in base ISA complexity.
@@ -337,7 +337,7 @@ been renamed to FMV.S.X and FMV.D.X, respectively.
 * The MFFSR and MTFSR instructions have been renamed to FRCSR and FSCSR,
 respectively. FRRM, FSRM, FRFLAGS, and FSFLAGS instructions have been
 added to individually access the rounding mode and exception flags
-subfields of the `fcsr`.
+subfields of the 'fcsr'.
 * The FMV.X.S and FMV.X.D instructions now source their operands from
 _rs1_, instead of _rs2_. This change simplifies datapath design.
 * FCLASS.S and FCLASS.D floating-point classify instructions have been

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -302,7 +302,7 @@ description of the RV32E calling convention.
 This is the second release of the user ISA specification, and we intend
 the specification of the base user ISA plus general extensions (i.e.,
 IMAFD) to remain fixed for future development. The following changes
-have been made since Version 1.0 cite:[] of this ISA specification.
+have been made since Version 1.0 cite:[riscvtr] of this ISA specification.
 
 * The ISA has been divided into an integer base with several standard
 extensions.

--- a/src/images/wavedrom/csr-instr.adoc
+++ b/src/images/wavedrom/csr-instr.adoc
@@ -6,7 +6,7 @@
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM','SYSTEM','SYSTEM',],   type: 8},
   {bits: 5,  name: 'rd',     attr: ['3', 'dest','dest', 'dest' ],     type: 2},
-  {bits: 3,  name: 'func3',  attr: ['3', 'CSRRW', 'CSRRS', 'CSRRC'], type: 8},
+  {bits: 3,  name: 'funct3',  attr: ['3', 'CSRRW', 'CSRRS', 'CSRRC'], type: 8},
   {bits: 5,  name: 'rs1',    attr: ['5', 'source','source','source',],   type: 4},
   {bits: 12, name: 'csr',    attr: ['12', 'source/dest','source/dest','source/dest'], type: 4},
 ]}
@@ -17,7 +17,7 @@
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM','SYSTEM','SYSTEM'],     type: 8},
   {bits: 5,  name: 'rd',     attr: ['3', 'dest','dest', 'dest' ],       type: 2},
-  {bits: 3,  name: 'func3',  attr: ['3', 'CSRRWI', 'CSRRSI', 'CSRRCI'], type: 8},
+  {bits: 3,  name: 'funct3',  attr: ['3', 'CSRRWI', 'CSRRSI', 'CSRRCI'], type: 8},
   {bits: 5,  name: 'rs1',    attr: ['5', 'uimm[4:0]','uimm[4:0]', 'uimm[4:0]'],   type: 3},
   {bits: 12, name: 'csr',    attr: ['12', 'source/dest','source/dest','source/dest'], type: 4},
 ]}

--- a/src/images/wavedrom/ct-unconditional-2.adoc
+++ b/src/images/wavedrom/ct-unconditional-2.adoc
@@ -5,8 +5,8 @@
 {reg: [
   {bits: 7,  name: 'opcode',     attr: 'JALR', type: 8},
   {bits: 5,  name: 'rd',         attr: 'dest', type: 2},
-  {bits: 3,  name: 'func3',      attr: 0, type: 8},
+  {bits: 3,  name: 'funct3',      attr: 0, type: 8},
   {bits: 5,  name: 'rs1',        attr: 'base', type: 4},
-  {bits: 12, name: 'imm[11:0]',  attr: 'offset', type: 3},
+  {bits: 12, name: 'imm[11:0]',  attr: 'offset[11:0]', type: 3},
 ]}
 ....

--- a/src/images/wavedrom/ct-unconditional.adoc
+++ b/src/images/wavedrom/ct-unconditional.adoc
@@ -8,7 +8,7 @@
   {bits: 5,  name: 'rd',         attr: 'dest', type: 2},
   {bits: 8,  name: 'imm[19:12]', type: 3},
   {bits: 1,  name: '[11]',    type: 3},
-  {bits: 10, name: 'imm[10:1]',  attr: 'offset[20:1], type: 3},
+  {bits: 10, name: 'imm[10:1]',  attr: ['offset[20:1]], type: 3},
   {bits: 4,  name: '[20]',    type: 3},
 ]}
 ....

--- a/src/images/wavedrom/ct-unconditional.adoc
+++ b/src/images/wavedrom/ct-unconditional.adoc
@@ -4,12 +4,12 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 7,  name: 'opcode',     attr: 'JAL', type: 8},
-  {bits: 5,  name: 'rd',         attr: 'dest', type: 2},
+  {bits: 7,  name: 'opcode', attr: 'JAL', type: 8},
+  {bits: 5,  name: 'rd', attr: 'dest', type: 2},
   {bits: 8,  name: 'imm[19:12]', type: 3},
-  {bits: 1,  name: '[11]',    type: 3},
-  {bits: 10, name: 'imm[10:1]',  attr: ['offset[20:1]], type: 3},
-  {bits: 4,  name: '[20]',    type: 3},
+  {bits: 1,  name: '[11]', type: 3},
+  {bits: 10, name: 'imm[10:1]', attr: ['offset[20:1]'], type: 3},
+  {bits: 4,  name: '[20]', type: 3},
 ]}
 ....
 

--- a/src/images/wavedrom/ct-unconditional.adoc
+++ b/src/images/wavedrom/ct-unconditional.adoc
@@ -7,9 +7,9 @@
   {bits: 7,  name: 'opcode',     attr: 'JAL', type: 8},
   {bits: 5,  name: 'rd',         attr: 'dest', type: 2},
   {bits: 8,  name: 'imm[19:12]', type: 3},
-  {bits: 1,  name: '[11]',    type: 3, attr: 'offset'},
-  {bits: 10, name: 'imm[10:1]',  type: 3},
-  {bits: 1,  name: '[20]',    type: 3},
+  {bits: 1,  name: '[11]',    type: 3},
+  {bits: 10, name: 'imm[10:1]',  attr: 'offset[20:1], type: 3},
+  {bits: 4,  name: '[20]',    type: 3},
 ]}
 ....
 

--- a/src/images/wavedrom/immediate.adoc
+++ b/src/images/wavedrom/immediate.adoc
@@ -5,11 +5,11 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 1,  name: '[20]'},
-  {bits: 4,  name: '[24:21]'},
-  {bits: 6,  name: '[30:25]'},
-  {bits: 21,  name: '— [31] —', type: 7},
-]}
+  {bits: 5,  name: 'inst[20]'},
+  {bits: 7,  name: 'inst[24:21]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 21,  name: '— inst[31] —', type: 7},
+], config:{label:{right: 'I-immediate'}}}
 ....
 //#### S-immediate
 

--- a/src/images/wavedrom/immediate.adoc
+++ b/src/images/wavedrom/immediate.adoc
@@ -56,5 +56,5 @@
   {bits: 5,  name: 'inst[20]'},
   {bits: 6,  name: 'inst[19:12]'},
   {bits: 12, name: '— inst[31] —', type: 7},
-], config:{label:{right: 'J-immediage'}}}
+], config:{label:{right: 'J-immediate'}}}
 ....

--- a/src/images/wavedrom/immediate.adoc
+++ b/src/images/wavedrom/immediate.adoc
@@ -8,7 +8,7 @@
   {bits: 4,  name: 'inst[20]'},
   {bits: 5,  name: 'inst[24:21]'},
   {bits: 5,  name: 'inst[30:25]'},
-  {bits: 21,  name: '— inst[31] —', type: 7},
+  {bits: 15,  name: '— inst[31] —', type: 7},
 ], config:{label:{right: 'I-immediate'}}}
 ....
 //#### S-immediate
@@ -19,7 +19,7 @@
   {bits: 4,  name: 'inst[7]'},
   {bits: 5,  name: 'inst[11:8]'},
   {bits: 6,  name: 'inst[30:25]'},
-  {bits: 21,  name: '— inst[31] —', type: 7},
+  {bits: 15,  name: '— inst[31] —', type: 7},
 ], config:{label:{right: 'S-immediate'}}}
 ....
 //#### B-immediate
@@ -31,7 +31,7 @@
   {bits: 4,  name: 'inst[11:8]'},
   {bits: 5,  name: 'inst[30:25]'},
   {bits: 4,  name: 'inst[7]'},
-  {bits: 20, name: '— inst[31] —', type: 7},
+  {bits: 15, name: '— inst[31] —', type: 7},
 ], config:{label:{right: 'B-immediate'}}}
 ....
 //#### U-immediate
@@ -39,7 +39,7 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 12, name: '0', type: 5},
+  {bits: 10, name: '0', type: 5},
   {bits: 8,  name: 'inst[19:12]'},
   {bits: 11, name: 'inst[30:20]'},
   {bits: 5,  name: 'inst[31]', type: 7},
@@ -55,6 +55,6 @@
   {bits: 6,  name: 'inst[30:25]'},
   {bits: 5,  name: 'inst[20]'},
   {bits: 6,  name: 'inst[19:12]'},
-  {bits: 12, name: '— inst[31] —', type: 7},
+  {bits: 10, name: '— inst[31] —', type: 7},
 ], config:{label:{right: 'J-immediate'}}}
 ....

--- a/src/images/wavedrom/immediate.adoc
+++ b/src/images/wavedrom/immediate.adoc
@@ -5,9 +5,9 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 5,  name: 'inst[20]'},
-  {bits: 7,  name: 'inst[24:21]'},
-  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 4,  name: 'inst[20]'},
+  {bits: 5,  name: 'inst[24:21]'},
+  {bits: 5,  name: 'inst[30:25]'},
   {bits: 21,  name: '— inst[31] —', type: 7},
 ], config:{label:{right: 'I-immediate'}}}
 ....
@@ -16,45 +16,45 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 1,  name: '[7]'},
-  {bits: 4,  name: '[11:8]'},
-  {bits: 6,  name: '[30:25]'},
-  {bits: 21,  name: '— [31] —', type: 7},
-]}
+  {bits: 4,  name: 'inst[7]'},
+  {bits: 5,  name: 'inst[11:8]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 21,  name: '— inst[31] —', type: 7},
+], config:{label:{right: 'S-immediate'}}}
 ....
 //#### B-immediate
 
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 1,  name: 'zero', type: 5},
-  {bits: 4,  name: '[11:8]'},
-  {bits: 6,  name: '[30:25]'},
-  {bits: 1,  name: '[7]'},
-  {bits: 20, name: '— [31] —', type: 7},
-]}
+  {bits: 1,  name: '0', type: 5},
+  {bits: 4,  name: 'inst[11:8]'},
+  {bits: 5,  name: 'inst[30:25]'},
+  {bits: 4,  name: 'inst[7]'},
+  {bits: 20, name: '— inst[31] —', type: 7},
+], config:{label:{right: 'B-immediate'}}}
 ....
 //#### U-immediate
 
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 12, name: 'zero', type: 5},
-  {bits: 8,  name: '[19:12]'},
-  {bits: 11, name: '[30:20]'},
-  {bits: 1,  name: '[31]', type: 7},
-]}
+  {bits: 12, name: '0', type: 5},
+  {bits: 8,  name: 'inst[19:12]'},
+  {bits: 11, name: 'inst[30:20]'},
+  {bits: 5,  name: 'inst[31]', type: 7},
+], config:{label:{right: 'U-immediate'}}}
 ....
 //#### J-immediate
 
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 1,  name: 'zero', type: 5},
-  {bits: 4,  name: '[24:21]'},
-  {bits: 6,  name: '[30:25]'},
-  {bits: 1,  name: '[20]'},
-  {bits: 8,  name: '[19:12]'},
-  {bits: 12, name: '— [31] —', type: 7},
-]}
+  {bits: 1,  name: '0', type: 5},
+  {bits: 6,  name: 'inst[24:21]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 5,  name: 'inst[20]'},
+  {bits: 6,  name: 'inst[19:12]'},
+  {bits: 12, name: '— inst[31] —', type: 7},
+], config:{label:{right: 'J-immediage'}}}
 ....

--- a/src/images/wavedrom/immediate_variants.adoc
+++ b/src/images/wavedrom/immediate_variants.adoc
@@ -41,13 +41,13 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
-  {bits: 4,  name: 'imm[11]',      type: 3},
+  {bits: 1,  name: 'imm[11]',      type: 3},
   {bits: 4,  name: 'imm[4:1]',  type: 3},
   {bits: 3,  name: 'func3'},
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 6,  name: 'imm[10:5]', type: 3},
-  {bits: 1,  name: '[12]',      type: 3}
+  {bits: 1,  name: 'imm[12]',      type: 3}
 ], config: {label: {right: 'B-Type'}}}
 ....
 

--- a/src/images/wavedrom/immediate_variants.adoc
+++ b/src/images/wavedrom/immediate_variants.adoc
@@ -66,9 +66,9 @@
   {bits: 7,  name: 'opcode'},
   {bits: 5,  name: 'rd'},
   {bits: 8,  name: 'imm[19:12]', type: 3},
-  {bits: 1,  name: '[11]',       type: 3},
+  {bits: 4,  name: 'imm[11]',       type: 3},
   {bits: 10, name: 'imm[10:1]',  type: 3},
-  {bits: 1,  name: '[20]',       type: 3}
+  {bits: 4,  name: 'imm[20]',       type: 3}
 ], config: {label: {right: 'J-Type'}}}
 ....
 

--- a/src/images/wavedrom/immediate_variants.adoc
+++ b/src/images/wavedrom/immediate_variants.adoc
@@ -41,7 +41,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
-  {bits: 1,  name: '[11]',      type: 3},
+  {bits: 4,  name: 'imm[11]',      type: 3},
   {bits: 4,  name: 'imm[4:1]',  type: 3},
   {bits: 3,  name: 'func3'},
   {bits: 5,  name: 'rs1'},

--- a/src/images/wavedrom/immediate_variants.adoc
+++ b/src/images/wavedrom/immediate_variants.adoc
@@ -7,7 +7,7 @@
 {reg: [
   {bits: 7,  name: 'opcode'},
   {bits: 5,  name: 'rd'},
-  {bits: 3,  name: 'func3'},
+  {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 7,  name: 'funct7'}
@@ -19,7 +19,7 @@
 {reg: [
   {bits: 7,  name: 'opcode'},
   {bits: 5,  name: 'rd'},
-  {bits: 3,  name: 'func3'},
+  {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 12, name: 'imm[11:0]', type: 3},
 ], config: {label: {right: 'I-Type'}}}
@@ -30,7 +30,7 @@
 {reg: [
   {bits: 7,  name: 'opcode'},
   {bits: 5,  name: 'imm[4:0]', type: 3},
-  {bits: 3,  name: 'func3'},
+  {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 7,  name: 'imm[11:5]', type: 3}
@@ -43,7 +43,7 @@
   {bits: 7,  name: 'opcode'},
   {bits: 1,  name: 'imm[11]',      type: 3},
   {bits: 4,  name: 'imm[4:1]',  type: 3},
-  {bits: 3,  name: 'func3'},
+  {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 6,  name: 'imm[10:5]', type: 3},

--- a/src/images/wavedrom/immediate_variants.adoc
+++ b/src/images/wavedrom/immediate_variants.adoc
@@ -41,13 +41,13 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
-  {bits: 1,  name: 'imm[11]',      type: 3},
+  {bits: 4,  name: 'imm[11]',      type: 3},
   {bits: 4,  name: 'imm[4:1]',  type: 3},
   {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 6,  name: 'imm[10:5]', type: 3},
-  {bits: 1,  name: 'imm[12]',      type: 3}
+  {bits: 4,  name: 'imm[12]',      type: 3}
 ], config: {label: {right: 'B-Type'}}}
 ....
 

--- a/src/images/wavedrom/int-comp-lui-aiupc.adoc
+++ b/src/images/wavedrom/int-comp-lui-aiupc.adoc
@@ -7,6 +7,6 @@
 {reg: [
   {bits: 7,  name: 'opcode',     attr: ['LUI', 'AUIPC'], type: 8},
   {bits: 5,  name: 'rd',         attr: ['dest', 'dest'], type: 2},
-  {bits: 20, name: 'imm[31:12]', attr: ['U-immediate[31:12]', 'U-immediate[31:12]]', type: 3}
+  {bits: 20, name: 'imm[31:12]', attr: ['U-immediate[31:12]', 'U-immediate[31:12]'], type: 3}
 ]}
 ....

--- a/src/images/wavedrom/int-comp-lui-aiupc.adoc
+++ b/src/images/wavedrom/int-comp-lui-aiupc.adoc
@@ -6,7 +6,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',     attr: ['LUI', 'AUIPC'], type: 8},
-  {bits: 5,  name: 'rd',         attr: 'dest', type: 2},
-  {bits: 20, name: 'imm[31:12]', attr: 'U-immediate[31:12]', type: 3}
+  {bits: 5,  name: 'rd',         attr: ['dest', 'dest'], type: 2},
+  {bits: 20, name: 'imm[31:12]', attr: ['U-immediate[31:12]', 'U-immediate[31:12]]', type: 3}
 ]}
 ....

--- a/src/images/wavedrom/int-comp-slli-srli-srai.adoc
+++ b/src/images/wavedrom/int-comp-slli-srli-srai.adoc
@@ -7,7 +7,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['OP-IMM', 'OP-IMM', 'OP-IMM'], type: 8},
   {bits: 5,  name: 'rd',        attr: ['dest', 'dest', 'dest'], type: 2},
-  {bits: 3,  name: 'func3',     attr: ['SLLI', 'SRLI', 'SRAI'], type: 8},
+  {bits: 3,  name: 'funct3',     attr: ['SLLI', 'SRLI', 'SRAI'], type: 8},
   {bits: 5,  name: 'rs1',       attr: ['src', 'src', 'src'], type: 4},
   {bits: 5,  name: 'imm[4:0]',  attr: ['shamt[4:0]', 'shamt[4:0]', 'shamt[4:0]'], type: 3},
   {bits: 7,  name: 'imm[11:5]', attr: [0, 0, 32], type: 8}

--- a/src/images/wavedrom/int-comp-slli-srli-srai.adoc
+++ b/src/images/wavedrom/int-comp-slli-srli-srai.adoc
@@ -5,11 +5,11 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 7,  name: 'opcode',    attr: 'OP-IMM', type: 8},
-  {bits: 5,  name: 'rd',        attr: 'dest', type: 2},
+  {bits: 7,  name: 'opcode',    attr: ['OP-IMM', 'OP-IMM', 'OP-IMM'], type: 8},
+  {bits: 5,  name: 'rd',        attr: ['dest', 'dest', 'dest'], type: 2},
   {bits: 3,  name: 'func3',     attr: ['SLLI', 'SRLI', 'SRAI'], type: 8},
-  {bits: 5,  name: 'rs1',       attr: 'src', type: 4},
-  {bits: 5,  name: 'imm[4:0]',  attr: 'shamt[4:0]', type: 3},
+  {bits: 5,  name: 'rs1',       attr: ['src', 'src', 'src'], type: 4},
+  {bits: 5,  name: 'imm[4:0]',  attr: ['shamt[4:0]', 'shamt[4:0]', 'shamt[4:0]'], type: 3},
   {bits: 7,  name: 'imm[11:5]', attr: [0, 0, 32], type: 8}
 ]}
 ....

--- a/src/images/wavedrom/int_reg-reg.adoc
+++ b/src/images/wavedrom/int_reg-reg.adoc
@@ -8,6 +8,6 @@
   {bits: 3,  name: 'funct3',     attr: ['ADD/SLT[U]', 'AND/OR/XOR', 'SLL/SRL', 'SUB/SRA'], type: 8},
   {bits: 5,  name: 'rs1',       attr: ['src1', 'src1', 'src1', 'src1'], type: 4},
   {bits: 5,  name: 'rs2',       attr: ['src2', 'src2', 'src2', 'src2'], type: 4},
-  {bits: 7,  name: 'funct7', attr: [0, 0, 0, 0, 0, 0, 0, 0, 32, 32], type: 8}
+  {bits: 7,  name: 'funct7', attr: [0, 0, 0, 32], type: 8}
 ]}
 ....

--- a/src/images/wavedrom/int_reg-reg.adoc
+++ b/src/images/wavedrom/int_reg-reg.adoc
@@ -3,11 +3,11 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 7,  name: 'opcode',    attr: 'OP', type: 8},
-  {bits: 5,  name: 'rd',        attr: 'dest', type: 2},
-  {bits: 3,  name: 'func3',     attr: ['ADD', 'SLT', 'SLTU', 'AND', 'OR', 'XOR', 'SLL', 'SRL', 'SUB', 'SRA'], type: 8},
-  {bits: 5,  name: 'rs1',       attr: 'src1', type: 4},
-  {bits: 5,  name: 'rs2',       attr: 'src2', type: 4},
+  {bits: 7,  name: 'opcode',    attr: ['OP', 'OP', 'OP', 'OP'], type: 8},
+  {bits: 5,  name: 'rd',        attr: ['dest', 'dest', 'dest','dest'], type: 2},
+  {bits: 3,  name: 'funct3',     attr: ['ADD/SLT[U]', 'AND/OR/XOR', 'SLL/SRL', 'SUB/SRA'], type: 8},
+  {bits: 5,  name: 'rs1',       attr: ['src1', 'src1', 'src1', 'src1'], type: 4},
+  {bits: 5,  name: 'rs2',       attr: ['src2', 'src2', 'src2', 'src2'], type: 4},
   {bits: 7,  name: 'funct7', attr: [0, 0, 0, 0, 0, 0, 0, 0, 32, 32], type: 8}
 ]}
 ....

--- a/src/images/wavedrom/integer_computational.adoc
+++ b/src/images/wavedrom/integer_computational.adoc
@@ -6,7 +6,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['OP-IMM', 'OP-IMM'], type: 8},
   {bits: 5,  name: 'rd',        attr: ['dest', 'dest'], type: 2},
-  {bits: 3,  name: 'func3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
+  {bits: 3,  name: 'funct3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
   {bits: 5,  name: 'rs1',       attr: ['src', 'src'], type: 4},
   {bits: 12, name: 'imm[11:0]', attr: ['I-immediate[11:0]', 'I-immediate[11:0]'], type: 3}
 ]}

--- a/src/images/wavedrom/integer_computational.adoc
+++ b/src/images/wavedrom/integer_computational.adoc
@@ -8,7 +8,7 @@
   {bits: 5,  name: 'rd',        attr: 'dest', 'dest', type: 2},
   {bits: 3,  name: 'func3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
   {bits: 5,  name: 'rs1',       attr: 'src', 'src', type: 4},
-  {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]','I-immediate[11:0]', type: 3}
+  {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]', 'I-immediate[11:0]', type: 3}
 ]}
 ....
 

--- a/src/images/wavedrom/integer_computational.adoc
+++ b/src/images/wavedrom/integer_computational.adoc
@@ -4,11 +4,11 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 7,  name: 'opcode',    attr: 'OP-IMM', 'OP-IMM', type: 8},
-  {bits: 5,  name: 'rd',        attr: 'dest', 'dest', type: 2},
-  {bits: 3,  name: 'func3',     attr: 'ADDI/SLTI[U]', 'ANDI/ORI/XORI', type: 8},
-  {bits: 5,  name: 'rs1',       attr: 'src', 'src', type: 4},
-  {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]', 'I-immediate[11:0]', type: 3}
+  {bits: 7,  name: 'opcode',    attr: ['OP-IMM', 'OP-IMM'], type: 8},
+  {bits: 5,  name: 'rd',        attr: ['dest', 'dest'], type: 2},
+  {bits: 3,  name: 'func3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
+  {bits: 5,  name: 'rs1',       attr: ['src', 'src'], type: 4},
+  {bits: 12, name: 'imm[11:0]', attr: ['I-immediate[11:0]', 'I-immediate[11:0]'], type: 3}
 ]}
 ....
 

--- a/src/images/wavedrom/integer_computational.adoc
+++ b/src/images/wavedrom/integer_computational.adoc
@@ -4,11 +4,11 @@
 [wavedrom, ,]
 ....
 {reg: [
-  {bits: 7,  name: 'opcode',    attr: 'OP-IMM', type: 8},
-  {bits: 5,  name: 'rd',        attr: 'dest', type: 2},
-  {bits: 3,  name: 'func3',     attr: ['ADDI', 'SLTI', 'SLTIU', 'ANDI', 'ORI', 'XORI'], type: 8},
-  {bits: 5,  name: 'rs1',       attr: 'src', type: 4},
-  {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]', type: 3}
+  {bits: 7,  name: 'opcode',    attr: 'OP-IMM', 'OP-IMM', type: 8},
+  {bits: 5,  name: 'rd',        attr: 'dest', 'dest', type: 2},
+  {bits: 3,  name: 'func3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
+  {bits: 5,  name: 'rs1',       attr: 'src', 'src', type: 4},
+  {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]','I-immediate[11:0]', type: 3}
 ]}
 ....
 

--- a/src/images/wavedrom/integer_computational.adoc
+++ b/src/images/wavedrom/integer_computational.adoc
@@ -6,7 +6,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: 'OP-IMM', 'OP-IMM', type: 8},
   {bits: 5,  name: 'rd',        attr: 'dest', 'dest', type: 2},
-  {bits: 3,  name: 'func3',     attr: ['ADDI/SLTI[U]', 'ANDI/ORI/XORI'], type: 8},
+  {bits: 3,  name: 'func3',     attr: 'ADDI/SLTI[U]', 'ANDI/ORI/XORI', type: 8},
   {bits: 5,  name: 'rs1',       attr: 'src', 'src', type: 4},
   {bits: 12, name: 'imm[11:0]', attr: 'I-immediate[11:0]', 'I-immediate[11:0]', type: 3}
 ]}

--- a/src/images/wavedrom/nop.adoc
+++ b/src/images/wavedrom/nop.adoc
@@ -4,7 +4,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: 'OP-IMM', type: 8},
   {bits: 5,  name: 'rd',        attr: 0, type: 2},
-  {bits: 3,  name: 'func3',     attr: 'ADDI', type: 8},
+  {bits: 3,  name: 'funct3',     attr: 'ADDI', type: 8},
   {bits: 5,  name: 'rs1',       attr: 0, type: 4},
   {bits: 12, name: 'imm[11:0]', attr: 0, type: 3}
 ]}

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -480,7 +480,7 @@ instructions longer than 32 bits is not considered frozen.
 Standard instruction-set extensions encoded with more than 32 bits have
 additional low-order bits set to "1", with the conventions for 48-bit
 and 64-bit lengths shown in
-<<instlengthcode>>. Instruction lengths
+<<instlengthcode, Table 1>>. Instruction lengths
 between 80 bits and 176 bits are encoded using a 3-bit field in bits
 [14:12] giving the number of 16-bit words in addition to the first
 5latexmath:[$\times$]16-bit words. The encoding with bits [14:12] set to

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -445,7 +445,7 @@ encoding scheme is designed to support ISA extensions with
 variable-length instructions, where each instruction can be any number
 of 16-bit instruction _parcels_ in length and parcels are naturally
 aligned on 16-bit boundaries. The standard compressed ISA extension
-described in <<compressed>> reduces code size by
+described in <<compressed, Chapter 18>> reduces code size by
 providing compressed 16-bit instructions and relaxes the alignment
 constraints to allow all instructions (16 bit and 32 bit) to be aligned
 on any 16-bit boundary to improve code density.
@@ -463,7 +463,7 @@ multiple of IALIGN. For implementations supporting only a base
 instruction set, ILEN is 32 bits. Implementations supporting longer
 instructions have larger values of ILEN.
 
-<<instlengthcode>> illustrates the standard
+<<instlengthcode, Table 1>> illustrates the standard
 RISC-V instruction-length encoding convention. All the 32-bit
 instructions in the base ISA have their lowest two bits set to "11". The
 optional compressed 16-bit instruction-set extensions have their lowest
@@ -487,24 +487,26 @@ between 80 bits and 176 bits are encoded using a 3-bit field in bits
 "111" is reserved for future longer instruction encodings.
 
 [[instlengthcode]]
-.RISC-V instruction length encoding. Only the 16-bit and 32-bit encodings are considered frozen at this time.
-[cols="^2,^4,^3,^3,<2",]
+.RISC-V instruction length encoding. 
+
+Only the 16-bit and 32-bit encodings are considered frozen at this time.
+[%autowidth,cols="^2,^2,^3,^3,<4"]
 |===
-| | | |`xxxxxxxxxxxxxxaa` |16-bit (`aa`&#8800;`11`)
+||||xxxxxxxxxxxxxxaa |16-bit (aa&#8800;11)
 
-| | |`xxxxxxxxxxxxxxxx` |`xxxxxxxxxxxbbb11` |32-bit (`bbb`&#8800;`111`)
+|||xxxxxxxxxxxxxxxx |xxxxxxxxxxxbbb11 |32-bit (bbb&#8800;111)
 
-| |latexmath:[$\cdot\cdot\cdot$]`xxxx` |`xxxxxxxxxxxxxxxx`
-|`xxxxxxxxxx011111` |48-bit
+||latexmath:[$\cdot\cdot\cdot$]xxxx |xxxxxxxxxxxxxxxx
+|xxxxxxxxxx011111 |48-bit
 
-| |latexmath:[$\cdot\cdot\cdot$]`xxxx` |`xxxxxxxxxxxxxxxx`
-|`xxxxxxxxx0111111` |64-bit
+||latexmath:[$\cdot\cdot\cdot$]xxxx |xxxxxxxxxxxxxxxx
+|xxxxxxxxx0111111 |64-bit
 
-| |latexmath:[$\cdot\cdot\cdot$]`xxxx` |`xxxxxxxxxxxxxxxx`
-|`xnnnxxxxx1111111` |(80+16*`nnn`)-bit, `nnn`&#8800;`111`
+||latexmath:[$\cdot\cdot\cdot$]xxxx |xxxxxxxxxxxxxxxx
+|xnnnxxxxx1111111 |(80+16*nnn)-bit, nnn&#8800;111
 
-| |latexmath:[$\cdot\cdot\cdot$]`xxxx` |`xxxxxxxxxxxxxxxx`
-|`x111xxxxx1111111` |Reserved for &#8805;192-bits
+||latexmath:[$\cdot\cdot\cdot$]xxxx |xxxxxxxxxxxxxxxx
+|x111xxxxx1111111 |Reserved for &#8805;192-bits
 
 |Byte Address: |base+4 |base+2 |base |
 |===

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -489,7 +489,7 @@ between 80 bits and 176 bits are encoded using a 3-bit field in bits
 [[instlengthcode]]
 .RISC-V instruction length encoding. 
 
-Only the 16-bit and 32-bit encodings are considered frozen at this time.
+.RISC-V instruction length encoding. Only the 16-bit and 32-bit encodings are considered frozen at this time.
 [%autowidth,cols="^2,^2,^3,^3,<4"]
 |===
 ||||xxxxxxxxxxxxxxaa |16-bit (aa&#8800;11)
@@ -691,11 +691,11 @@ kind of trap.
 
 [[trapcharacteristics]]
 .Characteristics of traps: 1) Termination may be requested. 2) Imprecise fatal traps might be observable by software.
-[cols="<,^,^,^,^",options="header",]
+[%autowidth,cols="<,^,^,^,^",options="header",]
 |===
 | |Contained |Requested |Invisible |Fatal
-|Execution terminates |No |Nolatexmath:[$^{1}$] |No |Yes
-|Software is oblivious |No |No |Yes |Yeslatexmath:[$^{2}$]
+|Execution terminates |No |Nofootnote:[Termination may be requested.]|No |Yes
+|Software is oblivious |No |No |Yes |Yesfoot:[Imprecise fatal traps might be observable by software.]
 |Handled by environment |No |Yes |Yes |Yes
 |===
 

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -18,7 +18,7 @@ FPGA), but which allows efficient implementation in any of these.
 a base for customized accelerators or for educational purposes, and
 optional standard extensions, to support general-purpose software
 development.
-* Support for the revised 2008 IEEE-754 floating-point standard .
+* Support for the revised 2008 IEEE-754 floating-point standard.
 * An ISA supporting extensive ISA extensions and specialized variants.
 * Both 32-bit and 64-bit address space variants for applications,
 operating system kernels, and hardware implementations.
@@ -185,7 +185,7 @@ The important distinction between a hardware thread (hart) and a
 software thread context is that the software running inside an execution
 environment is not responsible for causing progress of each of its
 harts; that is the responsibility of the outer execution environment. So
-the environment’s harts operate like hardware threads from the
+the environment's harts operate like hardware threads from the
 perspective of the software inside the execution environment.
 
 An execution environment implementation might time-multiplex a set of
@@ -224,7 +224,7 @@ RV32I base instruction set, which has been added to support small
 microcontrollers, and which has half the number of integer registers.
 <<rv128>> sketches a future RV128I variant of the
 base integer instruction set supporting a flat 128-bit address space
-(XLEN=128). The base integer instruction sets use a two’s-complement
+(XLEN=128). The base integer instruction sets use a two's-complement
 representation for signed integer values.
 
 
@@ -312,7 +312,7 @@ extensions. Non-standard extensions are either custom extensions, that
 use only custom encodings, or _non-conforming_ extensions, that use any
 standard or reserved encoding. Instruction-set extensions are generally
 shared but may provide slightly different functionality depending on the
-base ISA. <<extensions>> describes various ways
+base ISA. <<extending>> describes various ways
 of extending the RISC-V ISA. We have also developed a naming convention
 for RISC-V base instructions and instruction-set extensions, described
 in detail in <<naming>>.

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -463,7 +463,7 @@ multiple of IALIGN. For implementations supporting only a base
 instruction set, ILEN is 32 bits. Implementations supporting longer
 instructions have larger values of ILEN.
 
-<<instlengthcode, Table 1>> illustrates the standard
+<<instlengthcode>> illustrates the standard
 RISC-V instruction-length encoding convention. All the 32-bit
 instructions in the base ISA have their lowest two bits set to "11". The
 optional compressed 16-bit instruction-set extensions have their lowest
@@ -480,13 +480,13 @@ instructions longer than 32 bits is not considered frozen.
 Standard instruction-set extensions encoded with more than 32 bits have
 additional low-order bits set to "1", with the conventions for 48-bit
 and 64-bit lengths shown in
-<<instlengthcode, Table 1>>. Instruction lengths
+<<instlengthcode>>. Instruction lengths
 between 80 bits and 176 bits are encoded using a 3-bit field in bits
 [14:12] giving the number of 16-bit words in addition to the first
 5latexmath:[$\times$]16-bit words. The encoding with bits [14:12] set to
 "111" is reserved for future longer instruction encodings.
 
-[[instlengthcode]]
+[[instlengthcode, Table 1]]
 .RISC-V instruction length encoding. 
 
 .RISC-V instruction length encoding. Only the 16-bit and 32-bit encodings are considered frozen at this time.
@@ -689,13 +689,13 @@ Fatal Trap:::
 <<trapcharacteristics>> shows the characteristics of each
 kind of trap.
 
-[[trapcharacteristics]]
+[[trapcharacteristics, Table 2]]
 .Characteristics of traps: 1) Termination may be requested. 2) Imprecise fatal traps might be observable by software.
 [%autowidth,cols="<,^,^,^,^",options="header",]
 |===
 | |Contained |Requested |Invisible |Fatal
 |Execution terminates |No |Nofootnote:[Termination may be requested.]|No |Yes
-|Software is oblivious |No |No |Yes |Yesfoot:[Imprecise fatal traps might be observable by software.]
+|Software is oblivious |No |No |Yes |Yesfootnote:[Imprecise fatal traps might be observable by software.]
 |Handled by environment |No |Yes |Yes |Yes
 |===
 

--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -226,6 +226,8 @@ table:
   border_color: dddddd
   border_width: $base_border_width
   cell_padding: 3
+  head:
+    background-color: #2596be
 toc:
   indent: $horizontal_rhythm
   line_height: 1.4

--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -217,7 +217,7 @@ outline_list:
   item_spacing: $vertical_rhythm / 2
 table:
   background_color: $page_background_color
-  #head_background_color: <hex value>
+  head_background_color: #2596be
   #head_font_color: $base_font_color
   head_font_style: bold
   #body_background_color: <hex value>
@@ -226,8 +226,6 @@ table:
   border_color: dddddd
   border_width: $base_border_width
   cell_padding: 3
-  head:
-    background-color: #2596be
 toc:
   indent: $horizontal_rhythm
   line_height: 1.4

--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -217,7 +217,7 @@ outline_list:
   item_spacing: $vertical_rhythm / 2
 table:
   background_color: $page_background_color
-  head_background_color: #2596be
+  #head_background_color: #2596be
   #head_font_color: $base_font_color
   head_font_style: bold
   #body_background_color: <hex value>

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -28,7 +28,7 @@ instructions as a single trap.
 [NOTE]
 ====
 The standard RISC-V assembly language syntax is documented in the
-Assembly Programmer’s Manual cite:[riscv-asm-manual].
+Assembly Programmer's Manual cite:[riscv-asm-manual].
 ====
 
 [NOTE]
@@ -39,13 +39,13 @@ Most of the commentary for RV32I also applies to the RV64I base.
 === Programmers’ Model for Base Integer ISA
 
 <<gprs>> shows the unprivileged state for the base
-integer ISA. For RV32I, the 32 `x` registers are each 32 bits wide,
-i.e., XLEN=32. Register `x0` is hardwired with all bits equal to 0.
-General purpose registers `x1`–`x31` hold values that various
+integer ISA. For RV32I, the 32 'x' registers are each 32 bits wide,
+i.e., XLEN=32. Register 'x0' is hardwired with all bits equal to 0.
+General purpose registers 'x1'–'x31' hold values that various
 instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.
 
-There is one additional unprivileged register: the program counter `pc`
+There is one additional unprivileged register: the program counter 'pc'
 holds the address of the current instruction.
 
 [[gprs]]
@@ -93,17 +93,17 @@ holds the address of the current instruction.
 
 There is no dedicated stack pointer or subroutine return address link
 register in the Base Integer ISA; the instruction encoding allows any
-`x` register to be used for these purposes. However, the standard
-software calling convention uses register `x1` to hold the return
-address for a call, with register `x5` available as an alternate link
-register. The standard calling convention uses register `x2` as the
+'x' register to be used for these purposes. However, the standard
+software calling convention uses register 'x1' to hold the return
+address for a call, with register 'x5' available as an alternate link
+register. The standard calling convention uses register 'x2' as the
 stack pointer.
 
 Hardware might choose to accelerate function calls and returns that use
-`x1` or `x5`. See the descriptions of the JAL and JALR instructions.
+'x1' or 'x5'. See the descriptions of the JAL and JALR instructions.
 
 The optional compressed 16-bit instruction format is designed around the
-assumption that `x1` is the return address register and `x2` is the
+assumption that 'x1' is the return address register and 'x2' is the
 stack pointer. Software using other conventions will operate correctly
 but may have greater code size.
 
@@ -176,9 +176,7 @@ bit 31 of the instruction to speed sign-extension circuitry.
 
 include::images/wavedrom/instruction_formats.adoc[]
 [[base_instr]]
-.RISC-V base instruction formats
-
-Each immediate subfield in <<base_instr>> above is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction’s immediate field as is usually done.
+.RISC-V base instruction formats.  Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
 
 [NOTE]
 ====
@@ -205,7 +203,7 @@ on the handling of immediates, as shown in <<baseinstformatsimm>>.
 
 include::images/wavedrom/immediate_variants.adoc[]
 [[baseinstformatsimm]]
-.RISC-V base instruction formats.
+.RISC-V base instruction formats showing immediate variants.
 
 The only difference between the S and B formats is that the 12-bit
 immediate field is used to encode branch offsets in multiples of 2 in
@@ -226,7 +224,7 @@ instruction bit (inst[_y_]) produces each bit of the immediate value.
 
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
-.Immediate variants for I, S, B, U, and J
+.Types of immediate produced by RISC-V instructions.  The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -386,10 +386,10 @@ the lower 5 bits of register _rs2_.
 
 include::images/wavedrom/nop.adoc[]
 [[nop]]
-.NOP instructions
+//.NOP instructions
 
 The NOP instruction does not change any architecturally visible state,
-except for advancing the `pc` and incrementing any applicable
+except for advancing the 'pc' and incrementing any applicable
 performance counters. NOP is encoded as ADDI _x0, x0, 0_.
 
 [NOTE]
@@ -431,8 +431,8 @@ J-immediate encodes a signed offset in multiples of 2 bytes. The offset
 is sign-extended and added to the address of the jump instruction to
 form the jump target address. Jumps can therefore target a
 &#177;1 MiB range. JAL stores the address of the instruction
-following the jump (`pc`+4) into register _rd_. The standard software
-calling convention uses `x1` as the return address register and `x5` as
+following the jump ('pc'+4) into register _rd_. The standard software
+calling convention uses 'x1' as the return address register and 'x5' as
 an alternate link register.
 
 [NOTE]
@@ -446,11 +446,11 @@ than the regular link register.
 ====
 
 Plain unconditional jumps (assembler pseudoinstruction J) are encoded as
-a JAL with _rd_=`x0`.
+a JAL with _rd_='x0'.
 
 include::images/wavedrom/ct-unconditional.adoc[]
 [[ct-unconditional]]
-.The unconditional-jump instruction, JAL
+//.The unconditional-jump instruction, JAL
 
 The indirect jump instruction JALR (jump and link register) uses the
 I-type encoding. The target address is obtained by adding the

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -462,7 +462,7 @@ required.
 
 include::images/wavedrom/ct-unconditional-2.adoc[]
 [[ct-unconditional-2]]
-.The indirect unconditional-jump instruction, JALR
+//.The indirect unconditional-jump instruction, JALR
 
 [NOTE]
 ====
@@ -487,7 +487,7 @@ there is potentially a slight loss of error checking in this case, in
 practice jumps to an incorrect instruction address will usually quickly
 raise an exception.
 
-When used with a base _rs1_=`x0`, JALR can be used to
+When used with a base _rs1_='x0', JALR can be used to
 implement a single instruction subroutine call to the lowest or highest
 address region from anywhere in the address space, which could be used
 to implement fast calls to a small runtime library. Alternatively, an
@@ -509,10 +509,10 @@ compressed instruction-set extension, C.
 Return-address prediction stacks are a common feature of
 high-performance instruction-fetch units, but require accurate detection
 of instructions used for procedure calls and returns to be effective.
-For RISC-V, hints as to the instructions’ usage are encoded implicitly
+For RISC-V, hints as to the instructions' usage are encoded implicitly
 via the register numbers used. A JAL instruction should push the return
-address onto a return-address stack (RAS) only when _rd_ is `x1` or
-`x5`. JALR instructions should push/pop a RAS as shown in <<rashints>>.
+address onto a return-address stack (RAS) only when _rd_ is 'x1' or
+'x5'. JALR instructions should push/pop a RAS as shown in <<rashints, Table 4>>.
 
 [[rashints]]
 .Return-address stack prediction hints encoded in the register operands of a JALR instruction.
@@ -539,9 +539,9 @@ instructions to guide return-address stack manipulation. We use implicit
 hinting tied to register numbers and the calling convention to reduce
 the encoding space used for these hints.
 
-When two different link registers (`x1` and `x5`) are given as _rs1_ and
+When two different link registers ('x1' and 'x5') are given as _rs1_ and
 _rd_, then the RAS is both popped and pushed to support coroutines. If
-_rs1_ and _rd_ are the same link register (either `x1` or `x5`), the RAS
+_rs1_ and _rd_ are the same link register (either 'x1' or 'x5'), the RAS
 is only pushed to enable macro-op fusion of the sequences:
 _lui ra, imm20; jalr ra, imm12(ra)_  and
 _auipc ra, imm20; jalr ra, imm12(ra)_
@@ -557,7 +557,7 @@ give the target address. The conditional branch range is
 
 include::images/wavedrom/ct-conditional.adoc[]
 [[ct-conditional]]
-.Conditional branches
+//.Conditional branches
 
 Branch instructions compare two registers. BEQ and BNE take the branch
 if registers _rs1_ and _rs2_ are equal or unequal respectively. BLT and

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -36,12 +36,12 @@ Assembly Programmer's Manual cite:[riscv-asm-manual].
 Most of the commentary for RV32I also applies to the RV64I base.
 ====
 
-=== Programmers’ Model for Base Integer ISA
+=== Programmers' Model for Base Integer ISA
 
 <<gprs>> shows the unprivileged state for the base
 integer ISA. For RV32I, the 32 'x' registers are each 32 bits wide,
 i.e., XLEN=32. Register 'x0' is hardwired with all bits equal to 0.
-General purpose registers 'x1'–'x31' hold values that various
+General purpose registers 'x1'-'x31' hold values that various
 instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.
 
@@ -136,7 +136,7 @@ RV32E subset, which only has 16 registers
 === Base Instruction Formats
 
 In the base RV32I ISA, there are four core instruction formats
-(R/I/S/U), as shown in <<base_instr>>. All are a fixed 32
+(R/I/S/U), as shown in <<base_instr, RISC-V base instruction formats>>. All are a fixed 32
 bits in length and must be aligned on a four-byte boundary in memory. An
 instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not four-byte aligned.
@@ -168,7 +168,7 @@ opcode space be used for non-conforming extensions.
 The RISC-V ISA keeps the source (_rs1_ and _rs2_) and destination (_rd_)
 registers at the same position in all formats to simplify decoding.
 Except for the 5-bit immediates used in CSR instructions
-(<<csrinsts>>), immediates are always
+(<<csrinsts, Chapter 11>>), immediates are always
 sign-extended, and are generally packed towards the leftmost available
 bits in the instruction and have been allocated to reduce hardware
 complexity. In particular, the sign bit for all immediates is always in
@@ -225,6 +225,7 @@ instruction bit (inst[_y_]) produces each bit of the immediate value.
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
 .Types of immediate produced by RISC-V instructions.  The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
+
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -223,9 +223,11 @@ formats and with each other.
 each of the base instruction formats, and is labeled to show which
 instruction bit (inst[_y_]) produces each bit of the immediate value.
 
-.Types of immediate produced by RISC-V instructions. The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
+//.Types of immediate produced by RISC-V instructions. 
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
+
+The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -177,7 +177,6 @@ bit 31 of the instruction to speed sign-extension circuitry.
 include::images/wavedrom/instruction_formats.adoc[]
 [[base_instr]]
 .RISC-V base instruction formats
-image::image_placeholder.png[]
 
 Each immediate subfield in <<base_instr>> above is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction’s immediate field as is usually done.
 
@@ -207,7 +206,6 @@ on the handling of immediates, as shown in <<baseinstformatsimm>>.
 include::images/wavedrom/immediate_variants.adoc[]
 [[baseinstformatsimm]]
 .RISC-V base instruction formats.
-image::image_placeholder.png[]
 
 The only difference between the S and B formats is that the 12-bit
 immediate field is used to encode branch offsets in multiples of 2 in
@@ -229,7 +227,6 @@ instruction bit (inst[_y_]) produces each bit of the immediate value.
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
 .Immediate variants for I, S, B, U, and J
-image::image_placeholder.png[]
 
 [NOTE]
 ====
@@ -296,7 +293,6 @@ comparing the results of ADD and ADDW on the operands.
 
 include::images/wavedrom/integer_computational.adoc[]
 .Integer Computational Instructions
-image::image_placeholder.png[]
 
 ADDI adds the sign-extended 12-bit immediate to register _rs1_.
 Arithmetic overflow is ignored and the result is simply the low XLEN
@@ -319,7 +315,6 @@ inversion of register _rs1_ (assembler pseudoinstruction NOT _rd, rs_).
 include::images/wavedrom/int-comp-slli-srli-srai.adoc[]
 [[int-comp-slli-srli-srai]]
 .Integer register-immediate, SLLI, SRLI, SRAI
-image::image_placeholder.png[]
 
 Shifts by a constant are encoded as a specialization of the I-type
 format. The operand to be shifted is in _rs1_, and the shift amount is
@@ -332,7 +327,6 @@ original sign bit is copied into the vacated upper bits).
 include::images/wavedrom/int-comp-lui-aiupc.adoc[]
 [[int-comp-lui-aiupc]]
 .Integer register-immediate, U-immediate
-image::image_placeholder.png[]
 
 LUI (load upper immediate) is used to build 32-bit constants and uses
 the U-type format. LUI places the 32-bit U-immediate value into the
@@ -373,7 +367,6 @@ operation.
 include::images/wavedrom/int_reg-reg.adoc[]
 [[int-reg-reg]]
 .Integer register-register
-image::image_placeholder.png[]
 
 ADD performs the addition of _rs1_ and _rs2_. SUB performs the
 subtraction of _rs2_ from _rs1_. Overflows are ignored and the low XLEN
@@ -393,7 +386,6 @@ the lower 5 bits of register _rs2_.
 include::images/wavedrom/nop.adoc[]
 [[nop]]
 .NOP instructions
-image::image_placeholder.png[]
 
 The NOP instruction does not change any architecturally visible state,
 except for advancing the `pc` and incrementing any applicable
@@ -458,7 +450,6 @@ a JAL with _rd_=`x0`.
 include::images/wavedrom/ct-unconditional.adoc[]
 [[ct-unconditional]]
 .The unconditional-jump instruction, JAL
-image::image_placeholder.png[]
 
 The indirect jump instruction JALR (jump and link register) uses the
 I-type encoding. The target address is obtained by adding the
@@ -471,7 +462,6 @@ required.
 include::images/wavedrom/ct-unconditional-2.adoc[]
 [[ct-unconditional-2]]
 .The indirect unconditional-jump instruction, JALR
-image::image_placeholder.png[]
 
 [NOTE]
 ====
@@ -567,7 +557,6 @@ give the target address. The conditional branch range is
 include::images/wavedrom/ct-conditional.adoc[]
 [[ct-conditional]]
 .Conditional branches
-image::image_placeholder.png[]
 
 Branch instructions compare two registers. BEQ and BNE take the branch
 if registers _rs1_ and _rs2_ are equal or unequal respectively. BLT and
@@ -702,7 +691,6 @@ memory byte addresses to the less-significant register bytes.
 include::images/wavedrom/load_store.adoc[]
 [[load-store,load and store]]
 .Load and store instructions
-image::image_placeholder.png[]
 
 Load and store instructions transfer a value between the registers and
 memory. Loads are encoded in the I-type format and stores are S-type.
@@ -792,7 +780,6 @@ are aligned.
 include::images/wavedrom/mem_order.adoc[]
 [[mem-order]]
 .Memory ordering instructions
-image::image_placeholder.png[]
 
 The FENCE instruction is used to order device I/O and memory accesses as
 viewed by other RISC-V harts and external devices or coprocessors. Any
@@ -901,7 +888,6 @@ hardware.
 include::images/wavedrom/env_call-breakpoint.adoc[]
 [[env-call]]
 .Evironment call and breakpoint instructions
-image::image_placeholder.png[]
 
 These two instructions cause a precise requested trap to the supporting
 execution environment.

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -265,11 +265,11 @@ on integer arithmetic operations in the base instruction set, as many
 overflow checks can be cheaply implemented using RISC-V branches.
 Overflow checking for unsigned addition requires only a single
 additional branch instruction after the addition:
-`add t0, t1, t2; bltu t0, t1, overflow`.
+'add t0, t1, t2; bltu t0, t1, overflow'.
 
-For signed addition, if one operand’s sign is known, overflow checking
+For signed addition, if one operand's sign is known, overflow checking
 requires only a single branch after the addition:
-`addi t0, t1, +imm; blt t0, t1, overflow`. This covers the common case
+'addi t0, t1, +imm; blt t0, t1, overflow'. This covers the common case
 of addition with an immediate operand.
 
 For general signed addition, three additional instructions after the

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -176,7 +176,8 @@ bit 31 of the instruction to speed sign-extension circuitry.
 
 include::images/wavedrom/instruction_formats.adoc[]
 [[base_instr]]
-.RISC-V base instruction formats.  Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
+.RISC-V base instruction formats. Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
+
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -176,8 +176,8 @@ bit 31 of the instruction to speed sign-extension circuitry.
 
 include::images/wavedrom/instruction_formats.adoc[]
 [[base_instr]]
-.RISC-V base instruction formats, each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
-
+.RISC-V base instruction formats. 
+Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -543,8 +543,7 @@ When two different link registers ('x1' and 'x5') are given as _rs1_ and
 _rd_, then the RAS is both popped and pushed to support coroutines. If
 _rs1_ and _rd_ are the same link register (either 'x1' or 'x5'), the RAS
 is only pushed to enable macro-op fusion of the sequences:
-_lui ra, imm20; jalr ra, imm12(ra)_  and
-_auipc ra, imm20; jalr ra, imm12(ra)_
+_lui ra, imm20; jalr ra, imm12(ra)_ and _auipc ra, imm20; jalr ra, imm12(ra)_
 ====
 
 ==== Conditional Branches

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -219,13 +219,14 @@ Similarly, the only difference between the U and J formats is that the
 and J format immediates is chosen to maximize overlap with the other
 formats and with each other.
 
-<<immtypes>> shows the immediates produced by
+<<immtypes, Immediate Types>> shows the immediates produced by
 each of the base instruction formats, and is labeled to show which
 instruction bit (inst[_y_]) produces each bit of the immediate value.
 
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
-.Types of immediate produced by RISC-V instructions.  The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
+.Types of immediate produced by RISC-V instructions.  
+The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
 
 
 [NOTE]
@@ -292,7 +293,7 @@ comparing the results of ADD and ADDW on the operands.
 ==== Integer Register-Immediate Instructions
 
 include::images/wavedrom/integer_computational.adoc[]
-.Integer Computational Instructions
+//.Integer Computational Instructions
 
 ADDI adds the sign-extended 12-bit immediate to register _rs1_.
 Arithmetic overflow is ignored and the result is simply the low XLEN
@@ -314,7 +315,7 @@ inversion of register _rs1_ (assembler pseudoinstruction NOT _rd, rs_).
 
 include::images/wavedrom/int-comp-slli-srli-srai.adoc[]
 [[int-comp-slli-srli-srai]]
-.Integer register-immediate, SLLI, SRLI, SRAI
+//.Integer register-immediate, SLLI, SRLI, SRAI
 
 Shifts by a constant are encoded as a specialization of the I-type
 format. The operand to be shifted is in _rs1_, and the shift amount is
@@ -326,13 +327,13 @@ original sign bit is copied into the vacated upper bits).
 
 include::images/wavedrom/int-comp-lui-aiupc.adoc[]
 [[int-comp-lui-aiupc]]
-.Integer register-immediate, U-immediate
+//.Integer register-immediate, U-immediate
 
 LUI (load upper immediate) is used to build 32-bit constants and uses
 the U-type format. LUI places the 32-bit U-immediate value into the
 destination register _rd_, filling in the lowest 12 bits with zeros.
 
-AUIPC (add upper immediate to `pc`) is used to build _pc_-relative
+AUIPC (add upper immediate to 'pc') is used to build _pc_-relative
 addresses and uses the U-type format. AUIPC forms a 32-bit offset from
 the U-immediate, filling in the lowest 12 bits with zeros, adds this
 offset to the address of the AUIPC instruction, then places the result
@@ -340,7 +341,7 @@ in register _rd_.
 
 [NOTE]
 ====
-The assembly syntax for `lui` and `auipc` does not represent the lower
+The assembly syntax for 'lui' and 'auipc' does not represent the lower
 12 bits of the U-immediate, which are always zero.
 
 The AUIPC instruction supports two-instruction sequences to access
@@ -366,7 +367,7 @@ operation.
 
 include::images/wavedrom/int_reg-reg.adoc[]
 [[int-reg-reg]]
-.Integer register-register
+//.Integer register-register
 
 ADD performs the addition of _rs1_ and _rs2_. SUB performs the
 subtraction of _rs2_ from _rs1_. Overflows are ignored and the low XLEN

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -223,11 +223,9 @@ formats and with each other.
 each of the base instruction formats, and is labeled to show which
 instruction bit (inst[_y_]) produces each bit of the immediate value.
 
+.Types of immediate produced by RISC-V instructions. The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
 include::images/wavedrom/immediate.adoc[]
 [[immtypes]]
-.Types of immediate produced by RISC-V instructions.  
-The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
-
 
 [NOTE]
 ====

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -42,7 +42,7 @@ Most of the commentary for RV32I also applies to the RV64I base.
 integer ISA. For RV32I, the 32 `x` registers are each 32 bits wide,
 i.e., XLEN=32. Register `x0` is hardwired with all bits equal to 0.
 General purpose registers `x1`–`x31` hold values that various
-instructions interpret as a collection of Boolean values, or as two’s
+instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.
 
 There is one additional unprivileged register: the program counter `pc`
@@ -50,7 +50,7 @@ holds the address of the current instruction.
 
 [[gprs]]
 .RISC-V base unprivileged integer register state.
-[col[s="<|^|>"|option[s="header",width="50%",align="center"grid="none"]
+[col[s="<|^|>"|option[s="header",width="50%",align="center"grid="rows"]
 |===
 <| [.small]#XLEN-1#| >| [.small]#0#
 3+^| [.small]#x0/zero#
@@ -86,7 +86,7 @@ holds the address of the current instruction.
 3+^| [.small]#x30#
 3+^| [.small]#x31#
 3+^| [.small]#XLEN#
-| [.small]#31#| >| [.small]#0#
+| [.small]#XLEN-1#| >| [.small]#0#
 3+^|  [.small]#pc#
 3+^| [.small]#XLEN#
 |===
@@ -113,7 +113,7 @@ would arguably be sufficient for an integer ISA running compiled code,
 it is impossible to encode a complete ISA with 16 registers in 16-bit
 instructions using a 3-address format. Although a 2-address format would
 be possible, it would increase instruction count and lower efficiency.
-We wanted to avoid intermediate instruction sizes (such as Xtensa’s
+We wanted to avoid intermediate instruction sizes (such as Xtensa's
 24-bit instructions) to simplify base hardware implementations, and once
 a 32-bit instruction size was adopted, it was straightforward to support
 32 integer registers. A larger number of integer registers also helps

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -176,7 +176,7 @@ bit 31 of the instruction to speed sign-extension circuitry.
 
 include::images/wavedrom/instruction_formats.adoc[]
 [[base_instr]]
-.RISC-V base instruction formats. Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
+.RISC-V base instruction formats, each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction's immediate field as is usually done.
 
 
 [NOTE]


### PR DESCRIPTION
Andrew's suggestions:
Fixed mid-table rows that should be highlighted like headers. Fixed broken double quotes.
Fixed single quotes converted to backticks in errors. Removed cite ref to OpenRISC spec, which is wrong. TO BE FIXED.