### PR TITLE
Clarify xRET clearing mstatus.MPRV when leaving M-mode

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -640,7 +640,7 @@ executing an {\em x}\/RET instruction, supposing {\em x}\/PP holds the
 value {\em y}, {\em x}\/IE is set to {\em x}\/PIE; the privilege mode
 is changed to {\em y}; {\em x}\/PIE is set to 1; and {\em x}\/PP is
 set to the least-privileged supported mode (U if U-mode is implemented, else M).
-If {\em x}\/PP$\neq$M, {\em x}\/RET also sets MPRV=0.
+If {\em y}$\neq$M, {\em x}\/RET also sets MPRV=0.
 
 \begin{commentary}
 Setting {\em x}\/PP to the least-privileged supported mode on an {\em x}\/RET


### PR DESCRIPTION
Current spec says the following about xRET clearing mstatus.MPRV:

```
  ... and xPP is set to the least-privileged supported mode (U if
  U-mode is implemented, else M). If xPP̸=M, xRET also sets MPRV=0.
```

It may confuse people to think that the condition to set MPRV=0 is
to compare the updated xPP value against M, as this sentence comes
right after the xPP update sentence.

Change 'xPP' to its original value 'y' which avoids the confusion.