### PR TITLE
Disambiguate the use of the term "reserved" for HINT instructions

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1435,7 +1435,10 @@ visible effect.
 Table~\ref{tab:rv32i-hints} lists all RV32I HINT code points.  91\% of the HINT
 space is reserved for standard HINTs.  The
 remainder of the HINT space is designated for custom HINTs: no standard HINTs
-will ever be defined in this subspace.
+will ever be defined in this subspace. In this table, ``reserved'' does not
+refer to the {\em reserved} instruction-set category (they are in the {\em
+standard} category). As such, it is incorrect to raise an illegal-instruction
+exception for any of these encodings.
 
 \begin{commentary}
 We anticipate

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -267,7 +267,10 @@ custom HINT encoding spaces.
 Table~\ref{tab:rv64i-hints} lists all RV64I HINT code points.  91\% of the HINT
 space is reserved for standard HINTs.  The
 remainder of the HINT space is designated for custom HINTs: no standard HINTs
-will ever be defined in this subspace.
+will ever be defined in this subspace. In this table, ``reserved'' does not
+refer to the {\em reserved} instruction-set category (they are in the {\em
+standard} category). As such, it is incorrect to raise an illegal-instruction
+exception for any of these encodings.
 
 \begin{table}[hbt]
 \centering


### PR DESCRIPTION
As was raised in #300, the overloaded use of the term "reserved" when listing HINT encodings is potentially confusing. As clarified in that thread, these encodings are "reserved" in the intuitive English language meaning of the word, but are _not_ part of the "reserved instruction-set category" as defined in the section 1.3 introduction and further elaborated in section 2.2 "Base Instruction Formats" (which notes how platforms can choose to raise an illegal-instruction exception for reserved instruction encodings).