### PR TITLE
Smrnmi fixes

### DIFF
--- a/src/rnmi.tex
+++ b/src/rnmi.tex
@@ -204,6 +204,8 @@ MNRET is an M-mode-only instruction that uses the values in {\tt mnepc} and
 {\tt mnstatus} to return to the program counter, privilege mode,
 and virtualization mode of the interrupted context.
 This instruction also sets {\tt mnstatus}.NMIE.
+If MNRET changes the privilege mode to a mode
+less privileged than M, it also sets {\tt mstatus}.MPRV to 0.
 
 \section{RNMI Operation}
 

--- a/src/rnmi.tex
+++ b/src/rnmi.tex
@@ -220,8 +220,9 @@ instruction, which restores the PC from {\tt mnepc}, the privilege mode
 from {\tt mnstatus}, and also sets {\tt mnstatus}.NMIE, which
 re-enables interrupts.
 
-If the hart encounters an exception while the {\tt mnstatus}.NMIE bit is
-clear, the actions taken are the same as if the exception had occurred while
+If the hart encounters an exception while executing in M-mode
+with the {\tt mnstatus}.NMIE bit clear,
+the actions taken are the same as if the exception had occurred while
 {\tt mnstatus}.NMIE were set, except that the program counter is set to the
 RNMI exception trap handler address (rather than the address specified by
 {\tt mtvec}).


### PR DESCRIPTION
Clarify that NMIE only affects M-mode synchronous exception behavior.

Also state that MNRET clears MPRV when returning to less-privileged modes.