### PR TITLE
Fix incorrect description of the calling convention for floats passed in GPRs

### DIFF
--- a/src/zfinx.tex
+++ b/src/zfinx.tex
@@ -59,10 +59,10 @@ hold both floating-point and integer operands.
 Hence, the need for NaN boxing is diminished.
 
 Sign-extending 32-bit floating-point numbers when held in RV64 {\tt x}
-registers matches the existing RV64 calling conventions, which require all
-32-bit types to be sign-extended when passed or returned in {\tt x} registers.
-To keep the architecture more regular, we extend this pattern to 16-bit
-floating-point numbers in both RV32 and RV64.
+registers is compatible with the existing RV64 calling conventions, which
+leave bits 63-32 undefined when passing a 32-bit floating point value in
+{\tt x} registers. To keep the architecture more regular, we extend this
+pattern to 16-bit floating-point numbers in both RV32 and RV64.
 \end{commentary}
 
 \section{Zdinx}


### PR DESCRIPTION
As I noted previously in <https://github.com/riscv/riscv-zfinx/issues/14>, it's incorrect to say that floating point values passed in GPRs are sign-extended in the standard calling convention. The [current, ratified psABI](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/6cda8927232dc59424426f4dd0de2e0723d865fb/riscv-cc.adoc) states "Floating-point reals are passed the same way as aggregates of the same size" and the relevant part from the description of aggregates is "Bits unused due to padding, and bits past the end of an aggregate whose size in bits is not divisible by XLEN, are undefined."