### PR TITLE
Label HINT encodings intended for future standard use as "designated"

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1450,7 +1450,7 @@ simulation/emulation.
 \begin{tabular}{|l|l|c|l|}
   \hline
   Instruction           & Constraints                                 & Code Points & Purpose \\ \hline \hline
-  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{10}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{10}{*}{\em Designated for future standard use} \\ \cline{1-3}
   AUIPC                 & {\em rd}={\tt x0}                           & $2^{20}$                    & \\ \cline{1-3}
   \multirow{2}{*}{ADDI} & {\em rd}={\tt x0}, and either               & \multirow{2}{*}{$2^{17}-1$} & \\
                         & {\em rs1}$\neq${\tt x0} or {\em imm}$\neq$0 &                             & \\ \cline{1-3}
@@ -1465,7 +1465,7 @@ simulation/emulation.
                         &                                             &                             & ({\em rs2}={\tt x3}) NTL.PALL \\
                         &                                             &                             & ({\em rs2}={\tt x4}) NTL.S1 \\
                         &                                             &                             & ({\em rs2}={\tt x5}) NTL.ALL \\ \hline
-  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{17}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{17}{*}{\em Designated for future standard use} \\ \cline{1-3}
   AND                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   OR                    & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   XOR                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}

--- a/src/rv64.tex
+++ b/src/rv64.tex
@@ -274,7 +274,7 @@ will ever be defined in this subspace.
 \begin{tabular}{|l|l|c|l|}
   \hline
   Instruction           & Constraints                                 & Code Points & Purpose \\ \hline \hline
-  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{11}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  LUI                   & {\em rd}={\tt x0}                           & $2^{20}$                    & \multirow{11}{*}{\em Designated for future standard use} \\ \cline{1-3}
   AUIPC                 & {\em rd}={\tt x0}                           & $2^{20}$                    & \\ \cline{1-3}
   \multirow{2}{*}{ADDI} & {\em rd}={\tt x0}, and either               & \multirow{2}{*}{$2^{17}-1$} & \\
                         & {\em rs1}$\neq${\tt x0} or {\em imm}$\neq$0 &                             & \\ \cline{1-3}
@@ -290,7 +290,7 @@ will ever be defined in this subspace.
                         &                                             &                             & ({\em rs2}={\tt x3}) NTL.PALL \\
                         &                                             &                             & ({\em rs2}={\tt x4}) NTL.S1 \\
                         &                                             &                             & ({\em rs2}={\tt x5}) NTL.ALL \\ \hline
-  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{22}{*}{\em Reserved for future standard use} \\ \cline{1-3}
+  SUB                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \multirow{22}{*}{\em Designated for future standard use} \\ \cline{1-3}
   AND                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   OR                    & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}
   XOR                   & {\em rd}={\tt x0}                           & $2^{10}$                    & \\ \cline{1-3}


### PR DESCRIPTION
The term "reserved" could be ambiguous, as it might be understood to refer to the "reserved instruction-set category" as defined in the section 1.3 instruction and further elaborated in section 2.2 "Base Instruction Formats". Avoid this potential confusion by using "designated" instead, which also matches the terminology used for HINT encodings intended for custom use.

This is an alternative to #990, following @aswaterman's suggestion.