### PR TITLE
Update riscv-isa-unpr-conv-review.adoc

### DIFF
--- a/src/riscv-isa-unpr-conv-review.adoc
+++ b/src/riscv-isa-unpr-conv-review.adoc
@@ -54,18 +54,7 @@ endif::[]
 :footnote:
 
 _Contributors to all versions of the spec in alphabetical order (please contact editors to suggest
-corrections): Arvind, Krste Asanović, Rimas Avižienis, Jacob Bachmeyer, Christopher F. Batten,
-Allen J. Baum, Alex Bradbury, Scott Beamer, Preston Briggs, Christopher Celio, Chuanhua
-Chang, David Chisnall, Paul Clayton, Palmer Dabbelt, Ken Dockser, Roger Espasa, Greg Favor,
-Shaked Flur, Stefan Freudenberger, Marc Gauthier, Andy Glew, Jan Gray, Michael Hamburg, John
-Hauser, David Horner, Bruce Hoult, Bill Huffman, Alexandre Joannou, Olof Johansson, Ben Keller,
-David Kruckemyer, Yunsup Lee, Paul Loewenstein, Daniel Lustig, Yatin Manerkar, Luc Maranget,
-Margaret Martonosi, Joseph Myers, Vijayanand Nagarajan, Rishiyur Nikhil, Jonas Oberhauser,
-Stefan O'Rear, Albert Ou, John Ousterhout, David Patterson, Christopher Pulte, Jose Renau,
-Josh Scheid, Colin Schmidt, Peter Sewell, Susmit Sarkar, Michael Taylor, Wesley Terpstra, Matt
-Thomas, Tommy Thorn, Caroline Trippel, Ray VanDeWalker, Muralidaran Vijayaraghavan, Megan
-Wachs, Andrew Waterman, Robert Watson, Derek Williams, Andrew Wright, Reinoud Zandijk,
-and Sizhuo Zhang._
+corrections): Alex Bradbury, Alexandre Joannou, Allen J. Baum, Andrew Waterman, Andrew Wright, Andy Glew, Arvind, Ben Keller, Bill Huffman, Bruce Hoult, Caroline Trippel, Chuanhua Chang, Christopher Celio, Christopher F. Batten, Christopher Pulte, Colin Schmidt, Daniel Lustig, David Chisnall, David Horner, David Kruckemyer, David Patterson, Derek Williams, Greg Favor, Jacob Bachmeyer, Jan Gray, John Hauser, John Ousterhout, Jonas Oberhauser, Jose Renau, Joseph Myers, Josh Scheid, Krste Asanović, Luc Maranget, Margaret Martonosi, Marc Gauthier, Matt Thomas, Megan Wachs, Michael Hamburg, Michael Taylor, Muralidaran Vijayaraghavan, Olof Johansson, Palmer Dabbelt, Paul Clayton, Paul Loewenstein, Peter Sewell, Preston Briggs, Ray VanDeWalker, Reinoud Zandijk, Rimas Avižienis, Rishiyur Nikhil, Robert Watson, Roger Espasa, Scott Beamer, Shaked Flur, Stefan Freudenberger, Stefan O'Rear, Susmit Sarkar, Sizhuo Zhang, Tommy Thorn, Vijayanand Nagarajan, Wesley Terpstra, Yatin Manerkar, Yunsup Lee, and Zandijk Reinou._
 
 _This document is released under a Creative Commons Attribution 4.0 International License._
 


### PR DESCRIPTION
Sort the name of the contributors alphabetically, according to what is described in the paragraph.