### PR TITLE
Zihpm and Zicntr are ratifed, give it a explictly version

### DIFF
--- a/src/counters.tex
+++ b/src/counters.tex
@@ -1,4 +1,4 @@
-\chapter{``Zicntr'' and ``Zihpm'' Counters}
+\chapter{``Zicntr'' and ``Zihpm'' Counters, Version 1.0}
 \label{counters}
 
 RISC-V ISAs provide a set of up to thirty-two 64-bit performance counters and

--- a/src/preface.tex
+++ b/src/preface.tex
@@ -38,10 +38,12 @@ The document contains the following versions of the RISC-V ISA modules:
     \em T          & \em 0.0 & \em Draft \\
     \em P          & \em 0.2 & \em Draft \\
     \em V          & \em 1.0 & \em Frozen \\
+    \bf Zicntr     & \bf 1.0 & \bf Ratified \\
     \bf Zicsr      & \bf 2.0 & \bf Ratified \\
     \bf Zifencei   & \bf 2.0 & \bf Ratified \\
     \bf Zihintpause & \bf 2.0 & \bf Ratified \\
     \em Zihintntl   & \em 0.3 & \em Frozen \\
+    \bf Zihpm      & \bf 1.0 & \bf Ratified \\
     \em Zam        & \em 0.1 & \em Draft \\
     \bf Zfh        & \bf 1.0 & \bf Ratified \\
     \bf Zfhmin     & \bf 1.0 & \bf Ratified \\


### PR DESCRIPTION
<del>Those two extension has added for a while, but didn't give it version info, I am not sure 1.0 or 2.0 should be used here, 1.0 should be represents that the item has been ratified, but I saw https://github.com/riscv/riscv-isa-manual/commit/7a58119dad5bd43e2171a26b56ef60f9591a1c9c is using `2.0` for `Zihintpause` so I using 2.0 in this PR.</del>

Those two extension has added for a while, so give it a explictly version.

Public review mail:
https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/HZGoqP1eyps/m/7e8iXjJhAQAJ

Status can be found here:
https://wiki.riscv.org/display/HOME/Specification+Status