### PR TITLE
Update the path for Makefile cleanup and GitHub Actions build

### DIFF
--- a/.github/workflows/build-pdf-and-html.yml
+++ b/.github/workflows/build-pdf-and-html.yml
@@ -68,3 +68,11 @@ jobs:
         name: unpriv-isa-asciidoc-${{ env.SHORT_SHA }}.html
         path: ${{ github.workspace }}/build/unpriv-isa-asciidoc.html
         retention-days: 7
+
+    # Upload the priv-isa-latex PDF file
+    - name: Upload riscv-privileged.pdf
+      uses: actions/upload-artifact@v3
+      with:
+        name: riscv-privileged-latex-${{ env.SHORT_SHA }}.pdf
+        path: ${{ github.workspace }}/build/riscv-privileged.pdf
+        retention-days: 7

--- a/build/Makefile
+++ b/build/Makefile
@@ -43,7 +43,7 @@ PDFLATEX := TEXINPUTS=$(SRCDIR)/latex: pdflatex -interaction=nonstopmode -halt-o
 BIBTEX := BIBINPUTS=$(SRCDIR)/latex: bibtex
 
 # Temporary files to clean up for LaTeX build
-JUNK := *.pdf *.aux *.log *.bbl *.blg *.toc *.out
+JUNK := *.pdf *.aux *.log *.bbl *.blg *.toc *.out *.fdb_latexmk *.fls *.synctex.gz
 
 # Privileged ISA build
 priv: priv-isa-asciidoc.pdf
@@ -104,7 +104,8 @@ clean:
 		rm -f unpriv-isa-asciidoc.html; \
 	fi
 	@echo "Cleaning up files from LaTeX build"
-	@for file in $(JUNK); do \
+	@cd $(SRCDIR)/latex; \
+	for file in $(JUNK); do \
 		if [ -f "$$file" ]; then \
 			echo "Removing $$file"; \
 			rm -f "$$file"; \


### PR DESCRIPTION
This commit introduces a new step in the GitHub Actions build process, improves the Makefile's cleanup function to remove lingering files, and expands the JUNK variable to include additional file extensions for a more thorough cleanup.