### PR TITLE
priv-1.13: clarify that MXLEN >= SXLEN; constrain SXLEN >= UXLEN

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -474,6 +474,9 @@ zero. Otherwise, it is a *WARL* field that encodes the current value of UXLEN.
 In particular, an implementation may make UXL be a read-only field whose
 value always ensures that UXLEN=MXLEN or UXLEN=SXLEN.
 
+If S-mode is implemented, the set of legal values that the UXL field may
+assume excludes those that would cause UXLEN to be greater than SXLEN.
+
 Whenever XLEN in any mode is set to a value less than the widest
 supported XLEN, all operations must ignore source operand register bits
 above the configured XLEN, and must sign-extend results to fill the

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -461,15 +461,15 @@ fields is the same as the MXL field of `misa`, shown in
 <<misabase>>. The effective XLEN in S-mode and
 U-mode are termed _SXLEN_ and _UXLEN_, respectively.
 
-For RV32 systems, the SXL and UXL fields do not exist, and SXLEN=32 and
+When MXLEN=32, the SXL and UXL fields do not exist, and SXLEN=32 and
 UXLEN=32.
 
-For RV64 systems, if S-mode is not supported, then SXL is read-only
+When MXLEN=64, if S-mode is not supported, then SXL is read-only
 zero. Otherwise, it is a *WARL* field that encodes the current value of SXLEN.
 In particular, an implementation may make SXL be a read-only field whose
 value always ensures that SXLEN=MXLEN.
 
-For RV64 systems, if U-mode is not supported, then UXL is read-only
+When MXLEN=64, if U-mode is not supported, then UXL is read-only
 zero. Otherwise, it is a *WARL* field that encodes the current value of UXLEN.
 In particular, an implementation may make UXL be a read-only field whose
 value always ensures that UXLEN=MXLEN or UXLEN=SXLEN.

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -37,6 +37,7 @@ version 1.12:
 * Defined the `misa`.V field to reflect that the V extension has been
 implemented.
 * Clarified semantics of explicit accesses to CSRs wider than XLEN bits.
+* Clarified that MXLEN&#8805;SXLEN.
 
 *_Preface to Version 20211203_*
 

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -37,7 +37,8 @@ version 1.12:
 * Defined the `misa`.V field to reflect that the V extension has been
 implemented.
 * Clarified semantics of explicit accesses to CSRs wider than XLEN bits.
-* Clarified that MXLEN&#8805;SXLEN.
+* Clarified that MXLEN&#8805;SXLEN, and added the constraint that
+SXLEN&#8805;UXLEN.
 
 *_Preface to Version 20211203_*
 


### PR DESCRIPTION
@gfavor FYI

@jhauser-us please check my wording.  It's a little obtuse because I was trying to constrain the set of legal values for SXL's WARL purposes.