### PR TITLE
Backport changes to naming.adoc

### DIFF
--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -83,7 +83,7 @@ an alphabetical name and an optional version number. For example,
 "Zifencei2p0" name version 2.0 of same.
 
 The first letter following the "Z" conventionally indicates the most
-closely related alphabetical extension category, IMAFDQLCBKJTPV. For the
+closely related alphabetical extension category, IMAFDQCVH. For the
 "Zam" extension for misaligned atomics, for example, the letter "a"
 indicates the extension is related to the "A" standard extension. If
 multiple "Z" extensions are named, they should be ordered first by
@@ -105,16 +105,6 @@ underscore.
 Standard supervisor-level extensions should be listed after standard
 unprivileged extensions. If multiple supervisor-level extensions are
 listed, they should be ordered alphabetically.
-
-=== Hypervisor-level Instruction-Set Extensions
-
-Standard hypervisor-level instruction-set extensions are named like
-supervisor-level extensions, but beginning with the letter "H" instead
-of the letter "S".
-
-Standard hypervisor-level extensions should be listed after standard
-lesser-privileged extensions. If multiple hypervisor-level extensions
-are listed, they should be ordered alphabetically.
 
 === Machine-level Instruction-Set Extensions
 
@@ -170,21 +160,17 @@ e.g., RV32IMACV is legal, whereas RV32IMAVC is not.
 
 |Double-Precision Floating-Point |D |F
 
-|General |G |IMADZifencei
+|General |G |IMAFDZicsr_Zifencei
 
 |Quad-Precision Floating-Point |Q |D
 
 |16-bit Compressed Instructions |C |
 
-|Bit Manipulation |B |
-
-|Cryptography Extensions |K |
-
-|Dynamic Languages |J |
-
 |Packed-SIMD Extensions |P |
 
-|Vector Extensions |V |
+|Vector Extension |V |D
+
+|Hypervisor Extension |H |
 
 |Control and Status Register Access |Zicsr |
 
@@ -197,10 +183,6 @@ e.g., RV32IMACV is legal, whereas RV32IMAVC is not.
 3+|*Standard Supervisor-Level Extensions*
 
 |Supervisor-level extension "def" |Sdef |
-
-|Standard Hypervisor-Level Extensions | |
-
-|Hypervisor-level extension "ghi" |Hghi |
 
 3+|*Standard Machine-Level Extensions*
 


### PR DESCRIPTION
Related commit

* (b61dd437) Strict single-letter extensions on Table 28.1 (Standard ISA extension
* (6b1754c8) D extension is implied by V extension
* (f5f9c270) Delete more nonexistent extensions from the naming constraints
* (7249db97) Remove multi-letter H* extensions from naming
* (db7a4a0d) Add single-letter "H" extension to the table
* (d8786eed) Updating 'G' definition

Related to #1035