### PR TITLE
Fix error in RVC Instruction Set Listings: Quadrant 2

### DIFF
--- a/src/images/bytefield/rvc-instr-quad2.adoc
+++ b/src/images/bytefield/rvc-instr-quad2.adoc
@@ -35,6 +35,13 @@
 (draw-box "rd≠0" {:span 5})
 (draw-box "uimm[4|9:6]" {:span 5})
 (draw-box "10" {:span 2})
+(draw-box (text "C.LQSP" :math [:sub "(RV128; RES, rd=0)"]) {:span 6 :text-anchor "start" :borders {}})
+
+(draw-box "010" {:span 3})
+(draw-box (text "uimm[5]" {:font-size 16}) {:span 1})
+(draw-box "rd≠0" {:span 5})
+(draw-box "uimm[4:2|7:6]" {:span 5})
+(draw-box "10" {:span 2})
 (draw-box (text "C.LWSP" :math [:sub "(RES, rd=0)"]) {:span 6 :text-anchor "start" :borders {}})
 
 (draw-box "011" {:span 3})


### PR DESCRIPTION
### Relate Issue

This PR fixes #1037 

### Description

1. Fix the definition of `C.LWSP`.
2. Added definition of `C.LQSP`.