### PR TITLE
A-ext chapter: 64-bit word => doubleword; 32-bit word => word

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -115,7 +115,7 @@ defined in future versions or extensions to the ISA.
 
 For LR and SC, the A extension requires that the address held in _rs1_
 be naturally aligned to the size of the operand (i.e., eight-byte
-aligned for 64-bit words and four-byte aligned for 32-bit words). If the
+aligned for _doublewords_ and four-byte aligned for _words_). If the
 address is not naturally aligned, an address-misaligned exception or an
 access-fault exception will be generated. The access-fault exception can
 be generated for a memory access that would otherwise be able to
@@ -358,13 +358,13 @@ R-type instruction format. These AMO instructions atomically load a data
 value from the address in _rs1_, place the value into register _rd_,
 apply a binary operator to the loaded value and the original value in
 _rs2_, then store the result back to the original address in _rs1_. AMOs
-can either operate on 64-bit (RV64 only) or 32-bit words in memory. For
+can either operate on _doublewords_ (RV64 only) or _words_ in memory. For
 RV64, 32-bit AMOs always sign-extend the value placed in _rd_, and
 ignore the upper 32 bits of the original value of _rs2_.
 
 For AMOs, the A extension requires that the address held in _rs1_ be
 naturally aligned to the size of the operand (i.e., eight-byte aligned
-for 64-bit words and four-byte aligned for 32-bit words). If the address
+for _doublewords_ and four-byte aligned for _words_). If the address
 is not naturally aligned, an address-misaligned exception or an
 access-fault exception will be generated. The access-fault exception can
 be generated for a memory access that would otherwise be able to


### PR DESCRIPTION
Use _doubleword_ instead of "64-bit word" and _word_ instead of "32-bit word"