### PR TITLE
Change "Reserved" to "Designated" in RVC HINT instructions table

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -872,7 +872,7 @@ no standard HINTs will ever be defined in this subspace.
 |===
 |Instruction |Constraints |Code Points |Purpose
 
-|C.NOP |_imm_≠0 |63 .6+.^|_Reserved for future standard use_
+|C.NOP |_imm_≠0 |63 .6+.^|_Designated for future standard use_
 
 |C.ADDI | _rd_≠`x0`, _imm_=0 |31
 


### PR DESCRIPTION
In https://github.com/riscv/riscv-isa-manual/pull/1001,
I think "Reserved for future standard use" in C extension's table should have been replaced with "Designated for future standard use".