### PR TITLE
Add RV64E to Base Integer ISA

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -76,7 +76,7 @@ integer loads and stores.
 ====
 
 RVC was designed under the constraint that each RVC instruction expands
-into a single 32-bit instruction in either the base ISA (RV32I/E, RV64I,
+into a single 32-bit instruction in either the base ISA (RV32I/E, RV64I/E,
 or RV128I) or the F and D standard extensions where present. Adopting
 this constraint has two main benefits:
 
@@ -185,7 +185,7 @@ ADDI4SPN instruction.
 The RISC-V ABI was changed to make the frequently used registers map to
 registers 'x8-x15'. This simplifies the decompression decoder by
 having a contiguous naturally aligned set of register numbers, and is
-also compatible with the RV32E base ISA, which only has 16 integer
+also compatible with the RV32E and RV64E base ISA, which only have 16 integer
 registers.
 ====
 Compressed register-based floating-point loads and stores also use the

--- a/src/extending.adoc
+++ b/src/extending.adoc
@@ -25,7 +25,7 @@ extensions.
 ==== Standard versus Non-Standard Extension
 
 Any RISC-V processor implementation must support a base integer ISA
-(RV32I, RV32E, RV64I, or RV128I). In addition, an implementation may
+(RV32I, RV32E, RV64I, RV64E, or RV128I). In addition, an implementation may
 support one or more extensions. We divide extensions into two broad
 categories: _standard_ versus _non-standard_.
 

--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -21,7 +21,7 @@ same SBI as an OS normally does from S-mode. An HS-mode hypervisor is
 expected to implement the SBI for its VS-mode guest.
 
 The hypervisor extension depends on an "I" base integer ISA with 32
-`x` registers (RV32I or RV64I), not RV32E, which has only 16 `x`
+`x` registers (RV32I or RV64I), not RV32E or RV64E, which have only 16 `x`
 registers. CSR `mtval` must not be read-only zero, and standard
 page-based address translation must be supported, either Sv32 for RV32,
 or a minimum of Sv39 for RV64.

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -221,9 +221,9 @@ integer variants, RV32I and RV64I, described in
 <<rv32>> and <<rv64>>, which provide 32-bit
 or 64-bit address spaces respectively. We use the term XLEN to refer to
 the width of an integer register in bits (either 32 or 64).
-<<rv32e, Chapter 6>> describes the RV32E subset variant of the
-RV32I base instruction set, which has been added to support small
-microcontrollers, and which has half the number of integer registers.
+<<rv32e, Chapter 6>> describes the RV32E and RV64E subset variants of the
+RV32I or RV64I base instruction sets respectively, which have been added to support small
+microcontrollers, and which have half the number of integer registers.
 <<rv128, Chapter 8>> sketches a future RV128I variant of the
 base integer instruction set supporting a flat 128-bit address space
 (XLEN=128). The base integer instruction sets use a two's-complement

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -66,7 +66,7 @@ The Extensions field encodes the presence of the standard extensions,
 with a single bit per letter of the alphabet (bit 0 encodes presence of
 extension "A" , bit 1 encodes presence of extension "B", through to
 bit 25 which encodes "Z"). The "I" bit will be set for RV32I, RV64I,
-RV128I base ISAs, and the "E" bit will be set for RV32E. The
+RV128I base ISAs, and the "E" bit will be set for RV32E, RV64E. The
 Extensions field is a *WARL* field that can contain writable bits where the
 implementation allows the supported ISA to be modified. At reset, the
 Extensions field shall contain the maximal set of supported extensions,
@@ -163,7 +163,7 @@ Z
 _Reserved_ +
 Compressed extension +
 Double-precision floating-point extension +
-RV32E base ISA +
+RV32E/64E base ISA +
 Single-precision floating-point extension +
 _Reserved_ +
 Hypervisor extension +

--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -17,7 +17,7 @@ The ISA naming strings are case insensitive.
 
 === Base Integer ISA
 
-RISC-V ISA strings begin with either RV32I, RV32E, RV64I, or RV128I
+RISC-V ISA strings begin with either RV32I, RV32E, RV64I, RV64E, or RV128I
 indicating the supported address space size in bits for the base integer
 ISA.
 


### PR DESCRIPTION
RV32E and RV64E Base Integer Instruction Sets status is Ratified, but there are sentences written only for RV32E.