### PR TITLE
fix formatting

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1410,7 +1410,7 @@ include::images/bytefield/mtval2reg.edn[]
 When a guest-page-fault trap is taken into M-mode, `mtval2` is written
 with either zero or the guest physical address that faulted, shifted
 right by 2 bits. For other traps, `mtval2` is set to zero, but a future
-standard or extension may redefine `mtval2`'s setting for other traps.
+standard or extension may redefine `mtval2` 's setting for other traps.
 
 If a guest-page fault is due to an implicit memory access during
 first-stage (VS-stage) address translation, a guest physical address

--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1410,7 +1410,7 @@ include::images/bytefield/mtval2reg.edn[]
 When a guest-page-fault trap is taken into M-mode, `mtval2` is written
 with either zero or the guest physical address that faulted, shifted
 right by 2 bits. For other traps, `mtval2` is set to zero, but a future
-standard or extension may redefine `mtval2` 's setting for other traps.
+standard or extension may redefine `mtval2's` setting for other traps.
 
 If a guest-page fault is due to an implicit memory access during
 first-stage (VS-stage) address translation, a guest physical address


### PR DESCRIPTION
`mtval2`'s doesn't render, suggesting a space to fix that but it might not be the best answer