### PR TITLE
Make "Conditional Branches" wavdrom consistent

### DIFF
--- a/src/images/wavedrom/ct-conditional.adoc
+++ b/src/images/wavedrom/ct-conditional.adoc
@@ -4,11 +4,10 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'BRANCH', 'BRANCH', 'BRANCH'], type: 8},
-  {bits: 1,  name: '[11]',      attr: '1', type: 3},
-  {bits: 4,  name: 'imm[4:1]',  attr: ['4', 'offset[11|4:1]', 'offset[11|4:1]', 'offset[11|4:1]'], type: 3},
+  {bits: 5,  name: 'imm[4:1|11]',  attr: ['5', 'offset[4:1|11]', 'offset[4:1|11]', 'offset[4:1|11]'], type: 3},
   {bits: 3,  name: 'funct3',     attr: ['3', 'BEQ/BNE', 'BLT[U]', 'BGE[U]'], type: 8},
   {bits: 5,  name: 'rs1', attr: ['5', 'src1', 'src1', 'src1'], type: 4},
   {bits: 5,  name: 'rs2', attr: ['5', 'src2','src2', 'src2'], type: 4},
-  {bits: 7,  name: 'imm[12|10:5]', attr: ['6', 'offset[12|10:5]', 'offset[12|10:5]', 'offset[12|10:5]'], type: 3},
+  {bits: 7,  name: 'imm[12|10:5]', attr: ['7', 'offset[12|10:5]', 'offset[12|10:5]', 'offset[12|10:5]'], type: 3},
 ], config:{fontsize: 10}}
 ....


### PR DESCRIPTION
Bit 12 was merged with bits 10:5, but it was still labeled as 6 bits instead of 7. Bits 4:1 and 11 were merged in the label but not in the diagram and they were merged backward in the label. Merge them in the diagram and fix the label.