### PR TITLE
Make "Integer Register-Immediate Operations" Consistent

### DIFF
--- a/src/images/wavedrom/c-int-reg-immed.adoc
+++ b/src/images/wavedrom/c-int-reg-immed.adoc
@@ -4,9 +4,9 @@
 ....
 {reg: [
   {bits: 2, name: 'op',        type: 3, attr: ['2','C1', 'C1', 'C1']},
-  {bits: 5, name: 'imm[4:0]',  type: 1, attr: ['5','imm[4:0]', 'imm[4:0], imm[4|6|8:7|5]']},
+  {bits: 5, name: 'imm',  type: 1, attr: ['5','imm[4:0]', 'imm[4:0]', 'imm[4|6|8:7|5]']},
   {bits: 5, name: 'rd/rs1',    type: 5, attr: ['5','dest≠0', 'dest≠0', '2']},
-  {bits: 1, name: 'imm[5]',    type: 5, attr: ['1','imm[5]', 'imm[5]', 'imm[9]']},
+  {bits: 1, name: 'imm',    type: 5, attr: ['1','imm[5]', 'imm[5]', 'imm[9]']},
   {bits: 3, name: 'funct3',    type: 5, attr: ['3','C.ADDI', 'C.ADDIW', 'C.ADDI16SP']},
 ], config: {bits: 16}}
 ....


### PR DESCRIPTION
Properly align the ADDI16SP immediate in wavedrom. Remove the bit brackets from the immediates because the instructions do not uniformly follow the same immediate format.