### PR TITLE
Correct Name of LR/SC Instructions rl bit

### DIFF
--- a/src/images/wavedrom/load-reserve-st-conditional.adoc
+++ b/src/images/wavedrom/load-reserve-st-conditional.adoc
@@ -10,7 +10,7 @@
   {bits: 3,  name: 'funct3',    attr: ['3', 'width', 'width'], type: 8},
   {bits: 5,  name: 'rs1',       attr: ['5', 'addr', 'addr'], type: 4},
   {bits: 5,  name: 'rs2',       attr: ['5', '0', 'src'], type: 4},
-  {bits: 1,  name: 'r1',        attr: ['1', 'ring', 'ring'], type: 8},
+  {bits: 1,  name: 'rl',        attr: ['1', 'ring', 'ring'], type: 8},
   {bits: 1,  name: 'aq',        attr: ['1', 'orde', 'orde'], type: 8},
   {bits: 5,  name: 'funct5',    attr: ['5', 'LR.W/D', 'SC.W/D'], type: 8},
 ]}


### PR DESCRIPTION
The name of this bit is rl and not r1.