### PR TITLE
`C.XOR` is not RV64/RV128 only

### DIFF
--- a/src/images/bytefield/rvc-instr-quad1.adoc
+++ b/src/images/bytefield/rvc-instr-quad1.adoc
@@ -112,7 +112,7 @@
 (draw-box "01" {:span 2})
 (draw-box "rs2′" {:span 3})
 (draw-box "01" {:span 2})
-(draw-box (text "C.XOR" :math [:sub "(RV64/128)"]) {:span 3 :text-anchor "start" :borders {}})
+(draw-box "C.XOR" {:span 3 :text-anchor "start" :borders {}})
 
 (draw-box "100" {:span 3})
 (draw-box "0" {:span 1})


### PR DESCRIPTION
It removes "(RV64/128)" from the `C.XOR` instruction in the RVC Instruction Set Listings.