### PR TITLE
Fix C.ADDI16SP immediate

### DIFF
--- a/src/images/bytefield/rvc-instr-quad1.adoc
+++ b/src/images/bytefield/rvc-instr-quad1.adoc
@@ -45,7 +45,7 @@
 (draw-box "011" {:span 3})
 (draw-box "imm[9]" {:span 1})
 (draw-box "2" {:span 5})
-(draw-box "imm[4:0]" {:span 5})
+(draw-box "imm[4|6|8:7|5]" {:span 5})
 (draw-box "01" {:span 2})
 (draw-box (text "C.ADDI16SP" :math [:sub "(RES, imm=0)"]) {:span 3 :text-anchor "start" :borders {}})
 


### PR DESCRIPTION
The lower immediate for C.ADDI16SP is [4|6|8:7|5] instead of [4:0]