### PR TITLE
Counters are now ratified (with version 2.0)

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -28,7 +28,7 @@ h|Extension h|Version h|Status
 |*D* |*2.2* |*Ratified*
 |*Q* |*2.2* |*Ratified*
 |*C* |*2.0* |*Ratified*
-|_Counters_ |_2.0_ |_Draft_
+|_Counters_ |*2.0* |*Ratified*
 |_P_ |_0.2_ |_Draft_
 |*V* |*1.0* |*Ratified*
 |*Zicsr* |*2.0* |*Ratified*

--- a/src/counters.adoc
+++ b/src/counters.adoc
@@ -1,5 +1,5 @@
 [[counters]]
-== "Zicntr" and "Zihpm" Counters
+== "Zicntr" and "Zihpm" Counters, Version 2.0
 
 RISC-V ISAs provide a set of up to thirty-two 64-bit performance
 counters and timers that are accessible via unprivileged XLEN-bit


### PR DESCRIPTION
Resolves the same issue as #1008.

# Pros against #1008 

*   It is based on the latest AsciiDoc-based documentation.
*   Version numbers are set to correct 2.0.

# Cons against #1008 

*   I didn't split "Counters" to `Zicntr` and `Zihpm` separate rows (of course, I can change that easily and tell me if I need to).
