### PR TITLE
Officially name the hypervisor extension "H"

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1,5 +1,5 @@
 [[hypervisor]]
-== Hypervisor Extension, Version 1.0
+== "H" Extension for Hypervisor Support, Version 1.0
 
 This chapter describes the RISC-V hypervisor extension, which
 virtualizes the supervisor-level architecture to support the efficient


### PR DESCRIPTION
Note that this is currently the initial change.

It does not replace other references to
*   *the hypervisor extension* to
*   *the "H" extension*.

Still, even without replacing those, it can be a first patch of the series.

### TODO List (for complete change)

- [x] Check whether the name "Standard Extension for Hypervisor" is okay.
    - "Standard Extension for Hypervisor Support" is the official name (as [suggested](https://github.com/riscv/riscv-isa-manual/pull/1084#issuecomment-2026107589) by @aswaterman)
- [ ] Determine where to replace (to *the "H" extension*)
- [ ] Actual replacement (or not)