### PR TITLE
Vector: Clarify Zicsr dependence from Zve32x

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -5063,6 +5063,8 @@ All Zve* extensions support all vector permutation instructions
 do not include those with floating-point operands, and Zve64f does not include those
 with EEW=64 floating-point operands.
 
+The Zve32x extension depends on the Zicsr extension.
+
 The Zve32f and Zve64f extensions depend upon the F extension,
 and implement all
 vector floating-point instructions (Section <<sec-vector-float>>) for


### PR DESCRIPTION
This is a port of riscv/riscv-v-spec#909 (by @nick-knight).