### PR TITLE
Add `*.pdf.tmp` to build/.gitignore

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -5,6 +5,7 @@
 *.log
 *.out
 *.pdf
+*.pdf.tmp
 *.toc
 images
 .asciidoctor


### PR DESCRIPTION
The author forgot to add this to the initial PR (#1089) because `*.pdf.tmp` normally only exists for a short amount of time (while building).

It excludes following build-related files:

*   `build/priv-isa-asciidoc.pdf.tmp`
*   `build/unpriv-isa-asciidoc.pdf.tmp`