### PR TITLE
Add OP-V and OP-P to base opcode map

### DIFF
--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -14,12 +14,12 @@ and RV64G.
 .RISC-V base opcode map, inst[1:0]=11
 [%autowidth.stretch,float="center",align="center",cols=  ">.^4m,  ^.^4m,    ^.^4m,      ^.^4m,    ^.^4m,  ^.^4m,      ^.^4m,           ^.^6m, ^.^4h"]
 |===
-|inst[4:2] .2+|000 .2+|001   .2+|010     .2+|011   .2+|100 .2+|101     .2+|110          .2+|111 (>32b)
+|inst[4:2] .2+|000 .2+|001   .2+|010     .2+|011   .2+|100 .2+|101 .2+|110          .2+|111 (>32b)
 |inst[6:5]
-|00           |LOAD   |LOAD-FP  |_custom-0_ |MISC-MEM |OP-IMM |AUIPC      |OP-IMM-32       |48b
-|01           |STORE  |STORE-FP |_custom-1_ |AMO      |OP     |LUI        |OP-32           |64b
-|10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |_reserved_ |_custom-2/rv128_|48b
-|11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |_reserved_ |_custom-3/rv128_|&#8805;80b
+|00           |LOAD   |LOAD-FP  |_custom-0_ |MISC-MEM |OP-IMM |AUIPC  |OP-IMM-32       |48b
+|01           |STORE  |STORE-FP |_custom-1_ |AMO      |OP     |LUI    |OP-32           |64b
+|10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |OP-V   |_custom-2/rv128_|48b
+|11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |OP-P   |_custom-3/rv128_|&#8805;80b
 |===
 
 <<opcodemap>> shows a map of the major opcodes for


### PR DESCRIPTION
"V" extension corresponding new base opcode OP-V (`0b1010111`) is now ratified and opcode using OP-P (`0b1110111`) is approved for the vector cryptography extensions.

This PR reflects new base opcodes.

Note that OP-V part is an AsciiDoc port of #862.
OP-P part is new in this PR (I didn't notice at the first time but vector cryptography extensions use instructions with OP-P).