### PR TITLE
Mark Zfa as Frozen and Version 1.0

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -40,6 +40,7 @@ h|Extension h|Version h|Status
 |*Zihintpause* |*2.0* |*Ratified*
 |_Zihintntl_ |_0.3_ |_Frozen_
 |_Zam_ |_0.1_ |_Draft_
+|*Zfh* |*1.0* |_Frozen_
 |*Zfh* |*1.0* |*Ratified*
 |*Zfhmin* |*1.0* |*Ratified*
 |*Zfinx* |*1.0* |*Ratified*

--- a/src/zfa.adoc
+++ b/src/zfa.adoc
@@ -1,10 +1,9 @@
 [[zfa]]
-== "Zfa" Standard Extension for Additional Floating-Point Instructions, Version 0.1
+== "Zfa" Standard Extension for Additional Floating-Point Instructions, Version 1.0
 
 [WARNING]
 ====
-This draft specification may change before being accepted as
-standard by RISC-V International.
+Zfa is frozen.
 ====
 
 This chapter describes the Zfa standard extension, which adds


### PR DESCRIPTION
While looking at some Zfa patches I couldn't actually find a concrete reference to the spec being frozen, just the commit text of the binutils patches.  I figured this was the easiest way to ask...