### PR TITLE
Don't describe WFI as a hint

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2182,7 +2182,7 @@ impossible to single-step through LR/SC sequences using a debugger.
 [[wfi]]
 ==== Wait for Interrupt
 
-The Wait for Interrupt instruction (WFI) provides a hint to the
+The Wait for Interrupt instruction (WFI) informs the
 implementation that the current hart can be stalled until an interrupt
 might need servicing. Execution of the WFI instruction can also be used
 to inform the hardware platform that suitable interrupts should
@@ -2205,9 +2205,9 @@ return from the trap handler will execute code after the WFI
 instruction.
 ====
 
-The purpose of the WFI instruction is to provide a hint to the
-implementation, and so a legal implementation is to simply implement WFI
-as a NOP.
+Implementations are permitted to resume execution for any reason, even if an
+enabled interrupt has not become pending.  Hence, a legal implementation is to
+simply implement the WFI instruction as a NOP.
 
 [NOTE]
 ====

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -39,6 +39,7 @@ implemented.
 * Clarified semantics of explicit accesses to CSRs wider than XLEN bits.
 * Clarified that MXLEN&#8805;SXLEN, and added the constraint that
 SXLEN&#8805;UXLEN.
+* Clarified that WFI is not a HINT instruction.
 
 [.big]*_Preface to Version 20211203_*
 


### PR DESCRIPTION
Even though one can say that WFI is a hint to the implementation, it is not a HINT in the RISC-V sense of the term, so avoid the word hint to avoid confusion.