### PR TITLE
Add OP-V to base opcode map (AsciiDoc port)

### DIFF
--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -18,7 +18,7 @@ and RV64G.
 |inst[6:5]
 |00           |LOAD   |LOAD-FP  |_custom-0_ |MISC-MEM |OP-IMM |AUIPC      |OP-IMM-32       |48b
 |01           |STORE  |STORE-FP |_custom-1_ |AMO      |OP     |LUI        |OP-32           |64b
-|10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |_reserved_ |_custom-2/rv128_|48b
+|10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |OP-V       |_custom-2/rv128_|48b
 |11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |_reserved_ |_custom-3/rv128_|&#8805;80b
 |===
 


### PR DESCRIPTION
This is a subset of #1094 and an AsciiDoc port of #862.