### PR TITLE
Allow Misaligned Stores with Page Fault to partially succeed

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -3046,9 +3046,8 @@ fetches may also be decomposed into multiple accesses, some of which may
 succeed before an access-fault exception occurs. In particular, a
 portion of a misaligned store that passes the PMP check may become
 visible, even if another portion fails the PMP check. The same behavior
-may manifest for floating-point stores wider than XLEN bits (e.g., the
-FSD instruction in RV32D), even when the store address is naturally
-aligned.
+may manifest for stores wider than XLEN bits (e.g., the FSD instruction
+in RV32D), even when the store address is naturally aligned.
 
 [[pmp-vmem]]
 ==== Physical Memory Protection and Paging

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1281,6 +1281,15 @@ standard extension, the LR/SC reservation set must lie completely within
 a single base physical page (i.e., a naturally aligned 4 KiB physical-memory
 region).
 
+On some implementations, misaligned loads, stores, and instruction
+fetches may also be decomposed into multiple accesses, some of which may
+succeed before a page-fault exception occurs. In particular, a
+portion of a misaligned store that passes the exception check may become
+visible, even if another portion fails the exception check. The same behavior
+may manifest for stores wider than XLEN bits (e.g., the FSD instruction
+in RV32D), even when the store address is naturally aligned.
+
+
 [[sv32algorithm]]
 ==== Virtual Address Translation Process
 


### PR DESCRIPTION
1. Extend the >XLEN decomposition relaxation to vector stores by deleting the word “floating-point” in the description of PMP faults.
2. Add similar text copied from the PMP section to the Sv32 section for virtual memory page faults.

> This is just a clarification, since it follows logically from misaligned accesses possibly being decomposed into smaller accesses.
> "Notably, instructions that reference virtual memory are decomposed into multiple accesses."