### PR TITLE
M implies Zmmul

### DIFF
--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -141,7 +141,7 @@ The Zmmul extension implements the multiplication subset of the M
 extension. It adds all of the instructions defined in
 <<Multiplication Operations>>, namely: MUL, MULH, MULHU,
 MULHSU, and (for RV64 only) MULW. The encodings are identical to those
-of the corresponding M-extension instructions.
+of the corresponding M-extension instructions. M implies Zmmul.
 (((MUL, Zmmul)))
 
 [NOTE]

--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -152,7 +152,7 @@ e.g., RV32IMACV is legal, whereas RV32IMAVC is not.
 
 3+|*Standard Unprivileged Extensions*
 
-|Integer Multiplication and Division |M |
+|Integer Multiplication and Division |M |Zmmul
 
 |Atomics |A |
 


### PR DESCRIPTION
Zmmul is defined to be a subset of M. It follows that M implies Zmmul. This closes https://github.com/riscv/riscv-isa-manual/issues/869. It also resolves a question raised in the Toolchains SIG: https://github.com/riscv-non-isa/riscv-asm-manual/issues/91#issuecomment-1714090713.

This PR adds this implication to a table in the "ISA Naming Conventions" chapter. (EDIT: and also in the M chapter.)