### PR TITLE
Clarify REM wording

### DIFF
--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -65,8 +65,8 @@ the sign of a nonzero result equals the sign of the dividend.
 
 [NOTE]
 ====
-For both signed and unsigned division, except in the case of signed overflow,
-it holds that
+For both signed and unsigned division, except in the case of overflow, it holds
+that
 latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \textrm{remainder}$].
 ====
 

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -61,11 +61,12 @@ include::images/wavedrom/division-op.adoc[]
 DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned
 integer division of _rs1_ by _rs2_, rounding towards zero. REM and REMU
 provide the remainder of the corresponding division operation. For REM,
-the sign of the result equals the sign of the dividend.
+the sign of a nonzero result equals the sign of the dividend.
 
 [NOTE]
 ====
-For both signed and unsigned division, it holds that
+For both signed and unsigned division, except in the case of signed overflow,
+it holds that
 latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \textrm{remainder}$].
 ====
 


### PR DESCRIPTION
I think this was obviously in the writers' intent that only nonzero results have the same sign as the dividend. The non-normative note is also updated to reflect the special case of signed division overflow.