### PR TITLE
Standardize on no hyphen in illegal instruction exception

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -885,7 +885,7 @@ widest supported width not wider than the new VSXLEN.
 
 When V=1, both `vsstatus`.FS and the HS-level `sstatus`.FS are in
 effect. Attempts to execute a floating-point instruction when either
-field is 0 (Off) raise an illegal-instruction exception. Modifying the
+field is 0 (Off) raise an illegal instruction exception. Modifying the
 floating-point state when V=1 causes both fields to be set to 3 (Dirty).
 
 [NOTE]
@@ -904,7 +904,7 @@ context-switching between virtual machines.
 
 Similarly, when V=1, both `vsstatus`.VS and the HS-level `sstatus`.VS
 are in effect. Attempts to execute a vector instruction when either
-field is 0 (Off) raise an illegal-instruction exception. Modifying the
+field is 0 (Off) raise an illegal instruction exception. Modifying the
 vector state when V=1 causes both fields to be set to 3 (Dirty).
 
 Read-only fields SD and XS summarize the extension context status as it

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1848,7 +1848,7 @@ address of the portion of the instruction that caused the fault, while
 The `mtval` register can optionally also be used to return the faulting
 instruction bits on an illegal instruction exception (`mepc` points to
 the faulting instruction in memory). If `mtval` is written with a
-nonzero value when an illegal-instruction exception occurs, then `mtval`
+nonzero value when an illegal instruction exception occurs, then `mtval`
 will contain the shortest of:
 
 * the actual faulting instruction
@@ -1857,7 +1857,7 @@ will contain the shortest of:
 
 * the first MXLEN bits of the faulting instruction
 
-The value loaded into `mtval` on an illegal-instruction exception is
+The value loaded into `mtval` on an illegal instruction exception is
 right-justified and all unused upper bits are cleared to zero.
 
 [NOTE]

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -161,7 +161,7 @@ The behavior upon decoding a reserved instruction is UNSPECIFIED.
 [NOTE]
 ====
 Some platforms may require that opcodes reserved for standard use raise
-an illegal-instruction exception. Other platforms may permit reserved
+an illegal instruction exception. Other platforms may permit reserved
 opcode space be used for non-conforming extensions.
 ====
 

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -538,14 +538,14 @@ address of the portion of the instruction that caused the fault, while
 The `stval` register can optionally also be used to return the faulting
 instruction bits on an illegal instruction exception (`sepc` points to
 the faulting instruction in memory). If `stval` is written with a
-nonzero value when an illegal-instruction exception occurs, then `stval`
+nonzero value when an illegal instruction exception occurs, then `stval`
 will contain the shortest of:
 
 * the actual faulting instruction
 * the first ILEN bits of the faulting instruction
 * the first SXLEN bits of the faulting instruction
 
-The value loaded into `stval` on an illegal-instruction exception is
+The value loaded into `stval` on an illegal instruction exception is
 right-justified and all unused upper bits are cleared to zero.
 
 For other traps, `stval` is set to zero, but a future standard may


### PR DESCRIPTION
Based on casual grepping, we omit the hyphen in 46 cases but retain it in 7.  Standardize on the more common one.