### PR TITLE
Hyphenate "virtual-/illegal-instruction exception"

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -172,7 +172,7 @@ data caches. However, it remains the only standard instruction-fetch
 coherence mechanism.
 * Removed prohibitions on using RV32E with other extensions.
 * Removed platform-specific mandates that certain encodings produce
-illegal instruction exceptions in RV32E and RV64I chapters.
+illegal-instruction exceptions in RV32E and RV64I chapters.
 * Counter/timer instructions are now not considered part of the
 mandatory base ISA, and so CSR instructions were moved into separate
 chapter and marked as version 2.0, with the unprivileged counters moved

--- a/src/counters.adoc
+++ b/src/counters.adoc
@@ -196,7 +196,7 @@ implementations with a richer set of counters.
 
 The implemented number and width of these additional counters, and the
 set of events they count, is platform-specific. Accessing an
-unimplemented or ill-configured counter may cause an illegal instruction
+unimplemented or ill-configured counter may cause an illegal-instruction
 exception or may return a constant value.
 
 The execution environment should provide a means to determine the number

--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -143,11 +143,11 @@ the dynamic rounding mode CSR state will serialize the pipeline. Static
 rounding modes are used to implement specialized arithmetic operations
 that often have to switch frequently between different rounding modes.
 
-The ratified version of the F spec mandated that an illegal instruction
+The ratified version of the F spec mandated that an illegal-instruction
 exception was raised when an instruction was executed with a reserved
 dynamic rounding mode. This has been weakened to reserved, which matches
-the behavior of static rounding-mode instructions. Raising an illegal
-instruction exception is still valid behavior when encountering a
+the behavior of static rounding-mode instructions. Raising an
+illegal-instruction exception is still valid behavior when encountering a
 reserved encoding, so implementations compatible with the ratified spec
 are compatible with the weakened spec.
 ====

--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -127,8 +127,8 @@ taking over all functions of the usual supervisor CSRs except as
 specified otherwise. Instructions that normally read or modify a
 supervisor CSR shall instead access the corresponding VS CSR. When V=1,
 an attempt to read or write a VS CSR directly by its own separate CSR
-address causes a virtual instruction exception. (Attempts from U-mode
-cause an illegal instruction exception as usual.) The VS CSRs can be
+address causes a virtual-instruction exception. (Attempts from U-mode
+cause an illegal-instruction exception as usual.) The VS CSRs can be
 accessed as themselves only from M-mode or HS-mode.
 
 While V=1, the normal HS-level supervisor CSRs that are replaced by VS
@@ -189,17 +189,17 @@ widest supported width not wider than the new HSXLEN.
 
 The `hstatus` fields VTSR, VTW, and VTVM are defined analogously to the
 `mstatus` fields TSR, TW, and TVM, but affect execution only in VS-mode,
-and cause virtual instruction exceptions instead of illegal instruction
+and cause virtual-instruction exceptions instead of illegal-instruction
 exceptions. When VTSR=1, an attempt in VS-mode to execute SRET raises a
-virtual instruction exception. When VTW=1 (and assuming `mstatus`.TW=0),
-an attempt in VS-mode to execute WFI raises a virtual instruction
+virtual-instruction exception. When VTW=1 (and assuming `mstatus`.TW=0),
+an attempt in VS-mode to execute WFI raises a virtual-instruction
 exception if the WFI does not complete within an
 implementation-specific, bounded time limit. An implementation may have
-WFI always raise a virtual instruction exception in VS-mode when VTW=1
+WFI always raise a virtual-instruction exception in VS-mode when VTW=1
 (and `mstatus`.TW=0), even if there are pending globally-disabled
 interrupts when the instruction is executed. When VTVM=1, an attempt in
 VS-mode to execute SFENCE.VMA or SINVAL.VMA or to access CSR `satp`
-raises a virtual instruction exception.
+raises a virtual-instruction exception.
 
 The VGEIN (Virtual Guest External Interrupt Number) field selects a
 guest external interrupt source for VS-level external interrupts. VGEIN
@@ -214,8 +214,8 @@ further in <<hinterruptregs>>.
 Field HU (Hypervisor in U-mode) controls whether the virtual-machine
 load/store instructions, HLV, HLVX, and HSV, can be used also in U-mode.
 When HU=1, these instructions can be executed in U-mode the same as in
-HS-mode. When HU=0, all hypervisor instructions cause an illegal
-instruction trap in U-mode.
+HS-mode. When HU=0, all hypervisor instructions cause an
+illegal-instruction exception in U-mode.
 
 [NOTE]
 ====
@@ -628,7 +628,7 @@ include::images/bytefield/hcounterenreg.edn[]
 
 When the CY, TM, IR, or HPM_n_ bit in the `hcounteren` register is
 clear, attempts to read the `cycle`, `time`, `instret`, or
-`hpmcounter` _n_ register while V=1 will cause a virtual instruction
+`hpmcounter` _n_ register while V=1 will cause a virtual-instruction
 exception if the same bit in `mcounteren` is 1. When one of these bits
 is set, access to the corresponding register is permitted when V=1,
 unless prevented for some other reason. In VU-mode, a counter is not
@@ -750,7 +750,7 @@ page table; a virtual machine identifier (VMID), which facilitates
 address-translation fences on a per-virtual-machine basis; and the MODE
 field, which selects the address-translation scheme for guest physical
 addresses. When `mstatus`.TVM=1, attempts to read or write `hgatp` while
-executing in HS-mode will raise an illegal instruction exception.
+executing in HS-mode will raise an illegal-instruction exception.
 
 [[rv32hgatp]]
 .Hypervisor guest address translation and protection register `hgatp` when HSXLEN=32.
@@ -885,7 +885,7 @@ widest supported width not wider than the new VSXLEN.
 
 When V=1, both `vsstatus`.FS and the HS-level `sstatus`.FS are in
 effect. Attempts to execute a floating-point instruction when either
-field is 0 (Off) raise an illegal instruction exception. Modifying the
+field is 0 (Off) raise an illegal-instruction exception. Modifying the
 floating-point state when V=1 causes both fields to be set to 3 (Dirty).
 
 [NOTE]
@@ -904,7 +904,7 @@ context-switching between virtual machines.
 
 Similarly, when V=1, both `vsstatus`.VS and the HS-level `sstatus`.VS
 are in effect. Attempts to execute a vector instruction when either
-field is 0 (Off) raise an illegal instruction exception. Modifying the
+field is 0 (Off) raise an illegal-instruction exception. Modifying the
 vector state when V=1 causes both fields to be set to 3 (Dirty).
 
 Read-only fields SD and XS summarize the extension context status as it
@@ -1134,9 +1134,9 @@ RV32, HLVX.WU can be considered a variant of HLV.W, as sign extension is
 irrelevant for 32-bit values.)
 
 Attempts to execute a virtual-machine load/store instruction (HLV, HLVX,
-or HSV) when V=1 cause a virtual instruction trap. Attempts to execute
+or HSV) when V=1 cause a virtual-instruction exception. Attempts to execute
 one of these same instructions from U-mode when `hstatus`.HU=0 cause an
-illegal instruction trap.
+illegal-instruction exception.
 
 [[hfence.vma]]
 ==== Hypervisor Memory-Management Fence Instructions
@@ -1245,10 +1245,10 @@ _rs1_=`x0` (and _rs2_ set to either `x0` or the VMID) must be executed
 to order subsequent guest translations with the MODE change—even if the
 old MODE or new MODE is Bare.
 
-Attempts to execute HFENCE.VVMA or HFENCE.GVMA when V=1 cause a virtual
-instruction trap, while attempts to do the same in U-mode cause an
-illegal instruction trap. Attempting to execute HFENCE.GVMA in HS-mode
-when `mstatus`.TVM=1 also causes an illegal instruction trap.
+Attempts to execute HFENCE.VVMA or HFENCE.GVMA when V=1 cause a
+virtual-instruction exception, while attempts to do the same in U-mode cause an
+illegal-instruction exception. Attempting to execute HFENCE.GVMA in HS-mode
+when `mstatus`.TVM=1 also causes an illegal-instruction exception.
 
 === Machine-Level CSRs
 
@@ -1674,8 +1674,8 @@ The hypervisor extension augments the trap cause encoding.
 <<hcauses>> lists the possible M-mode and HS-mode
 trap cause codes when the hypervisor extension is implemented. Codes are
 added for VS-level interrupts (interrupts 2, 6, 10), for
-supervisor-level guest external interrupts (interrupt 12), for virtual
-instruction exceptions (exception 22), and for guest-page faults
+supervisor-level guest external interrupts (interrupt 12), for
+virtual-instruction exceptions (exception 22), and for guest-page faults
 (exceptions 20, 21, 23). Furthermore, environment calls from VS-mode are
 assigned cause 10, whereas those from HS-mode or S-mode use cause 9 as
 usual.
@@ -1810,8 +1810,8 @@ _Reserved_
 HS-mode and VS-mode ECALLs use different cause values so they can be
 delegated separately.
 
-When V=1, a virtual instruction exception (code 22) is normally raised
-instead of an illegal instruction exception if the attempted instruction
+When V=1, a virtual-instruction exception (code 22) is normally raised
+instead of an illegal-instruction exception if the attempted instruction
 is _HS-qualified_ but is prevented from executing when V=1 either due to
 insufficient privilege or because the instruction is expressly disabled
 by a supervisor or hypervisor CSR such as `scounteren` or `hcounteren`.
@@ -1822,18 +1822,18 @@ assuming fields TSR and TVM of CSR `mstatus` are both zero.
 A special rule applies for CSR instructions that access 32-bit high-half
 CSRs such as `cycleh` and `htimedeltah`. When V=1 and
 XLEN=32, an invalid attempt to access a high-half CSR
-raises a virtual instruction
-exception instead of an illegal instruction exception if the same CSR
+raises a virtual-instruction
+exception instead of an illegal-instruction exception if the same CSR
 instruction for the corresponding _low-half_ CSR (e.g.`cycle` or
 `htimedelta`) is HS-qualified.
 
 [NOTE]
 ====
 When XLEN>32, an attempt to access a high-half CSR
-always raises an illegal instruction exception.
+always raises an illegal-instruction exception.
 ====
 
-Specifically, a virtual instruction exception is raised for the
+Specifically, a virtual-instruction exception is raised for the
 following cases:
 
 * in VS-mode, attempts to access a non-high-half counter CSR when the
@@ -1873,25 +1873,25 @@ implementation-specific, bounded time;
 instruction or to access `satp`, when `hstatus`.VTVM=1.
 
 Other extensions to the RISC-V Privileged Architecture may add to the
-set of circumstances that cause a virtual instruction exception when
+set of circumstances that cause a virtual-instruction exception when
 V=1.
 
-On a virtual instruction trap, `mtval` or `stval` is written the same as
-for an illegal instruction trap.
+On a virtual-instruction trap, `mtval` or `stval` is written the same as
+for an illegal-instruction trap.
 
 [NOTE]
 ====
 It is not unusual that hypervisors must emulate the instructions that
-raise virtual instruction exceptions, to support nested hypervisors or
+raise virtual-instruction exceptions, to support nested hypervisors or
 for other reasons. Machine level is expected ordinarily to delegate
-virtual instruction traps directly to HS-level, whereas illegal
-instruction traps are likely to be processed first in M-mode before
+virtual-instruction traps directly to HS-level, whereas
+illegal-instruction traps are likely to be processed first in M-mode before
 being conditionally delegated (by software) to HS-level. Consequently,
-virtual instruction traps are expected typically to be handled faster
-than illegal instruction traps.
+virtual-instruction traps are expected typically to be handled faster
+than illegal-instruction traps.
 
 When not emulating the trapping instruction, a hypervisor should convert
-a virtual instruction trap into an illegal instruction exception for the
+a virtual-instruction trap into an illegal-instruction exception for the
 guest virtual machine.
 
 ***

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -258,8 +258,8 @@ reserved for instructions only required by wider address-space variants.
 
 The main disadvantage of not treating the design as a single ISA is that
 it complicates the hardware needed to emulate one base ISA on another
-(e.g., RV32I on RV64I). However, differences in addressing and illegal
-instruction traps generally mean some mode switch would be required in
+(e.g., RV32I on RV64I). However, differences in addressing and
+illegal-instruction traps generally mean some mode switch would be required in
 hardware in any case even with full superset instruction encodings, and
 the different RISC-V base ISAs are similar enough that supporting
 multiple versions is relatively low cost. Although some have proposed
@@ -531,7 +531,7 @@ An implementation of the standard IMAFD ISA need only hold the
 most-significant 30 bits in instruction caches (a 6.25% saving). On
 instruction cache refills, any instructions encountered with either low
 bit clear should be recoded into illegal 30-bit instructions before
-storing in the cache to preserve illegal instruction exception behavior.
+storing in the cache to preserve illegal-instruction exception behavior.
 
 Perhaps more importantly, by condensing our base ISA into a subset of
 the 32-bit instruction word, we leave more space available for
@@ -572,7 +572,7 @@ standard binary library used by many different machines). Defining a
 32-bit word of all ones as illegal was also considered, as all machines
 must support a 32-bit instruction size, but this requires the
 instruction-fetch unit on machines with ILEN >32 report an
-illegal instruction exception rather than an access-fault exception when
+illegal-instruction exception rather than an access-fault exception when
 such an instruction borders a protection boundary, complicating
 variable-instruction-length fetch and decode.
 ====

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -91,7 +91,7 @@ clearing its bit in `misa` results in the extension being considered
 _not implemented_ in M-mode. For example, setting `misa`.F=0 results in
 the F extension being not implemented for M-mode, because the F
 extension's instructions will not act as the Unprivileged ISA requires
-but may instead raise an illegal instruction exception.
+but may instead raise an illegal-instruction exception.
 
 Defining the term _implemented_ based strictly on the observable
 behavior might conflict with other common understandings of the same
@@ -641,7 +641,7 @@ stores.
 The TVM (Trap Virtual Memory) bit is a *WARL* field that supports intercepting
 supervisor virtual-memory management operations. When TVM=1, attempts to
 read or write the `satp` CSR or execute an SFENCE.VMA or SINVAL.VMA
-instruction while executing in S-mode will raise an illegal instruction
+instruction while executing in S-mode will raise an illegal-instruction
 exception. When TVM=0, these operations are permitted in S-mode. TVM is
 read-only 0 when S-mode is not supported.
 
@@ -662,8 +662,8 @@ instruction may execute in lower privilege modes when not prevented for
 some other reason. When TW=1, then if WFI is executed in any
 less-privileged mode, and it does not complete within an
 implementation-specific, bounded time limit, the WFI instruction causes
-an illegal instruction exception. An implementation may have WFI always
-raise an illegal instruction exception in less-privileged modes when
+an illegal-instruction exception. An implementation may have WFI always
+raise an illegal-instruction exception in less-privileged modes when
 TW=1, even if there are pending globally-disabled interrupts when the
 instruction is executed. TW is read-only 0 when there are no modes less
 privileged than M.
@@ -675,14 +675,14 @@ OS, rather than wastefully idling in the current guest.
 ====
 
 When S-mode is implemented, then executing WFI in U-mode causes an
-illegal instruction exception, unless it completes within an
+illegal-instruction exception, unless it completes within an
 implementation-specific, bounded time limit. A future revision of this
 specification might add a feature that allows S-mode to selectively
 permit WFI in U-mode. Such a feature would only be active when TW=0.
 
 The TSR (Trap SRET) bit is a *WARL* field that supports intercepting the
 supervisor exception return instruction, SRET. When TSR=1, attempts to
-execute SRET while executing in S-mode will raise an illegal instruction
+execute SRET while executing in S-mode will raise an illegal-instruction
 exception. When TSR=0, this operation is permitted in S-mode. TSR is
 read-only 0 when S-mode is not supported.
 
@@ -793,8 +793,8 @@ saving extended user context to memory. If FS, XS, and VS are all
 read-only zero, then SD is also always zero.
 
 When an extension's status is set to Off, any instruction that attempts
-to read or write the corresponding state will cause an illegal
-instruction exception. When the status is Initial, the corresponding
+to read or write the corresponding state will cause an
+illegal-instruction exception. When the status is Initial, the corresponding
 state should have an initial constant value. When the status is Clean,
 the corresponding state is potentially different from the initial value,
 but matches the last value stored on a context swap. When the status is
@@ -837,7 +837,7 @@ cause the coprocessor state to be initialized to a constant value at
 context restore, not at every unconfigure.
 
 Executing a user-mode instruction to disable a unit and place it into
-the Off state will cause an illegal instruction exception to be raised
+the Off state will cause an illegal-instruction exception to be raised
 if any subsequent instruction tries to use the unit before it is turned
 back on. A user-mode instruction to turn a unit on must also ensure the
 unit's state is properly initialized, as the unit might have been used
@@ -1179,11 +1179,11 @@ read-only one. Platform standards may always add such restrictions.
 ====
 
 Traps never transition from a more-privileged mode to a less-privileged
-mode. For example, if M-mode has delegated illegal instruction
+mode. For example, if M-mode has delegated illegal-instruction
 exceptions to S-mode, and M-mode software later executes an illegal
 instruction, the trap is taken in M-mode, rather than being delegated to
 S-mode. By contrast, traps may be taken horizontally. Using the same
-example, if M-mode has delegated illegal instruction exceptions to
+example, if M-mode has delegated illegal-instruction exceptions to
 S-mode, and S-mode software later executes an illegal instruction, the
 trap is taken in S-mode.
 
@@ -1446,7 +1446,7 @@ counters, which continue to increment even when not accessible.
 When the CY, TM, IR, or HPM__n__ bit in the `mcounteren` register is
 clear, attempts to read the `cycle`, `time`, `instret`, or
 `hpmcountern` register while executing in S-mode or U-mode will cause an
-illegal instruction exception. When one of these bits is set, access to
+illegal-instruction exception. When one of these bits is set, access to
 the corresponding register is permitted in the next implemented
 privilege mode (S-mode if implemented, otherwise U-mode).
 
@@ -1478,7 +1478,7 @@ functionality on behalf of less-privileged modes in M-mode software.
 
 In systems with U-mode, the `mcounteren` must be implemented, but all
 fields are *WARL* and may be read-only zero, indicating reads to the
-corresponding counter will cause an illegal instruction exception when
+corresponding counter will cause an illegal-instruction exception when
 executing in a less-privileged mode. In systems without U-mode, the
 `mcounteren` register should not exist.
 
@@ -1611,8 +1611,8 @@ table.
 
 ***
 
-We do not distinguish privileged instruction exceptions from illegal
-opcode exceptions. This simplifies the architecture and also hides
+We do not distinguish privileged instruction exceptions from
+illegal-instruction exceptions. This simplifies the architecture and also hides
 details of which higher-privilege instructions are supported by an
 implementation. The privilege level servicing the trap can implement a
 policy on whether these need to be distinguished, and if so, whether a
@@ -1846,9 +1846,9 @@ address of the portion of the instruction that caused the fault, while
 `mepc` will point to the beginning of the instruction.
 
 The `mtval` register can optionally also be used to return the faulting
-instruction bits on an illegal instruction exception (`mepc` points to
+instruction bits on an illegal-instruction exception (`mepc` points to
 the faulting instruction in memory). If `mtval` is written with a
-nonzero value when an illegal instruction exception occurs, then `mtval`
+nonzero value when an illegal-instruction exception occurs, then `mtval`
 will contain the shortest of:
 
 * the actual faulting instruction
@@ -1857,7 +1857,7 @@ will contain the shortest of:
 
 * the first MXLEN bits of the faulting instruction
 
-The value loaded into `mtval` on an illegal instruction exception is
+The value loaded into `mtval` on an illegal-instruction exception is
 right-justified and all unused upper bits are cleared to zero.
 
 [NOTE]
@@ -2159,8 +2159,8 @@ include::images/wavedrom/trap-return.adoc[]
 To return after handling a trap, there are separate trap return
 instructions per privilege level, MRET and SRET. MRET is always
 provided. SRET must be provided if supervisor mode is supported, and
-should raise an illegal instruction exception otherwise. SRET should
-also raise an illegal instruction exception when TSR=1 in `mstatus`, as
+should raise an illegal-instruction exception otherwise. SRET should
+also raise an illegal-instruction exception when TSR=1 in `mstatus`, as
 described in <<virt-control>>. An __x__RET instruction
 can be executed in privilege mode _x_ or higher, where executing a
 lower-privilege __x__RET instruction will pop the relevant lower-privilege
@@ -2188,7 +2188,7 @@ might need servicing. Execution of the WFI instruction can also be used
 to inform the hardware platform that suitable interrupts should
 preferentially be routed to this hart. WFI is available in all
 privileged modes, and optionally available to U-mode. This instruction
-may raise an illegal instruction exception when TW=1 in `mstatus`, as
+may raise an illegal-instruction exception when TW=1 in `mstatus`, as
 described in <<virt-control>>.
 
 include::images/wavedrom/wfi.adoc[]

--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -42,9 +42,9 @@ accesses to be intercepted. This change should be transparent to the
 less-privileged software.
 ====
 
-Attempts to access a non-existent CSR raise an illegal instruction
+Attempts to access a non-existent CSR raise an illegal-instruction
 exception. Attempts to access a CSR without appropriate privilege level
-or to write a read-only register also raise illegal instruction
+or to write a read-only register also raise illegal-instruction
 exceptions. A read/write register might also contain some bits that are
 read-only, in which case writes to the read-only bits are ignored.
 
@@ -56,7 +56,7 @@ standard extensions.
 Machine-mode standard read-write CSRs `0x7A0`-`0x7BF` are reserved for
 use by the debug system. Of these CSRs, `0x7A0`-`0x7AF` are accessible
 to machine mode, whereas `0x7B0`-`0x7BF` are only visible to debug mode.
-Implementations should raise illegal instruction exceptions on
+Implementations should raise illegal-instruction exceptions on
 machine-mode access to the latter set of registers.
 
 [NOTE]
@@ -901,8 +901,8 @@ differentiate between the supported values, but must always return the
 complete specified bit-encoding of any supported value when read.
 ====
 
-Implementations are permitted but not required to raise an illegal
-instruction exception if an instruction attempts to write a
+Implementations are permitted but not required to raise an
+illegal-instruction exception if an instruction attempts to write a
 non-supported value to a *WLRL* field. Implementations can return arbitrary
 bit patterns on the read of a *WLRL* field when the last write was of an
 illegal value, but the value returned should deterministically depend on
@@ -1003,4 +1003,4 @@ Standard high-half CSRs are accessible only when
 the base RISC-V instruction set is RV32 (XLEN=32).
 For RV64 (when XLEN=64), the addresses of all standard high-half CSRs
 are reserved, so an attempt to access a high-half CSR
-typically raises an illegal instruction exception.
+typically raises an illegal-instruction exception.

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -161,7 +161,7 @@ The behavior upon decoding a reserved instruction is UNSPECIFIED.
 [NOTE]
 ====
 Some platforms may require that opcodes reserved for standard use raise
-an illegal instruction exception. Other platforms may permit reserved
+an illegal-instruction exception. Other platforms may permit reserved
 opcode space be used for non-conforming extensions.
 ====
 

--- a/src/rv64.adoc
+++ b/src/rv64.adoc
@@ -78,7 +78,7 @@ _imm[5] &#8800; 0_ are reserved.
 [NOTE]
 ====
 Previously, SLLIW, SRLIW, and SRAIW with _imm[5] &#8800; 0_
-were defined to cause illegal instruction exceptions, whereas now they
+were defined to cause illegal-instruction exceptions, whereas now they
 are marked as reserved. This is a backwards-compatible change.
 ====
 

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -338,7 +338,7 @@ counters to U-mode.
 
 When the CY, TM, IR, or HPM__n__ bit in the `scounteren` register is
 clear, attempts to read the `cycle`, `time`, `instret`, or `hpmcountern`
-register while executing in U-mode will cause an illegal instruction
+register while executing in U-mode will cause an illegal-instruction
 exception. When one of these bits is set, access to the corresponding
 register is permitted.
 
@@ -536,16 +536,16 @@ address of the portion of the instruction that caused the fault, while
 `sepc` will point to the beginning of the instruction.
 
 The `stval` register can optionally also be used to return the faulting
-instruction bits on an illegal instruction exception (`sepc` points to
+instruction bits on an illegal-instruction exception (`sepc` points to
 the faulting instruction in memory). If `stval` is written with a
-nonzero value when an illegal instruction exception occurs, then `stval`
+nonzero value when an illegal-instruction exception occurs, then `stval`
 will contain the shortest of:
 
 * the actual faulting instruction
 * the first ILEN bits of the faulting instruction
 * the first SXLEN bits of the faulting instruction
 
-The value loaded into `stval` on an illegal instruction exception is
+The value loaded into `stval` on an illegal-instruction exception is
 right-justified and all unused upper bits are cleared to zero.
 
 For other traps, `stval` is set to zero, but a future standard may
@@ -1031,8 +1031,8 @@ attractive for its simplicity and possibly better scalability.
 ====
 
 For implementations that make `satp`.MODE read-only zero (always Bare),
-attempts to execute an SFENCE.VMA instruction might raise an illegal
-instruction exception.
+attempts to execute an SFENCE.VMA instruction might raise an
+illegal-instruction exception.
 
 [[sv32]]
 === Sv32: Page-Based 32-bit Virtual-Memory Systems
@@ -1935,12 +1935,12 @@ HINVAL.GVMA uses VMIDs instead of ASIDs.
 SINVAL.VMA, HINVAL.VVMA, and HINVAL.GVMA require the same permissions
 and raise the same exceptions as SFENCE.VMA, HFENCE.VVMA, and
 HFENCE.GVMA, respectively. In particular, an attempt to execute any of
-these instructions in U-mode always raises an illegal instruction
+these instructions in U-mode always raises an illegal-instruction
 exception, and an attempt to execute SINVAL.VMA or HINVAL.GVMA in S-mode
-or HS-mode when `mstatus`.TVM=1 also raises an illegal instruction
+or HS-mode when `mstatus`.TVM=1 also raises an illegal-instruction
 exception. An attempt to execute HINVAL.VVMA or HINVAL.GVMA in VS-mode
-or VU-mode, or to execute SINVAL.VMA in VU-mode, raises a virtual
-instruction exception. When `hstatus`.VTVM=1, an attempt to execute
+or VU-mode, or to execute SINVAL.VMA in VU-mode, raises a
+virtual-instruction exception. When `hstatus`.VTVM=1, an attempt to execute
 SINVAL.VMA in VS-mode also raises a virtual instruction exception.
 
 [NOTE]

--- a/src/zicsr.adoc
+++ b/src/zicsr.adoc
@@ -51,7 +51,7 @@ CSR are not explicitly written.
 
 For both CSRRS and CSRRC, if _rs1_=`x0`, then the instruction will not
 write to the CSR at all, and so shall not cause any of the side effects
-that might otherwise occur on a CSR write, nor raise illegal instruction
+that might otherwise occur on a CSR write, nor raise illegal-instruction
 exceptions on accesses to read-only CSRs. Both CSRRS and CSRRC always
 read the addressed CSR and cause any read side effects regardless of
 _rs1_ and _rd_ fields. Note that if _rs1_ specifies a register holding a
@@ -67,7 +67,7 @@ encoded in the _rs1_ field instead of a value from an integer register.
 For CSRRSI and CSRRCI, if the uimm[4:0] field is zero, then these
 instructions will not write to the CSR, and shall not cause any of the
 side effects that might otherwise occur on a CSR write, nor raise
-illegal instruction exceptions on accesses to read-only CSRs. For
+illegal-instruction exceptions on accesses to read-only CSRs. For
 CSRRWI, if _rd_=`x0`, then the instruction shall not read the CSR and
 shall not cause any of the side effects that might occur on a CSR read.
 Both CSRRSI and CSRRCI will always read the CSR and cause any read side

--- a/src/zimop.adoc
+++ b/src/zimop.adoc
@@ -9,7 +9,7 @@ The Zimop extension defines an encoding space for 40 MOPs.
 [NOTE]
 ====
 It is sometimes desirable to define instruction-set extensions whose
-instructions, rather than raising illegal instruction exceptions when the extension is
+instructions, rather than raising illegal-instruction exceptions when the extension is
 not implemented, take no useful action (beyond writing `x[rd]`).
 For example, programs with control-flow integrity checks can
 execute correctly on implementations without the corresponding extension,


### PR DESCRIPTION
Reverts #1131 

One might argue that "illegal instruction" is a compound noun in the context of computer architecture, and so hyphenating "illegal instruction exception" would not be necessary.  But there are certainly other noun phrases we use as exception types where the hyphen would be mandatory.  This scheme is also friendlier to readers, since it provides explicit phrase grouping.  So, standardize on hyphenation.

Also, fix a couple places where "trap" was used where "exception" was more appropriate.