### PR TITLE
Fix typos

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -154,7 +154,7 @@ as more abstract EEIs provide greater portability across different
 hardware platforms. Often EEIs are layered on top of one another, where
 one higher-level EEI uses another lower-level EEI.
 ====
-(((hart, exectution environment)))
+(((hart, execution environment)))
 From the perspective of software running in a given execution
 environment, a hart is a resource that autonomously fetches and executes
 RISC-V instructions within that execution environment. In this respect,

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1426,7 +1426,7 @@ only bits 31-0; reads of the `mcycleh`, `minstreth`, and `mhpmcounternh`
 CSRs return bits 63-32 of the corresponding counter, and writes change
 only bits 63-32.
 
-.Upper 32 bits of hardware performace monitor counters, RV32 only.
+.Upper 32 bits of hardware performance monitor counters, RV32 only.
 include::images/bytefield/hpmcounters.adoc[]
 
 [[mcounteren]]

--- a/src/mm-eplan.adoc
+++ b/src/mm-eplan.adoc
@@ -545,7 +545,7 @@ drain to memory)
 * (g), (h), and (i) execute
 * (a) executes and drains to memory, (b) executes, and (c)
 executes and drains to memory
-* (d) unstalls and executes
+* (d) installs and executes
 * (e) drains from the store buffer to memory
 
 This corresponds to a global memory order of (f), (i), (a), (c), (d),

--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -217,7 +217,7 @@ example:
   border_radius: $base_border_radius
   border_width: 0.2
   background_color: ffffff
-  # FIXME reenable padding bottom once margin collapsing is implemented
+  # FIXME re-enable padding bottom once margin collapsing is implemented
   padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
 image:
   align: left

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -143,4 +143,4 @@ include::mm-formal.adoc[]
 include::index.adoc[]
 // this is generated generated from index markers.
 include::bibliography.adoc[]
-// this references the riscv-spec.bi file that has been copied into the resources directoy
+// this references the riscv-spec.bi file that has been copied into the resources directory

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -885,7 +885,7 @@ hardware.
 
 include::images/wavedrom/env_call-breakpoint.adoc[]
 [[env-call]]
-//.Evironment call and breakpoint instructions
+//.Environment call and breakpoint instructions
 
 These two instructions cause a precise requested trap to the supporting
 execution environment.

--- a/src/rvwmo.adoc
+++ b/src/rvwmo.adoc
@@ -7,7 +7,7 @@ returned by loads of memory. RISC-V uses a memory model called "RVWMO"
 (RISC-V Weak Memory Ordering) which is designed to provide flexibility
 for architects to build high-performance scalable designs while
 simultaneously supporting a tractable programming model.
-(((design, high performace)))
+(((design, high performance)))
 (((design, scalable)))
 
 Under RVWMO, code running on a single hart appears to execute in order


### PR DESCRIPTION
Found via `codespell -L hart,sie,stip,sxl,fle,bu,edn,synopsys,fpr,useed,addd,rouge`