### PR TITLE
Fix typo

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -525,7 +525,7 @@ We also wanted to optionally allow longer instructions to support
 experimentation and larger instruction-set extensions. Although our
 encoding convention required a tighter encoding of the core RISC-V ISA,
 this has several beneficial effects.
-(((IMAFED)))
+(((IMAFD)))
 
 An implementation of the standard IMAFD ISA need only hold the
 most-significant 30 bits in instruction caches (a 6.25% saving). On


### PR DESCRIPTION
Fix typo in the index section of unprivileged ISA manual.