### PR TITLE
Fix journal name typo

### DIFF
--- a/src/resources/riscv-spec.bib
+++ b/src/resources/riscv-spec.bib
@@ -25,7 +25,7 @@
 @article{Katevenis:1984,
  author = {Katevenis, Manolis G.H. and Sherburne,Jr., Robert W. and Patterson, David A. and S{\'e}quin, Carlo H.},
  title = {The {RISC II} micro-architecture},
- journal = {Advances in VLSI and Computur Systems},
+ journal = {Advances in VLSI and Computer Systems},
  issue_date = {Fall 1984},
  volume = {1},
  number = {2},


### PR DESCRIPTION
Changed 'Computur' to 'Computer' for accuracy.