### PR TITLE
Fix wrong bit length of rd field

### DIFF
--- a/src/images/wavedrom/csr-instr.adoc
+++ b/src/images/wavedrom/csr-instr.adoc
@@ -5,7 +5,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM'], type: 8},
-  {bits: 5,  name: 'rd',     attr: ['3', 'dest', 'dest', 'dest', 'dest', 'dest', 'dest'], type: 2},
+  {bits: 5,  name: 'rd',     attr: ['5', 'dest', 'dest', 'dest', 'dest', 'dest', 'dest'], type: 2},
   {bits: 3,  name: 'funct3', attr: ['3', 'CSRRW', 'CSRRS', 'CSRRC', 'CSRRWI', 'CSRRSI', 'CSRRCI'], type: 8},
   {bits: 5,  name: 'rs1',    attr: ['5', 'source', 'source', 'source', 'uimm[4:0]', 'uimm[4:0]', 'uimm[4:0]'], type: 4},
   {bits: 12, name: 'csr',    attr: ['12', 'source/dest', 'source/dest', 'source/dest', 'source/dest', 'source/dest', 'source/dest'], type: 4},


### PR DESCRIPTION
The bit length of rd register should be 5 instead of 3.