### PR TITLE
Fix AsciiDoc error in D-extension chapter

### DIFF
--- a/src/d-st-ext.adoc
+++ b/src/d-st-ext.adoc
@@ -27,7 +27,7 @@ floating-point precisions supported, including H, F, D, and Q.
 === NaN Boxing of Narrower Values
 
 When multiple floating-point precisions are supported, then valid values
-of narrower _n_-bit types, _n<_FLEN, are represented in the lower _n_ bits of an FLEN-bit NaN value, in a process termed NaN-boxing. The upper bits of a valid NaN-boxed value must be all 1s. Valid NaN-boxed _n_-bit values
+of narrower _n_-bit types, _n_ < FLEN, are represented in the lower _n_ bits of an FLEN-bit NaN value, in a process termed NaN-boxing. The upper bits of a valid NaN-boxed value must be all 1s. Valid NaN-boxed _n_-bit values
 therefore appear as negative quiet NaNs (qNaNs) when viewed as any wider
 _m_-bit value, _n_ < _m_ &#8804; FLEN. Any operation that writes a narrower result to an 'f' register must write all 1s to the uppermost FLEN-_n_ bits to yield a legal NaN-boxedvalue.
 (((floating-point, requirements)))


### PR DESCRIPTION
The underscore was in the wrong place, causing unintentional italicization of subsequent text.

I also added whitespace around the inequality, for consistency with a subsequent sentence.