### PR TITLE
   delete user-mode interrupt notes in mtvec register section

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1102,14 +1102,6 @@ times the interrupt cause number. For example, a machine-mode timer
 interrupt (see <<mcauses>>) causes the `pc`
 to be set to BASE+`0x1c`.
 
-[NOTE]
-====
-When vectored interrupts are enabled, interrupt cause 0, which
-corresponds to user-mode software interrupts, are vectored to the same
-location as synchronous exceptions. This ambiguity does not arise in
-practice, since user-mode software interrupts are either disabled or
-delegated to user mode.
-====
 
 An implementation may have different alignment constraints for different
 modes. In particular, MODE=Vectored may have stricter alignment


### PR DESCRIPTION
Drop notes on obsoleted user-mode software interrupts   
Resolves #1158