### PR TITLE
Fix MODE field description of mtvec register

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1087,7 +1087,7 @@ hand, we wish to allow flexibility for larger systems.
 |Direct +
 Vectored +
 ---
-|All exceptions set `pc` to BASE. +
+|All traps set `pc` to BASE. +
 Asynchronous interrupts set `pc` to BASE+4&#215;cause. +
 _Reserved_
 |===


### PR DESCRIPTION
Fix MODE field description in the mtvec register

In Section 1.6, "Exceptions, Traps, and Interrupts" of the unprivileged specification, a distinction is made between exceptions and interrupts.

Table 13 in the privileged specification uses the term "exceptions" as a catch-all expression, encompassing both "exceptions and interrupts" which may not be immediately apparent.

Reading "exceptions" merely as "exceptions" while seeing following word "interrupts" can led to believe that the 0th bit is used to control exception handling behavior, while the 1st bit is used to control interrupt handling behavior.