### PR TITLE
Specify that the supervisor physical address is divided by 4 KiB

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -669,7 +669,7 @@ shown in <<rv32satp>> for SXLEN=32 and
 <<rv64satp>> for SXLEN=64, which controls
 supervisor-mode address translation and protection. This register holds
 the physical page number (PPN) of the root page table, i.e., its
-supervisor physical address divided by ; an address space identifier
+supervisor physical address divided by 4 KiB; an address space identifier
 (ASID), which facilitates address-translation fences on a
 per-address-space basis; and the MODE field, which selects the current
 address-translation scheme. Further details on the access to this


### PR DESCRIPTION
It appears that during the conversion from Latex to asciidoc, the 4 KiB divisor for the satp description was dropped. This commit brings it back.