### PR TITLE
Add an information about the potential risk with uninitialized MTVEC

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1115,6 +1115,14 @@ implemented without a hardware adder circuit.
 ***
 
 Reset and NMI vector locations are given in a platform specification.
+
+***
+
+A potential security risk exists (e.g. CVE-2021-1104) if the mtvec CSR
+is not initialized to a suitable defined value before a hart starts
+execution out of reset, i.e. boot firmware initialization of mtvec
+results in a window of execution during which mtvec does not have
+a defined value.
 ====
 
 ==== Machine Trap Delegation Registers (`medeleg` and `mideleg`)


### PR DESCRIPTION
More about the problem can be found here:
https://nvd.nist.gov/vuln/detail/CVE-2021-1104

RISC-V website also posted a small article about it here: https://riscv.org/news/2021/08/video-glitching-risc-v-chips-mtvec-corruption-for-hardening-isa-adam-zabrocki-and-alex-matrosov-def-con-29/

The full DefCon presentation can be found here:
https://www.youtube.com/watch?v=iz_Y1lOtX08