### PR TITLE
Add marchid for Boa-RISC-V

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -51,3 +51,4 @@ RISu064       | Wenting Zhang                   | [Wenting Zhang](mailto:zephray
 AIRISC        | Fraunhofer IMS                  | [AIRISC Support](mailto:airisc@ims.fraunhofer.de)           | 31               | https://github.com/Fraunhofer-IMS/airisc_core_complex
 Proteus       | imec-DistriNet, KU Leuven       | [Marton Bognar](mailto:marton.bognar@kuleuven.be)           | 32               | https://github.com/proteus-core/proteus
 VexRiscv      | SpinalHDL                       | [Charles Papon](mailto:charles.papon.90@gmail.com)          | 33               | https://github.com/SpinalHDL/VexRiscv
+Boa RISC-V    | Julian Scheffers                | [Julian Scheffers](mailto:julian@scheffers.net)             | 34               | https://github.com/robotman2412/boa-risc-v


### PR DESCRIPTION
After testing my Boa32 CPU with the RISC-V tests I felt like it was time to create the first official release of my CPU and at the same time apply for a value of `marchid`.

If you'd like to run the tests for yourself:
- Install `riscv32-unknown-elf-gcc`
- Install Verilator
- Change directory to `sim/riscv-tests`
- Run `tests.py`

After creating this pull request, I will add a public release to the repository:
https://github.com/robotman2412/boa-risc-v