### PR TITLE
Add marchid for Boa-RISC-V (on the correct branch this time)

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -54,3 +54,4 @@ VexRiscv      | SpinalHDL                       | [Charles Papon](mailto:charles
 Shuttle       | UC Berkeley                     | [Jerry Zhao](mailto:jerryz123@berkeley.edu)                 | 34               | https://github.com/ucb-bar/shuttle
 CV32E2        | OpenHW Group                    | [Davide Schiavone](mailto:davide@openhwgroup.org), OpenHW Group | 35                 | https://github.com/openhwgroup/cve2
 CVW        | OpenHW Group                       | [James Stine](mailto:james.stine@okstate.edu), OpenHW Group | 36             | https://github.com/openhwgroup/cvw
+Boa32         | Julian Scheffers                | [Julian Scheffers](mailto:julian@scheffers.net)             | 37               | https://github.com/robotman2412/boa-risc-v


### PR DESCRIPTION
Last PR I made was apparently on the wrong branch, whoops.
I have recently released my RISC-V core and as it passes the RISC-V unit tests, I think it's time to apply for an marchid value.
If this PR is merged, I will set the value of marchid in my core to 37 (or whatever value ends up being merged).

My CPU and it's testing environment can be found here:
https://github.com/robotman2412/boa-risc-v