### PR TITLE
Add marchid for WIV64

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -55,3 +55,4 @@ Shuttle       | UC Berkeley                     | [Jerry Zhao](mailto:jerryz123@
 CV32E2        | OpenHW Group                    | [Davide Schiavone](mailto:davide@openhwgroup.org), OpenHW Group | 35                 | https://github.com/openhwgroup/cve2
 CVW        | OpenHW Group                       | [James Stine](mailto:james.stine@okstate.edu), OpenHW Group | 36             | https://github.com/openhwgroup/cvw
 Boa32         | Julian Scheffers                | [Julian Scheffers](mailto:julian@scheffers.net)             | 37               | https://github.com/robotman2412/boa-risc-v
+WIV64         | Jesús Sanz del Rey              | [Jesús Sanz del Rey](mailto:jesussanz2003@gmail.com)        | 38               | https://github.com/StartForKiller/WivCPU


### PR DESCRIPTION
I've finally tested fully my RISC-V core and i think it's type to apply for a value of marchid.
I've released my first version WIV64 and created the script for automated testing.

If you want to try the tests just:
- Install `verilator`
- Install `riscv64-unknown-elf-gcc`
- Configure `cmake` and build it
- Run `./test.sh`on the main directory

The actual release:
[WIV64 1.00](https://github.com/StartForKiller/WivCPU/releases/tag/v1.00)

I've used `marchid` `38` as a temporary value, awaiting the approval