### PR TITLE
Add marchid for Coreblocks

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -61,3 +61,4 @@ ApogeoRV      | Gabriele Tripi                  | [Gabriele Tripi](mailto:tripi.
 MicroRV32      | AGRA, Group of Computer Architecture, University of Bremen | [RISC-V @ AGRA](mailto:riscv@informatik.uni-bremen.de)       | 41               | https://github.com/agra-uni-bremen/microrv32
 QEMU          | qemu.org                        | [QEMU Mailing List](mailto:qemu-riscv@nongnu.org)           | 42               | https://qemu.org
 KianV         | Hirosh Dabui                    | [Hirosh Dabui](mailto:hirosh@dabui.de)                      | 43               | https://github.com/splinedrive/kianRiscV
+Coreblocks    | Kuźnia Rdzeni, University of Wrocław | [Coreblocks Team](mailto:coreblocks@cs.uni.wroc.pl)    | 44               | https://github.com/kuznia-rdzeni/coreblocks


### PR DESCRIPTION
`marchid` 42 allocation request for Coreblocks. It is an experimental, modular out-of-order RISC-V core generator.
Repository link: https://github.com/kuznia-rdzeni/coreblocks