### PR TITLE
Add a QEMU architecture ID

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -59,3 +59,4 @@ WIV64         | Jesús Sanz del Rey              | [Jesús Sanz del Rey](mailto:
 RV6           | Nikola Lukić                    | [Nikola Lukić](mailto:lukicn@protonmail.com)                | 39               | https://github.com/kiclu/rv6
 ApogeoRV      | Gabriele Tripi                  | [Gabriele Tripi](mailto:tripi.gabriele2002@gmail.com)       | 40               | https://github.com/GabbedT/ApogeoRV
 MicroRV32      | AGRA, Group of Computer Architecture, University of Bremen | [RISC-V @ AGRA](mailto:riscv@informatik.uni-bremen.de)       | 41               | https://github.com/agra-uni-bremen/microrv32
+QEMU          | qemu.org                        | [QEMU Mailing List](mailto:qemu-riscv@nongnu.org)           | 42               | https://qemu.org


### PR DESCRIPTION
For the cases where QEMU isn't pretending to be something else (for example, when targeting a virtual platform) it'd be nice to set the arch IDs to something other than 0.  That way users can detect they're running on QEMU and act differently, in case they want to work around a QEMU issue of some sort.

Link: https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/arch-riscv64/dynamic_function_dispatch.cpp#47
Link: https://lore.kernel.org/r/20240131182430.20174-1-palmer@rivosinc.com/