### PR TITLE
How should xPIE be set ?

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -412,7 +412,7 @@ modes. __x__PIE holds the value of the interrupt-enable bit active prior
 to the trap, and __x__PP holds the previous privilege mode. The __x__PP
 fields can only hold privilege modes up to _x_, so MPP is two bits wide
 and SPP is one bit wide. When a trap is taken from privilege mode _y_
-into privilege mode _x_, __x__PIE is set to the value of __x__IE; __x__IE is
+into privilege mode _x_, __x__PIE is set to the value of __y__IE; __y__IE is
 set to 0; and __x__PP is set to _y_.
 
 [NOTE]


### PR DESCRIPTION
## If my understanding is wong, just close this PR
## In the next paragraph, the manual says:
```
An MRET or SRET instruction is used to return from a trap in M-mode or
S-mode respectively. When executing an __x__RET instruction, supposing
__x__PP holds the value _y_, __x__IE is set to __x__PIE;
```
## This sentence reinforces my belief that my revision may be correct