### PR TITLE
Fix typo: Quotation mark formatting mismatch in intro.adoc.

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -195,7 +195,7 @@ environment but must do so in a way that guest harts operate like
 independent hardware threads. In particular, if there are more guest
 harts than host harts then the execution environment must be able to
 preempt the guest harts and must not wait indefinitely for guest
-software on a guest hart to “yield" control of the guest hart.
+software on a guest hart to "yield" control of the guest hart.
 ====
 
 === RISC-V ISA Overview


### PR DESCRIPTION
“yield" -> "yield"