### PR TITLE
Update Smrnmi to account for Smdbltrp extension

### DIFF
--- a/src/images/bytefield/mncause.edn
+++ b/src/images/bytefield/mncause.edn
@@ -8,8 +8,8 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 24 :font-size 24 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-2" "" "" "" "MXLEN-1" ""])})
 
-(draw-box "1" {:span 4})
-(draw-box (text "NMI Cause" {:font-size 24}) {:span 14 :text-anchor "end" :borders {:top :border-unrelated :bottom :border-unrelated :left :border-unrelated}})
+(draw-box "Interrupt" {:span 4})
+(draw-box (text "Exception Code" {:font-size 24}) {:span 14 :text-anchor "end" :borders {:top :border-unrelated :bottom :border-unrelated :left :border-unrelated}})
 (draw-box (text "(WARL)" {:font-weight "bold" :font-size 24}) {:span 14 :text-anchor "start" :borders {:top :border-unrelated :right :border-unrelated :bottom :border-unrelated}})
 (draw-box "1" {:span 4 :borders {}})
 (draw-box "MXLEN-1" {:font-size 24 :span 28 :borders {}})

--- a/src/rnmi.adoc
+++ b/src/rnmi.adoc
@@ -71,9 +71,15 @@ of holding.
 .Resumable NMI cause `mncause`.
 include::images/bytefield/mncause.edn[]
 
-The `mncause` CSR holds the reason for the NMI, with bit MXLEN-1 set to
-1, and the NMI cause encoded in the least-significant bits or zero if
-NMI causes are not supported.
+The `mncause` CSR holds the reason for the NMI.
+If the reason is an interrupt, bit MXLEN-1 is set to 1, and the NMI
+cause is encoded in the least-significant bits.
+If the reason is an interrupt and NMI causes are not supported, bit MXLEN-1 is
+set to 1, and zero is written to the least-significant bits.
+If the reason is an exception within M-mode that results in a double trap as
+specified in the Smdbltrp extension, bit MXLEN-1 is set to 0 and the
+least-significant bits are set to the cause code corresponding to the
+exception that precipitated the double trap.
 
 .Resumable NMI status register `mnstatus`.
 include::images/bytefield/mnstatus.edn[]


### PR DESCRIPTION
This is a backwards compatible change to support resumable double traps within M-mode when both extensions are implemented.  Although the resumability feature is not terribly interesting, the reuse of the Smrnmi state for M-mode double traps aids debugging (and fault diagnosis for the hardware-error exception case).