### PR TITLE
Fix typo in Zawrs title

### DIFF
--- a/src/zawrs.adoc
+++ b/src/zawrs.adoc
@@ -1,4 +1,4 @@
-== "Zawrs" Statndard extension for Wait-on-Reservation-Set instructions, Version 1.01
+== "Zawrs" Standard extension for Wait-on-Reservation-Set instructions, Version 1.01
 
 The Zawrs extension defines a pair of instructions to be used in polling loops 
 that allows a core to enter a low-power state and wait on a store to a memory 


### PR DESCRIPTION
Replace 'Statndard' with 'Standard'.