### PR TITLE
Incorporate two fixes to RVV 1.0 spec

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -1240,8 +1240,9 @@ vector length in `vl` is used as the AVL, and the resulting value is
 written to `vl`, but not to a destination register.  This form can
 only be used when VLMAX and hence `vl` is not actually changed by the
 new SEW/LMUL ratio.  Use of the instruction with a new SEW/LMUL ratio
-that would result in a change of VLMAX is reserved.  Implementations
-may set `vill` in this case.
+that would result in a change of VLMAX is reserved.
+Use of the instruction is also reserved if `vill` was 1 beforehand.
+Implementations may set `vill` in either case.
 
 NOTE: This last form of the instructions allows the `vtype` register to
 be changed while maintaining the current `vl`, provided VLMAX is not

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -977,6 +977,10 @@ exceptions in machines without register renaming.
 
 Any instruction encoding that violates the overlap constraints is reserved.
 
+When source and destination registers overlap and have different EEW, the
+instruction is mask- and tail-agnostic, regardless of the setting of the
+`vta` and `vma` bits in `vtype`.
+
 The largest vector register group used by an instruction can not be
 greater than 8 vector registers (i.e., EMUL{le}8), and if a vector
 instruction would require greater than 8 vector registers in a group,


### PR DESCRIPTION
The changes are:

- Clarify that vsetvl[i] x0,x0 is reserved when `vill` was 1 beforehand.  This was discussed on the following mailing-list thread: https://lists.riscv.org/g/tech-vector-ext/topic/94729185#846
- Relax tail/mask policy to agnostic for mismatched source/dest EEW.  This was discussed on the following mailing-list thread: https://lists.riscv.org/g/tech-vector-ext/topic/94729097#845

As mentioned on the relevant threads, implementations that conform to RVV 1.0 are compatible with these changes.