### PR TITLE
Clarify slide semantics

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4534,13 +4534,13 @@ Destination elements _OFFSET_ through `vl`-1 are written if unmasked and
 if _OFFSET_ < `vl`.
 
 ----
-   vslideup behavior for destination elements
+   vslideup behavior for destination elements (`vstart` < `vl`)
 
    OFFSET is amount to slideup, either from x register or a 5-bit immediate
 
-                    0 <=  i < max(vstart, OFFSET)  Unchanged
-  max(vstart, OFFSET) <= i < vl                   vd[i] = vs2[i-OFFSET] if v0.mask[i] enabled
-                   vl <= i < VLMAX                Follow tail policy
+                    0 <= i < min(vl, max(vstart, OFFSET))  Unchanged
+  max(vstart, OFFSET) <= i < vl                            vd[i] = vs2[i-OFFSET] if v0.mask[i] enabled
+                   vl <= i < VLMAX                         Follow tail policy
 ----
 
 The destination vector register group for `vslideup` cannot overlap
@@ -4569,12 +4569,12 @@ using an unsigned integer in the `x` register specified by `rs1`, or a
 If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
 
 ----
-  vslidedown behavior for source elements for element i in slide
+  vslidedown behavior for source elements for element i in slide (`vstart` < `vl`)
                    0 <= i+OFFSET < VLMAX   src[i] = vs2[i+OFFSET]
                VLMAX <= i+OFFSET           src[i] = 0
 
-  vslidedown behavior for destination element i in slide
-                   0 <=  i < vstart         Unchanged
+  vslidedown behavior for destination element i in slide (`vstart` < `vl`)
+                   0 <= i < vstart         Unchanged
               vstart <= i < vl             vd[i] = src[i] if v0.mask[i] enabled
                   vl <= i < VLMAX          Follow tail policy
 


### PR DESCRIPTION
This PR is identical to https://github.com/riscv/riscv-v-spec/pull/917 . Please see conversation there.