### PR TITLE
Add marchid for rrv32

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -62,3 +62,4 @@ MicroRV32      | AGRA, Group of Computer Architecture, University of Bremen | [R
 QEMU          | qemu.org                        | [QEMU Mailing List](mailto:qemu-riscv@nongnu.org)           | 42               | https://qemu.org
 KianV         | Hirosh Dabui                    | [Hirosh Dabui](mailto:hirosh@dabui.de)                      | 43               | https://github.com/splinedrive/kianRiscV
 Coreblocks    | Kuźnia Rdzeni, University of Wrocław | [Coreblocks Team](mailto:coreblocks@cs.uni.wroc.pl)    | 44               | https://github.com/kuznia-rdzeni/coreblocks
+rrv32         | Solra Bizna                     | [Solra Bizna](mailto:solra@bizna.name)                      | 45               | https://github.com/SolraBizna/rrv32


### PR DESCRIPTION
This PR assigns ID 45 to rrv32, because that is the next `marchid` in line. If permissible, I would prefer to use 1495879317 instead. This larger ID encodes a memorial to my father, who passed away 13 months ago. He set and guided me on the 25-year path that led to the creation of rrv32. That ID still has the high bit unset, which means it is technically within the open source `marchid` space. (However, I could easily see such a huge ID being inconvenient and annoying for those who want to make a simple lookup table for `marchid` values.)