### PR TITLE
Integrate B standard extension text

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -1,6 +1,9 @@
 [[bits]]
 == "B" Standard Extension for Bit Manipulation, Version 1.0.0
 
+The B standard extension comprises instructions provided by the Zba, Zbb, and
+Zbs extensions.
+
 [[preface]]
 === Bit-manipulation a, b, c and s extensions grouped for public review and ratification
 

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -156,7 +156,7 @@ X +
 Y +
 Z
 |Atomic extension +
-_Reserved_ +
+B extension +
 Compressed extension +
 Double-precision floating-point extension +
 RV32E/64E base ISA +
@@ -191,6 +191,10 @@ The "U" and "S" bits will be set if there is support for user and
 supervisor modes respectively.
 
 The "X" bit will be set if there are any non-standard extensions.
+
+When "B" bit is 1, the implementation supports the instructions provided by the
+Zba, Zbb, and Zbs extensions. When "B" bit is 0, it indicates that the
+implementation may not support one or more of the Zba, Zbb, or Zbs extensions.
 
 [NOTE]
 ====

--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -182,6 +182,8 @@ e.g., RV32IMACV is legal, whereas RV32IMAVC is not.
 
 |16-bit Compressed Instructions |C |
 
+|B Extension |B |
+
 |Packed-SIMD Extensions |P |
 
 |Vector Extension |V |D


### PR DESCRIPTION
Should wait for ratification prior to merge.
Integrates text from: https://github.com/riscv/riscv-b/blob/main/b.adoc
