### PR TITLE
Add missing v to beginning of extension name in vector-crypto.adoc

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -338,7 +338,7 @@ overlap this `vs2` register group.
 | vsm4r.vs      | vs2      | vd 
 | vsha2c[hl]    | vs1, vs2 | vd
 | vsha2ms       | vs1, vs2 | vd
-| sm3me         | vs2      | vd
+| vsm3me        | vs2      | vd
 | vsm3c         | vs2      | vd
 
 


### PR DESCRIPTION
This table used sm3me instead of vsm3me