### PR TITLE
Set explicit anchor on table.

### DIFF
--- a/src/smcdeleg.adoc
+++ b/src/smcdeleg.adoc
@@ -44,6 +44,7 @@ with counter _i_ can be read or written via `sireg*`, while `siselect` holds
 the table below.
 
 .Indirect HPM State Mappings
+[#indirect-hpm-state-mappings]
 [width="100%",cols="21%,20%,21%,18%,20%",options="header",]
 |===
 |*`siselect` value* |*`sireg*` |*`sireg4`* |*`sireg2`* |*`sireg5`*
@@ -90,7 +91,7 @@ NOTE: _The memory-mapped `mtime` register is not a performance monitoring
 counter to be managed by supervisor software, hence the special
 treatment of `siselect` value 0x41 described above._
 
-For each `siselect` and `sireg*` combination defined in <<Indirect HPM State Mappings>>, the table
+For each `siselect` and `sireg*` combination defined in <<indirect-hpm-state-mappings>>, the table
 further indicates the extensions upon which the underlying counter state
 depends. If any extension upon which the underlying state depends is not
 implemented, an attempt from M or S mode to access the given state


### PR DESCRIPTION
Set an explicit anchor on the Indirect HPM State Mappings table and update link to it further down in the document.

This fixes https://github.com/riscv/riscv-isa-manual/issues/1291