### PR TITLE
Fix reference to menvcfgreg

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1996,10 +1996,11 @@ M-mode software towards the beginning of the boot process.
 ====  Machine Environment Configuration Register (`menvcfg`)
 
 The `menvcfg` CSR is a 64-bit read/write register, formatted
-as shown in [[menvcfg]], that controls
+as shown in <<menvcfgreg>>, that controls
 certain characteristics of the execution environment for modes less
 privileged than M.
 
+[#menvcfgreg]
 .Machine environment configuration register (`menvcfg`).
 include::images/bytefield/menvcfgreg.adoc[]
 


### PR DESCRIPTION
There was a missing reference to Figure 16. Fixes https://github.com/riscv/riscv-isa-manual/issues/1294