### PR TITLE
Preface update

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -1,6 +1,7 @@
 [colophon]
 = Preface
 
+
 This document describes the RISC-V unprivileged architecture.
 
 The ISA modules marked *Ratified* have been ratified at this time. The
@@ -13,43 +14,51 @@ The document contains the following versions of the RISC-V ISA modules:
 [%autowidth,float="center",align="center",cols="^,<,^",options="header"]
 |===
 |Base |Version |Status
-|*RVWMO* |*2.0* |*Ratified*
 |*RV32I* |*2.1* |*Ratified*
-|*RV64I* |*2.1* |*Ratified*
 |*RV32E* |*2.0* |*Ratified*
 |*RV64E* |*2.0* |*Ratified*
+|*RV64I* |*2.1* |*Ratified*
 |_RV128I_ |_1.7_ |_Draft_
 
 h|Extension h|Version h|Status
 
+|*Zifencei* |*2.0* |*Ratified*
+|*Zicsr* |*2.0* |*Ratified*
+|*Zicntr* |*2.0* |*Ratified*
+|*Zihintntl* |*1.0* |*Ratified*
+|*Zihintpause* |*2.0* |*Ratified*
+|_Zimop_ | _0.1_ | _Draft_
+|*Zicond* | *1.0* |*Ratified*
 |*M* |*2.0* |*Ratified*
+|*Zmmul* |*1.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
+|*Zawrs* |*1.01* |*Ratified*
+|*Zacas* |*1.0* |*Ratifed*
+|*RVWMO* |*2.0* |*Ratified*
+|*Ztso* |*1.0* |*Ratified*
+|*CMO* |*1.0* |*Ratified*
 |*F* |*2.2* |*Ratified*
 |*D* |*2.2* |*Ratified*
 |*Q* |*2.2* |*Ratified*
-|*C* |*2.0* |*Ratified*
-|_Counters_ |*2.0* |*Ratified*
-|_P_ |_0.2_ |_Draft_
-|*V* |*1.0* |*Ratified*
-|*Zicsr* |*2.0* |*Ratified*
-|*Zifencei* |*2.0* |*Ratified*
-|*Zihintpause* |*2.0* |*Ratified*
-|*Zihintntl* |*1.0* |*Ratified*
-|*Zfa* |*1.0* |*Ratified*
 |*Zfh* |*1.0* |*Ratified*
 |*Zfhmin* |*1.0* |*Ratified*
+|*Zfa* |*1.0* |*Ratified*
 |*Zfinx* |*1.0* |*Ratified*
 |*Zdinx* |*1.0* |*Ratified*
 |*Zhinx* |*1.0* |*Ratified*
 |*Zhinxmin* |*1.0* |*Ratified*
-|*Zmmul* |*1.0* |*Ratified*
-|*Ztso* |*1.0* |*Ratified*
+|*C* |*2.0* |*Ratified*
+|*Zc* |*1.0* |*1.0* |*Ratified*
+|*B* |*1.0* |*Ratified*
+|_P_ |_0.2_ |_Draft_
+|*V* |*1.0* |*Ratified*
+|*Zbk,Zk* |*1.0* |*Ratified*
+|*Zvb,Zvk* |*1.0* |*Ratified*
 |===
 
 The changes in this version of the document include:
 
-* The draft Zam extension has been removed, in favor of the
-definition of a misaligned atomicity granule PMA.
+* The inclusion of ALL ratified extensions up to March 2024.
 
 [.big]*_Preface to Document Version 20191213-Base-Ratified_*
 

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -48,7 +48,7 @@ h|Extension h|Version h|Status
 |*Zhinx* |*1.0* |*Ratified*
 |*Zhinxmin* |*1.0* |*Ratified*
 |*C* |*2.0* |*Ratified*
-|*Zc* |*1.0* |*1.0* |*Ratified*
+|*Zc* |*1.0* |*Ratified*
 |*B* |*1.0* |*Ratified*
 |_P_ |_0.2_ |_Draft_
 |*V* |*1.0* |*Ratified*
@@ -59,6 +59,49 @@ h|Extension h|Version h|Status
 The changes in this version of the document include:
 
 * The inclusion of ALL ratified extensions up to March 2024.
+
+* Reorder unpriv chapters more logically (2f0dd91, 2024-03-20)
+* remove unnecessary comments in riscv-unprivileged.adoc (3c8e0c9, 2024-03-20)
+* Merge branch 'main' into zicond (dd33cca, 2024-03-20)
+* Merge branch 'main' into zacas (c220633, 2024-03-20)
+* Merge branch 'main' into vector-crypto (8aefd94, 2024-03-20)
+* Merge branch 'main' into scalar-crypto (918ba8b, 2024-03-20)
+* Merge branch 'main' into vector (7013a90, 2024-03-19)
+* Remove old comment and reformat contributors. (56f19ae, 2024-03-19)
+* Integration of Zicond into Unpriv. (7c08e25, 2024-03-19)
+* Integrate zacas chapter. (9ba8ba4, 2024-03-19)
+* Integration of Vector Crypto chapter. (8b5486b, 2024-03-19)
+* Fix spelling of Nathan Menhorn's lastname (a3d5b3a, 2024-03-13)
+* Pulling in all scalar crypto includes. (169ef9f, 2024-03-12)
+* Adding scalar crypto contributors (f1b9ba7, 2024-03-05)
+* Merge pull request #1216 from riscv/zc (c9ad1c8, 2024-02-29)
+* Moving cmo chapter acknowledgements to header. (51afb41, 2024-02-27)
+* Merge branch 'main' into cmo (14c5798, 2024-02-27)
+* Refactor Zc chapter into 1 file. (7dbf812, 2024-02-22)
+* Merge remote-tracking branch 'origin/main' into zc (5e54e21, 2024-02-20)
+* Merge pull request #1217 from riscv/zawrs (98918c8, 2024-02-20)
+* Move contributors to top level & remove Introduction heading. (e76ff4e, 2024-02-15)
+* Adding Base Cache Management Operation ISA Extensions chapter. (d28d56b, 2024-02-13)
+* Move Fractional Lmul Example into Vector Assembly Code Examples appendix. (aa87978, 2024-02-13)
+* Remove AW, KA, JH as editors (a40f3a6, 2024-02-09)
+* Initial seeding of zawrs chapter. (7662956, 2024-02-06)
+* Moved Zc to after tso (2f48395, 2024-01-31)
+* Pulling in the Zc chapter. (ad672f9, 2024-01-31)
+* Add zc include to unpriv. (a209a72, 2024-01-31)
+* Remove Zam; define misaligned atomicity granule PMA (#1206) (080ef75, 2024-01-29)
+* Revert "Removed DRAFT background image." (6fdf26d, 2023-10-02)
+* Removed DRAFT background image. (b3e0b04, 2023-10-02)
+* Fix typos (e1f42e7, 2023-09-29)
+* Add Zimop/Zcmop draft (2463e2a, 2023-09-15)
+* Fix CSS format wavedrom and backpage image. (d145558, 2023-08-11)
+* Adding new back page vector image (511696d, 2023-08-09)
+* Added html references for math. (4354619, 2023-08-01)
+* Set revdate and revnumber for unpriv. (4ea6dd7, 2023-07-31)
+* Added margin-top theming to the subtitle. (d93d29a, 2023-07-31)
+* Commenting out the backpage image for now. (858eab9, 2023-07-31)
+* Files should end in a newline (71ac43e, 2023-07-12)
+* Addition of Vector spec. (9cd24d5, 2023-06-26)
+* Renamed doc header file. (c8f4155, 2023-04-04)
 
 [.big]*_Preface to Document Version 20191213-Base-Ratified_*
 

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -41,7 +41,8 @@ _0.1_ +
 *1.0* +
 *1.0* +
 *1.0* +
-*1.0* 
+*1.0* +
+*1.0*
 
 |_Draft_ +
 *Ratified* +
@@ -61,9 +62,37 @@ _Draft_ +
 *Ratified*
 |===
 
-The following changes have been made since version 1.12, which, while
+The following changes have been made since version 1.13, which, while
 not strictly backwards compatible, are not anticipated to cause software
 portability problems in practice:
+
+* The inclusion of ALL ratified extensions up to March 2024.
+
+* include smcdeleg in riscv-privileged (a6af601, 2024-03-25)
+* Reorder priv-spec chapters (54ed5b9, 2024-03-20)
+* Fix misspelling of Sscofpmf (3d1be86, 2024-03-20)
+* remove superfluous comments (78e0c5d, 2024-03-20)
+* Merge pull request #1276 from riscv/indirect-csr (b11c1f6, 2024-03-20)
+* Revert "Integrate svadu chapter into priv." (7878cab, 2024-03-20)
+* Merge branch 'main' into svadu (bf52d08, 2024-03-20)
+* Merge pull request #1273 from riscv/smcntrpmf (9a57b51, 2024-03-20)
+* Merge branch 'main' into vector (7013a90, 2024-03-19)
+* Add indirect-csr.adoc to git. (0be7eea, 2024-03-19)
+* Integrate svadu chapter into priv. (56e2c53, 2024-03-19)
+* Integrate Smcntrpmf chapter. (0c70403, 2024-03-19)
+* Merge branch 'main' into smstateen (6afcca7, 2024-03-07)
+* Merge pull request #1229 from riscv/count-overflow (4571fc3, 2024-03-05)
+* Merge pull request #1230 from riscv/sstc (078b469, 2024-03-05)
+* Merge pull request #1219 from riscv/smepmp (e53b98a, 2024-02-29)
+* Add Sstc.adoc to privileged spec. (1a06203, 2024-02-15)
+* Adding Sscofpmf to priv spec. (7d7e9ab, 2024-02-15)
+* back to draft status (371b75f, 2024-01-30)
+* priv-1.13 internal review draft, take 3 (65ec0e7, 2024-01-30)
+* Remove AW, KA, JH as editors (a40f3a6, 2024-02-09)
+* back to draft status (c35bc9f, 2024-01-30)
+* priv-1.13 internal review draft, take 2 (e6f5cb0, 2024-01-30)
+* Adding smepmp chapter. (b647ef5, 2024-02-06)
+* Integration of Smstateen extension chapter. (772bfd2, 2024-02-06)
 
 [.big]*_Preface to Version 20240213_*
 

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -1,6 +1,72 @@
 [colophon]
 = Preface
 
+[.big]*_Preface to Version 20240326_*
+
+This document describes the RISC-V privileged architecture. This
+release, version 20240213, contains the following versions of the RISC-V ISA
+modules:
+
+[%autowidth,float="center",align="center",cols="^,<,^",options="header",]
+|===
+|Module |Version |Status
+|_Machine ISA_ +
+*Smstateen Extension* +
+*Smcsrind/Sscsrind Extension* +
+*Smepmp* +
+**Smcntrpmf* +
+*Smrnmi Extension* +
+*Smcdeleg* +
+_Supervisor ISA_ +
+*Svade Extension* +
+*Svnapot Extension* + 
+*Svpbmt Extension* +  
+*Svinval Extension* + 
+*Svadu Extension* +
+*Sstc* +
+*Sscofpmf* +
+*Hypervisor ISA*  
+
+|_1.13_ +
+*1.0.0* +
+*1.0.0* +
+*1.0.0* +
+*1.0.0* +
+*1.0.0* +
+_1.13_ +
+*1.0.0* +
+_0.1_ +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* 
+
+|_Draft_ +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+_Draft_ +
+*Ratified* +
+_Draft_ +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified* +
+*Ratified*
+|===
+
+The following changes have been made since version 1.12, which, while
+not strictly backwards compatible, are not anticipated to cause software
+portability problems in practice:
+
+[.big]*_Preface to Version 20240213_*
+
 This document describes the RISC-V privileged architecture. This
 release, version 20240213, contains the following versions of the RISC-V ISA
 modules:


### PR DESCRIPTION
Updated the Preface in Unpriv and Priv in anticipation of publishing both for internal review.  Note that Unpriv change history goes back to move to asciidoc and Priv changes go back to v1.13.