### PR TITLE
Opcode 0x77 is named OP-VE, for "Vector Extensions"

### DIFF
--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -19,7 +19,7 @@ and RV64G.
 |00           |LOAD   |LOAD-FP  |_custom-0_ |MISC-MEM |OP-IMM |AUIPC      |OP-IMM-32       |48b
 |01           |STORE  |STORE-FP |_custom-1_ |AMO      |OP     |LUI        |OP-32           |64b
 |10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |OP-V       |_custom-2/rv128_|48b
-|11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |_reserved_ |_custom-3/rv128_|&#8805;80b
+|11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |OP-VE      |_custom-3/rv128_|&#8805;80b
 |===
 
 <<opcodemap>> shows a map of the major opcodes for

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -1199,7 +1199,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00001'},
@@ -1213,7 +1213,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00001'},
@@ -1300,7 +1300,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00000'},
@@ -1314,7 +1314,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00000'},
@@ -1406,7 +1406,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00011'},
@@ -1420,7 +1420,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00011'},
@@ -1511,7 +1511,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00010'},
@@ -1525,7 +1525,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00010'},
@@ -1616,7 +1616,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'uimm'},
@@ -1732,7 +1732,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'uimm'},
@@ -1845,7 +1845,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '00111'},
@@ -2564,7 +2564,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'vs1'},
@@ -2692,7 +2692,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '10001'},
@@ -3136,7 +3136,7 @@ Encoding (Vector-Vector) High part::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'vs1'},
@@ -3150,7 +3150,7 @@ Encoding (Vector-Vector) Low part::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'vs1'},
@@ -3348,7 +3348,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'vs1'},
@@ -3533,7 +3533,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'uimm'},
@@ -3726,7 +3726,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'vs1'},
@@ -3878,7 +3878,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: 'uimm'},
@@ -4096,7 +4096,7 @@ Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '10000'},
@@ -4110,7 +4110,7 @@ Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 7, name: 'OP-P'},
+{bits: 7, name: 'OP-VE'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
 {bits: 5, name: '10000'},
@@ -4372,7 +4372,7 @@ Included in::
 [[crypto_vector_instructions]]
 === Crypto Vector Cryptographic Instructions
 
-OP-P (0x77)
+OP-VE (0x77)
 Crypto Vector instructions except Zvbb and Zvbc
 
 // [cols="4,1,1,1,8,4,1,1,8,4,1,1,8"]


### PR DESCRIPTION
Resolves #1310

This major opcode is currently used by vector crypto extensions.  It'll likely be used by future vector extensions, as well.

The official naming table currently describes this opcode as _reserved_, which is obviously no longer the case.  Informally, it has sometimes been referred to as OP-P, since there was once a plan to encode the packed-SIMD extensions there.  That plan has been superseded by a proposal to use brownfield space elsewhere.

The vector crypto spec reflects the informal usage of OP-P; this PR fixes that up, too.