### PR TITLE
Sstc editorial fixes.

### DIFF
--- a/src/sstc.adoc
+++ b/src/sstc.adoc
@@ -179,12 +179,12 @@ enables stimecmp for S-mode when set to one, and the same bit of henvcfg
 enables vstimecmp for VS-mode. These STCE bits are WARL and are hard-wired to 0
 when this extension is not implemented.
 
-When STCE in menvcfg is zero, an attempt to access stimecmp or vstimecmp in a
+When this extension is implemented and STCE in menvcfg is zero, an attempt to access stimecmp or vstimecmp in a
 mode other than M-mode raises an illegal instruction exception, STCE in henvcfg
 is read-only zero, and STIP in mip and sip reverts to its defined behavior as
-if this extension is not implemented.
+if this extension is not implemented. Further, if the H extension is implemented, then hip.VSTIP also reverts its defined behavior as if this extension is not implemented.
 
-When STCE in menvcfg is one but STCE in henvcfg is zero, an attempt to access
+When this extension is implemented and STCE in menvcfg is one but STCE in henvcfg is zero, an attempt to access
 stimecmp (really vstimecmp) when V = 1 raises a virtual instruction exception,
 and VSTIP in hip reverts to its defined behavior as if this extension is not
 implemented.

--- a/src/sstc.adoc
+++ b/src/sstc.adoc
@@ -184,7 +184,7 @@ mode other than M-mode raises an illegal instruction exception, STCE in henvcfg
 is read-only zero, and STIP in mip and sip reverts to its defined behavior as
 if this extension is not implemented. Further, if the H extension is implemented, then hip.VSTIP also reverts its defined behavior as if this extension is not implemented.
 
-When this extension is implemented and STCE in menvcfg is one but STCE in henvcfg is zero, an attempt to access
+But when STCE in menvcfg is one and STCE in henvcfg is zero, an attempt to access
 stimecmp (really vstimecmp) when V = 1 raises a virtual instruction exception,
 and VSTIP in hip reverts to its defined behavior as if this extension is not
 implemented.


### PR DESCRIPTION
The second to last paragraph starts "When STCE in menvcfg is zero, ...".  This should be clarified to say "When this extension is implemented and STCE in menvcfg is zero, ...".  And ditto for the beginning of the last paragraph.