### PR TITLE
Sscofpmf editorial fixes.

### DIFF
--- a/src/sscofpmf.adoc
+++ b/src/sscofpmf.adoc
@@ -62,9 +62,9 @@ bit [61] +++SINH+++ - If set, then counting of events in S/HS-mode is inhibited
 
 bit [60] +++UINH+++ - If set, then counting of events in U-mode is inhibited
 
-bit [59] +++VSINH+++ - If set, then counting of events in VS-mode is inhibited
+bit [59] +++VSINH+++ - If set and the H extension is implemented, then counting of events in VS-mode is inhibited
 
-bit [58] +++VUINH+++ - If set, then counting of events in VU-mode is inhibited
+bit [58] +++VUINH+++ - If set and the H extension is implemented, then counting of events in VU-mode is inhibited
 
 bit [57] 0 - Reserved for possible future modes
 
@@ -183,7 +183,7 @@ M-mode).
 
 Read access to bit _X_ is subject to the same mcounteren (or mcounteren and
 hcounteren) CSRs that mediate access to the hpmcounter CSRs by S-mode (or
-VS-mode). In M and S modes, scountovf bit _X_ is readable when mcounteren bit
+VS-mode). In S modes, scountovf bit _X_ is readable when mcounteren bit
 _X_ is set, and otherwise reads as zero. Similarly, in VS mode, scountovf bit
 _X_ is readable when mcounteren bit _X_ and hcounteren bit _X_ are both set,
 and otherwise reads as zero.


### PR DESCRIPTION
For the beginning of the descriptions of bits 58 and 59, "If set, ..." should instead be "If set and the H extension is implemented, ...".

In the last paragraph, "In M and S modes, ..." should instead say "In S mode, ...".