### PR TITLE
Fix typo in hypervisor.adoc

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1708,7 +1708,7 @@ NOTE: No mechanism is provided to atomically change `vsatp` and `hgatp`
 together.  Hence, to prevent speculative execution causing one guest's
 VS-stage translations to be cached under another guest's VMID, world-switch
 code should zero `vsatp`, then swap `hgatp`, then finally write the new
-`vstap` value.  Similarly, if `henvcfg`.PBMTE need be world-switched, it
+`vsatp` value.  Similarly, if `henvcfg`.PBMTE need be world-switched, it
 should be switched after zeroing `vsatp` but before writing the new `vsatp`
 value, obviating the need to execute an HFENCE.VVMA instruction.
 


### PR DESCRIPTION
* `vstap` should be `vsatp`