### PR TITLE
[scalar-crypto] fixing typo in bitmanip extension list in zkt

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4251,7 +4251,7 @@ See <<crypto_scalar_appx_es_access>>.
 
 =====	RVB (Bitmanip)
 
-The <<zbkb>>, <<zbkx>> and <<zbkx>> extensions are included in their entirety.
+The <<zbkb>>, <<zbkc>> and <<zbkx>> extensions are included in their entirety.
 
 .Note to implementers
 [NOTE,caption="SH"]


### PR DESCRIPTION
In `Zkt` description of covered crypto bitmanip extensions: `zbkx` is repeated twice and `zbkc` is not mentioned (although `clmul` and `clmulh` are listed below as part of `Zkt`)