### PR TITLE
Typo fixes.

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -924,7 +924,7 @@ LQ ^.^| LW ^.^| FLW +
 LD +
 LD ^.^| _Reserved_ ^.^| FSD +
 FSD +
-SQSW ^.^| SW ^.^| FSW +
+SQ ^.^| SW ^.^| FSW +
 SD +
 SD 
 ^.^| RV32 +
@@ -939,14 +939,14 @@ RV128
 
 2+>.^|10 ^.^|SLLI ^.^|FLDSP +
 FLDSP +
-LDSP ^.^|LWSP ^.^|FLWSP +
+LQSP ^.^|LWSP ^.^|FLWSP +
 LDSP +
 LDSP ^.^|J[AL]R/MV/ADD ^.^|FSDSP +
 FSDSP +
 SQSP ^.^|SWSP ^.^|FSWSP +
 SDSP +
 SDSP ^.^|RV32 +
-RV6 +
+RV64 +
 RV128
 
 2+>.^|11 9+^|>16b


### PR DESCRIPTION
Fixes #1332 where RV6 s/b RV64.
Fixes #1333 where LDSP s/b LQSP.
Fixes #1334 where SQSW s/b SQ.