### PR TITLE
Fix heading spacing

### DIFF
--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -80,8 +80,9 @@ codespan:
 menu_caret_content: " <font size=\"1.15em\"><color rgb=\"000000\">\u203a</color></font> "
 heading:
     align: left
-    margin_bottom: 0.25in
-    margin_top: 0.5in
+    margin_bottom: $block_margin_bottom
+    #margin_top: 0.25in
+    margin_top: $block_margin_bottom
     min_height_after: auto
     font_color: 000000
     font_family: headings

--- a/src/sscofpmf.adoc
+++ b/src/sscofpmf.adoc
@@ -84,7 +84,6 @@ LCOFIP bit is cleared by software before servicing the count overflow interrupt
 resulting from one or more count overflows.
 
 [NOTE]
-.Non-normative
 ====
 There are not separate overflow status and overflow interrupt enable bits. In
 practice, enabling overflow interrupt generation (by clearing the OF bit) is
@@ -94,7 +93,6 @@ overflow interrupt can be generated.
 ====
 
 [NOTE]
-.Non-normative
 ====
 Software can distinguish newly overflowed counters (yet to be serviced by an
 overflow interrupt handler) from overflowed counters that have already been

--- a/src/sstc.adoc
+++ b/src/sstc.adoc
@@ -47,7 +47,6 @@ time - typically as a result of writing stimecmp. The interrupt will be taken
 based on the standard interrupt enable and delegation rules.
 
 [NOTE]
-.Non-normative
 ====
 A spurious timer interrupt might occur if an interrupt handler advances
 stimecmp then immediately returns, because STIP might not yet have fallen in
@@ -58,7 +57,6 @@ poll STIP until it falls.
 ====
 
 [NOTE]
-.Non-normative
 ====
 In systems in which a supervisor execution environment (SEE) provides timer
 facilities via an SBI function call, this SBI call will continue to support
@@ -134,7 +132,6 @@ typically as a result of writing vstimecmp. The interrupt will be taken based
 on the standard interrupt enable and delegation rules while V=1.
 
 [NOTE]
-.Non-normative
 ====
 In systems in which a supervisor execution environment (SEE) implemented by an
 HS-mode hypervisor provides timer facilities via an SBI function call, this SBI


### PR DESCRIPTION
Fix heading spacing in theme and delete redundant use of .Non-normative before some notes.