### PR TITLE
Removal of Erroneous Attributes

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -212,7 +212,7 @@ changed their behavior on signaling-NaN inputs to conform to the
 minimumNumber and maximumNumber operations in the proposed IEEE 754-201x
 specification.
 * The memory consistency model, RVWMO, has been defined.
-* The "Zam" extension, which permits misaligne%autowidth,float="center",align="center",d AMOs and specifies
+* The "Zam" extension, which permits misaligned AMOs and specifies
 their semantics, has been defined.
 * The "Ztso" extension, which enforces a stricter memory consistency
 model than RVWMO, has been defined.
@@ -378,4 +378,3 @@ added.
 allocated for user-defined custom extensions.
 * A typographical error that suggested that stores source their data
 from _rd_ has been corrected to refer to _rs2_.
-


### PR DESCRIPTION
I noticed that this piece of formatting code was introduced in `15322920b281458a100a6375262d6516e8671a45`, and then it looks very strange in `unpriv-isa-asciidoc.html`. I feel like it should be written incorrectly.

In https://github.com/riscv/riscv-isa-manual/releases/download/20240411-riscv-isa-release-DRAFT/unpriv-isa-asciidoc.html
```
The "Zam" extension, which permits misaligne%autowidth,float="center",align="center",d AMOs and specifies their semantics, has been defined.
```