### PR TITLE
Fix running `make -C build docker`

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -25,7 +25,7 @@ all: $(TARGETS)
 # Build with preinstalled docker container; first install it with:
 #   docker pull riscvintl/riscv-docs-base-container-image:latest
 docker:
-	cd .. && docker run -it -v .:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'cd ./build; make $(MAKEFLAGS)'
+	cd .. && docker run -it -v `pwd`:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'cd ./build; make -$(MAKEFLAGS)'
 
 # Asciidoctor options
 ASCIIDOCTOR_OPTS := -a compress \


### PR DESCRIPTION
Without this change I get the following error:
`docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.`

After fixing that by using `pwd`, I get the following (the w flag is added due to `-C build`): `make: *** No rule to make target 'w'` Fix this by using -$(MAKEFLAGS). I confirmed that both `make -C build docker -j4` and `cd build && make docker -j4` work.