### PR TITLE
Fixing italics issue.

### DIFF
--- a/src/indirect-csr.adoc
+++ b/src/indirect-csr.adoc
@@ -115,7 +115,7 @@ which the `miselect` value is allocated.
 [%unbreakable]
 [NOTE]
 ====
-Ordinarily, each_ `__mireg__i` _will access register state, access
+Ordinarily, each `mireg`*_i_* will access register state, access
 read-only 0 state, or raise an illegal instruction exception.
 
 For RV32, if an extension defines an indirectly accessed register as 64 bits wide, it is recommended that the lower 32 bits of the register are accessed through one of `mireg`, `mireg2`, or `mireg3`, while the upper 32 bits are accessed through `mireg4`, `mireg5`, or `mireg6`, respectively.
@@ -193,7 +193,7 @@ allocated.
 [%unbreakable]
 [NOTE]
 ====
-Ordinarily, each_ `__sireg__i` _will access register state, access
+Ordinarily, each `sireg`*_i_* will access register state, access
 read-only 0 state, or, unless executing in a virtual machine (covered in
 the next section), raise an illegal instruction exception.
 ====
@@ -285,7 +285,7 @@ allocated.
 [%unbreakable]
 [NOTE]
 ====
-Ordinarily, each_ `__vsireg__i` _will access register state, access read-only 0 state, or raise an exception (either an illegal instruction exception or, for select accesses from VS-mode, a virtual instruction exception).  When `vsiselect` holds a value that is implemented at HS level but not at VS level, attempts to access `sireg*` (really `vsireg*`) from VS-mode will typically raise a virtual instruction exception.  But there may be cases specific to an extension where different behavior is more appropriate.
+Ordinarily, each `vsireg`*_i_* will access register state, access read-only 0 state, or raise an exception (either an illegal instruction exception or, for select accesses from VS-mode, a virtual instruction exception).  When `vsiselect` holds a value that is implemented at HS level but not at VS level, attempts to access `sireg*` (really `vsireg*`) from VS-mode will typically raise a virtual instruction exception.  But there may be cases specific to an extension where different behavior is more appropriate.
 ====
 
 Like `siselect` and `sireg*`, the widths of `vsiselect` and `vsireg*` are always


### PR DESCRIPTION
Fixes issue #1367 setting register name as monospaced in non-normative text and italicizing and bolding the trailing variable.