### PR TITLE
1394 formatting issues in version 20240411

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -48,7 +48,7 @@ h|Extension h|Version h|Status
 |*Zhinx* |*1.0* |*Ratified*
 |*Zhinxmin* |*1.0* |*Ratified*
 |*C* |*2.0* |*Ratified*
-|*Zce |*1.0* |*Ratified*
+|*Zce* |*1.0* |*Ratified*
 |*B* |*1.0* |*Ratified*
 |_P_ |_0.2_ |_Draft_
 |*V* |*1.0* |*Ratified*

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -52,19 +52,19 @@ h|Extension h|Version h|Status
 |*B* |*1.0* |*Ratified*
 |_P_ |_0.2_ |_Draft_
 |*V* |*1.0* |*Ratified*
-|*Zbkb |*1.0* |*Ratified*
-|*Zbkc |*1.0* |*Ratified*
-|*Zbkx |*1.0* |*Ratified*
-|*Zk |*1.0* |*Ratified*
-|*Zks |*1.0* |*Ratified*
-|*Zvbb |*1.0* |*Ratified*
-|*Zvbc |*1.0* |*Ratified*
-|*Zvkg |*1.0* |*Ratified*
-|*Zvkned |*1.0* |*Ratified*
-|*Zvknhb |*1.0* |*Ratified*
-|*Zvksed |*1.0* |*Ratified*
-|*Zvksh |*1.0* |*Ratified*
-|*Zvkt |*1.0* |*Ratified*
+|*Zbkb* |*1.0* |*Ratified*
+|*Zbkc* |*1.0* |*Ratified*
+|*Zbkx* |*1.0* |*Ratified*
+|*Zk* |*1.0* |*Ratified*
+|*Zks* |*1.0* |*Ratified*
+|*Zvbb* |*1.0* |*Ratified*
+|*Zvbc* |*1.0* |*Ratified*
+|*Zvkg* |*1.0* |*Ratified*
+|*Zvkned* |*1.0* |*Ratified*
+|*Zvknhb* |*1.0* |*Ratified*
+|*Zvksed* |*1.0* |*Ratified*
+|*Zvksh* |*1.0* |*Ratified*
+|*Zvkt* |*1.0* |*Ratified*
 |===
 
 The changes in this version of the document include:


### PR DESCRIPTION
Fixes the bolding of extension names in the "what's included" table in the Preface.