### PR TITLE
Remove outdated RVV 2.0 notice from document #1402

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -11,17 +11,14 @@ domains._
 
 === Introduction
 
-This document is version 1.1-draft of the RISC-V vector extension.
+This document describes the Vector extensions to the RISC-V Instruction Set Architecture.
 
-NOTE: This version holds updates gathered after the start of the
-public review.  The spec will have a final update to version 2.0 at
-time of ratification.
 
-This spec includes the complete set of currently frozen vector
-instructions.  Other instructions that have been considered during
-development but are not present in this document are not included in
-the review and ratification process, and may be completely revised or
-abandoned.  Section <<sec-vector-extensions>> lists the standard
+This document is Ratified. No changes are allowed. Any desired or needed
+changes can be the subject of a follow-on new extension. Ratified extensions
+are never revised. For more information, see link:http://riscv.org/spec-state[here].
+
+Section <<sec-vector-extensions>> lists the standard
 vector extensions and which instructions and element widths are
 supported by each extension.
 


### PR DESCRIPTION
For reasons I [describe here](https://github.com/riscv/riscv-isa-manual/issues/1402#issuecomment-2110699739), I think it's best to remove the RVV 2.0 version notice from the specification, there does seem to be no indication that what the notice says is actually planned.

I replaced it with text derived from the Vector Crypto Introduction, both should ideally be reworded before an actual release, but this should remove the confusion for now.

See also past discussion on the v-spec repo: https://github.com/riscv/riscv-v-spec/pull/946

It sounded like the change would be merged, but the repo was archived before that got through. My understanding is that the riscv-v-spec repo wasn't supposed to be a source of truth, hence it was archived.