### PR TITLE
Remove "vacant" class of memory region

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -368,9 +368,11 @@ around modulo latexmath:[$2^{\text{XLEN}}$].
 
 The execution environment determines the mapping of hardware resources
 into a hart's address space. Different address ranges of a hart's
-address space may (1) be vacant, or (2) contain _main memory_, or
-(3) contain one or more _I/O devices_. Reads and writes of I/O devices
+address space may (1) contain _main memory_, or
+(2) contain one or more _I/O devices_. Reads and writes of I/O devices
 may have visible side effects, but accesses to main memory cannot.
+Vacant address ranges are not a separate category but can be represented as
+either main memory or I/O regions that are not accessible.
 Although it is possible for the execution environment to call everything
 in a hart's address space an I/O device, it is usually expected that
 some portion will be specified as main memory.
@@ -401,7 +403,7 @@ execution environment may dictate that instruction execution performs
 other _implicit_ memory accesses (such as to implement address
 translation) beyond those documented for the unprivileged ISA.
 
-The execution environment determines what portions of the non-vacant
+The execution environment determines what portions of the
 address space are accessible for each kind of memory access. For
 example, the set of locations that can be implicitly read for
 instruction fetch may or may not have any overlap with the set of
@@ -409,8 +411,7 @@ locations that can be explicitly read by a load instruction; and the set
 of locations that can be explicitly written by a store instruction may
 be only a subset of locations that can be read. Ordinarily, if an
 instruction attempts to access memory at an inaccessible address, an
-exception is raised for the instruction. Vacant locations in the address
-space are never accessible.
+exception is raised for the instruction.
 
 Except when specified otherwise, implicit reads that do not raise an
 exception and that have no side effects may occur arbitrarily early and

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2567,8 +2567,8 @@ reporting, and possible containment of the hardware error.
 === Physical Memory Attributes
 
 The physical memory map for a complete system includes various address
-ranges, some corresponding to memory regions, some to memory-mapped
-control registers, and some to vacant holes in the address space. Some
+ranges, some corresponding to memory regions and some to memory-mapped
+control registers, portions of which might not be accessible.  Some
 memory regions might not support reads, writes, or execution; some might
 not support subword or subblock accesses; some might not support atomic
 operations; and some might not support cache coherence or might have
@@ -2646,16 +2646,19 @@ example, switching cacheability attributes on some memory regions might
 involve platform-specific operations, such as cache flushes, that are
 available only to machine-mode.
 
-==== Main Memory versus I/O versus Vacant Regions
+==== Main Memory versus I/O Regions
 
 The most important characterization of a given memory address range is
-whether it holds regular main memory, or I/O devices, or is vacant.
+whether it holds regular main memory or I/O devices.
 Regular main memory is required to have a number of properties,
 specified below, whereas I/O devices can have a much broader range of
 attributes. Memory regions that do not fit into regular main memory, for
-example, device scratchpad RAMs, are categorized as I/O regions. Vacant
-regions are also classified as I/O regions but with attributes
-specifying that no accesses are supported.
+example, device scratchpad RAMs, are categorized as I/O regions.
+
+NOTE: What previous versions of this specification termed _vacant_ regions are
+no longer a distinct category; they are now described as I/O regions that are
+not accessible (i.e. lacking read, write, and execute permissions).
+Main memory regions that are not accessible are also allowed.
 
 ==== Supported Access Type PMAs
 

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1988,9 +1988,6 @@ For leaf PTEs, setting bits 62-61 to the value 3 is reserved for future
 standard use. Until this value is defined by a standard extension, using
 this reserved value in a leaf PTE raises a page-fault exception.
 
-If the underlying physical memory attribute for a page is vacant, the
-PBMT settings do not override that.
-
 When PBMT settings override a main memory page into I/O or vice versa,
 memory accesses to such pages obey the memory ordering rules of the
 final effective attribute, as follows.


### PR DESCRIPTION
Represent them as never-accessible main memory or I/O regions instead.