### PR TITLE
Improve readability of sentence

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -150,9 +150,9 @@ The alignment constraint for base ISA instructions is relaxed to a
 two-byte boundary when instruction extensions with 16-bit lengths or
 other odd multiples of 16-bit lengths are added (i.e., IALIGN=16).
 
-Instruction-address-misaligned exceptions are reported on the branch or
-jump that would cause instruction misalignment to help debugging, and to
-simplify hardware design for systems with IALIGN=32, where these are the
+To help debugging and to simplify hardware design for systems with
+IALIGN=32, instruction-address-misaligned exceptions are reported on the
+branch or jump that would cause instruction misalignment. These are the
 only places where misalignment can occur.
 ====
 


### PR DESCRIPTION
"... where these are the only places where misalignment can occur." was far away from the "branch or jump" making it difficult to follow.