### PR TITLE
Improve readability of sentence

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -170,7 +170,7 @@ registers at the same position in all formats to simplify decoding.
 Except for the 5-bit immediates used in CSR instructions
 (<<csrinsts>>), immediates are always
 sign-extended, and are generally packed towards the leftmost available
-bits in the instruction and have been allocated to reduce hardware
+bits in the instruction, and have been allocated so to reduce hardware
 complexity. In particular, the sign bit for all immediates is always in
 bit 31 of the instruction to speed sign-extension circuitry.
 


### PR DESCRIPTION
"allocated" should be followed by "so" or "in this way" or "in this manner".