### PR TITLE
Remove c.zext.h prerequisites and operation from c.sext.b

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -747,26 +747,6 @@ Operation:
 X(rsdc) = EXTS(X(rsdc)[7..0]);
 ----
 
-Prerequisites:
-
-Zbb is also required.
-//
-//32-bit equivalent:
-//
-//<<insns-zext_h>> from Zbb
-
-[NOTE]
-====
-The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
-====
-
-Operation:
-
-[source,sail]
-----
-X(rsdc) = EXTZ(X(rsdc)[15..0]);
-----
-
 <<<
 [#insns-c_zext_h,reftext="Zero extend halfword, 16-bit encoding"]
 ==== c.zext.h


### PR DESCRIPTION
The c.zext.h prerequisites and operation were duplicated at the end of the c.sext.b section.