### PR TITLE
remove superflous constrained LR/SC statement from zawrs chapter

### DIFF
--- a/src/zawrs.adoc
+++ b/src/zawrs.adoc
@@ -46,8 +46,7 @@ The `WRS.NTO` and `WRS.STO` instructions cause the hart to temporarily stall
 execution in a low-power state as long as the reservation set is valid and no
 pending interrupts, even if disabled, are observed. For `WRS.STO` the stall 
 duration is bounded by an implementation defined short timeout. These 
-instructions are available in all privilege modes. These instructions are not
-supported in a constrained `LR`/`SC` loop.
+instructions are available in all privilege modes.
 
 [wavedrom, ,svg]
 ....


### PR DESCRIPTION
Stating the WRS.* instructions are not supported in constrained LR/SC loops is superflous as the constrained LR/SC loop specification precisely identifies the supported instructions.