### PR TITLE
Update B extension description to remove mention of sub extensions grouped for review

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -5,12 +5,11 @@ The B standard extension comprises instructions provided by the Zba, Zbb, and
 Zbs extensions.
 
 [[preface]]
-=== Bit-manipulation a, b, c and s extensions grouped for public review and ratification
+=== Zb* Overview
 
 The bit-manipulation (bitmanip) extension collection is comprised of several component extensions to the base RISC-V architecture that are intended to provide some combination of code size reduction, performance improvement, and energy reduction.
 While the instructions are intended to have general use, some instructions are more useful in some domains than others.
-Hence, several smaller bitmanip extensions are provided, rather than one large extension.
-Each of these smaller extensions is grouped by common function and use case, and each has its own Zb*-extension name.
+Hence, several smaller bitmanip extensions are provided. Each of these smaller extensions is grouped by common function and use case, and each has its own Zb*-extension name.
 
 Each bitmanip extension includes a group of several bitmanip instructions that have similar purposes and that can often share the same logic. Some instructions are available in only one extension while others are available in several.
 The instructions have mnemonics and encodings that are independent of the extensions in which they appear.


### PR DESCRIPTION
- Remove heading stating "Bit-manipulation a, b, c and s extensions grouped for public review and ratification"
- Slightly reword intro to remove mention of lack of a larger extension now that B is ratified