### PR TITLE
Clarify the behavior of mcountinhibit CSR

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1592,7 +1592,7 @@ counters increment; their accessibility is not affected by the setting
 of this register.
 
 When the CY, IR, or HPM__n__ bit in the `mcountinhibit` register is clear,
-the `cycle`, `instret`, or `hpmcountern` register increments as usual.
+the `mcycle`, `minstret`, or `mhpmcountern` register increments as usual.
 When the CY, IR, or HPM_n_ bit is set, the corresponding counter does
 not increment.
 
@@ -1605,12 +1605,12 @@ behaves as though the register were set to zero.
 
 [NOTE]
 ====
-When the `cycle` and `instret` counters are not needed, it is desirable
+When the `mcycle` and `minstret` counters are not needed, it is desirable
 to conditionally inhibit them to reduce energy consumption. Providing a
 single CSR to inhibit all counters also allows the counters to be
 atomically sampled.
 
-Because the `time` counter can be shared between multiple cores, it
+Because the `mtime` counter can be shared between multiple cores, it
 cannot be inhibited with the `mcountinhibit` mechanism.
 ====
 


### PR DESCRIPTION
Use mcycle, minstret, mhpmcountern to replace cycle, instret, hpmcountern in mcountinhibit spec. This will not changing any meaning because of "read-only shadow".

See #1420 for details.