### PR TITLE
Table Fixes

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -492,7 +492,6 @@ between 80 bits and 176 bits are encoded using a 3-bit field in bits
 5latexmath:[$\times$]16-bit words. The encoding with bits [14:12] set to
 "111" is reserved for future longer instruction encodings.
 
-[[instlengthcode, Table 1]]
 .RISC-V instruction length encoding. 
 
 .RISC-V instruction length encoding. Only the 16-bit and 32-bit encodings are considered frozen at this time.

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -694,7 +694,7 @@ Fatal Trap:::
 <<trapcharacteristics>> shows the characteristics of each
 kind of trap.
 
-[[trapcharacteristics, Table 2]]
+[[trapcharacteristics]]
 
 [%autowidth,float="center",align="center",cols="<,^,^,^,^",options="header",]
 |===

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -492,8 +492,7 @@ between 80 bits and 176 bits are encoded using a 3-bit field in bits
 5latexmath:[$\times$]16-bit words. The encoding with bits [14:12] set to
 "111" is reserved for future longer instruction encodings.
 
-.RISC-V instruction length encoding. 
-
+[[instlengthcode]]
 .RISC-V instruction length encoding. Only the 16-bit and 32-bit encodings are considered frozen at this time.
 [%autowidth,cols="^2,^2,^3,^3,<4"]
 |===
@@ -690,18 +689,17 @@ Fatal Trap:::
   expire. Each EEI should define how execution is terminated and
   reported to an external environment.
 
-<<trapcharacteristics>> shows the characteristics of each
-kind of trap.
+<<trapcharacteristics>> shows the characteristics of each kind of trap.
 
 [[trapcharacteristics]]
-
+.Characteristics of traps: 1) Termination may be requested. 2) Imprecise fatal traps might be observable by software.
 [%autowidth,float="center",align="center",cols="<,^,^,^,^",options="header",]
 |===
 | |Contained |Requested |Invisible |Fatal
 |Execution terminates |No |No^1^|No |Yes
 |Software is oblivious |No |No |Yes |Yes^2^|Handled by environment |No |Yes |Yes |Yes
 |===
-<<trapcharacteristics>> Characteristics of traps: 1) Termination may be requested. 2) Imprecise fatal traps might be observable by software.
+
 
 The EEI defines for each trap whether it is handled precisely, though
 the recommendation is to maintain preciseness where possible. Contained

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -692,7 +692,7 @@ Fatal Trap:::
 <<trapcharacteristics>> shows the characteristics of each kind of trap.
 
 [[trapcharacteristics]]
-.Characteristics of traps: 1) Termination may be requested. 2) Imprecise fatal traps might be observable by software.
+.Characteristics of traps
 [%autowidth,float="center",align="center",cols="<,^,^,^,^",options="header",]
 |===
 | |Contained |Requested |Invisible |Fatal
@@ -700,6 +700,8 @@ Fatal Trap:::
 |Software is oblivious |No |No |Yes |Yes^2^|Handled by environment |No |Yes |Yes |Yes
 |===
 
+^1^ Termination may be requested +
+^2^ Imprecise fatal traps might be observable by software
 
 The EEI defines for each trap whether it is handled precisely, though
 the recommendation is to maintain preciseness where possible. Contained

--- a/src/rvwmo.adoc
+++ b/src/rvwmo.adoc
@@ -515,7 +515,7 @@ register(s) to destination register(s) as specified
 
 |CSRRCI ‡ |_csr_ |_rd_, _csr_^*^  | |^*^unless uimm[4:0]=0
 
-4+| ‡ carries a dependency from _csr_ to _rd_
+5+| ‡ carries a dependency from _csr_ to _rd_
 |===
 
 .RV64I Base Integer Instruction Set


### PR DESCRIPTION
This pull request addresses the following issues:
- https://github.com/riscv/riscv-isa-manual/issues/1403 - Incorrect table numbering due to hard-coded table numbers in unprivileged spec manual
- Reference symbols in intro now match the style used in other tables in the doc (explanation of symbol is below table, not in table description)
- asciidoctor error due to the incorrect number of columns specified in `cmo.adoc`