### PR TITLE
Clarify CBO access size

### DIFF
--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -337,6 +337,9 @@ _This specification assumes that the above constraints will typically be met for
 main memory regions and may be met for certain I/O regions._
 ====
 
+Additionally, for the purposes of PMP and PMA checks, the access size of a CMO
+instruction equals the size of the cache block accessed by the instruction.
+
 The Zicboz extension introduces an additional supported access type PMA for
 cache-block zero instructions. Main memory regions are required to support
 accesses by cache-block zero instructions; however, I/O regions may specify


### PR DESCRIPTION
Define access size to be size of cache block for PMP/PMA checks