### PR TITLE
Clarify CBO for unaligned rs1

### DIFF
--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -385,8 +385,8 @@ translation, the instruction does _not_ check the accessed and dirty bits and
 neither raises an exception nor sets the bits.
 
 When a page fault, guest-page fault, or access fault exception is taken, the
-relevant *tval CSR is written with the faulting effective address (i.e. the same
-faulting address value as for other causes of these exceptions).
+relevant *tval CSR is written with the faulting effective address (i.e. the
+value of _rs1_).
 
 [NOTE]
 ====
@@ -924,10 +924,14 @@ Encoding::
 Description::
 
 A *cbo.flush* instruction performs a flush operation on the cache block whose
-effective address is the base address specified in _rs1_. The offset operand may
-be omitted; otherwise, any expression that computes the offset shall evaluate to
-zero. The instruction operates on the set of coherent caches accessed by the
+that contains the address specified in _rs1_. It is not required that _rs1_ is
+aligned to the size of a cache block. On faults, the faulting virtual address
+is considered to be the value in rs1, rather than the base address of the cache
+block. The instruction operates on the set of coherent caches accessed by the
 agent executing the instruction.
+
+The assembly _offset_ operand may be omitted. If it isn't then any expression
+that computes the offset shall evaluate to zero.
 
 Operation::
 [source,sail]
@@ -959,12 +963,17 @@ Encoding::
 Description::
 
 A *cbo.inval* instruction performs an invalidate operation on the cache block
-whose effective address is the base address specified in _rs1_. The offset
-operand may be omitted; otherwise, any expression that computes the offset shall
-evaluate to zero. The instruction operates on the set of coherent caches
-accessed by the agent executing the instruction. Depending on CSR programming,
-the instruction may perform a flush operation instead of an invalidate
-operation.
+that contains the address specified in _rs1_. It is not required that _rs1_ is
+aligned to the size of a cache block. On faults, the faulting virtual address
+is considered to be the value in rs1, rather than the base address of the cache
+block. The instruction operates on the set of coherent caches accessed by the
+agent executing the instruction.
+
+Depending on CSR programming, the instruction may perform a flush operation
+instead of an invalidate operation.
+
+The assembly _offset_ operand may be omitted. If it isn't then any expression
+that computes the offset shall evaluate to zero.
 
 [NOTE]
 ====
@@ -1004,10 +1013,14 @@ Encoding::
 Description::
 
 A *cbo.zero* instruction performs stores of zeros to the full set of bytes
-corresponding to the cache block whose effective address is the base address
-specified in _rs1_. The offset operand may be omitted; otherwise, any expression
-that computes the offset shall evaluate to zero. An implementation may or may
-not update the entire set of bytes atomically.
+corresponding to the cache block that contains the address specified in _rs1_.
+It is not required that _rs1_ is aligned to the size of a cache block. On
+faults, the faulting virtual address is considered to be the value in rs1,
+rather than the base address of the cache block. An implementation may or
+may not update the entire set of bytes atomically.
+
+The assembly _offset_ operand may be omitted. If it isn't then any expression
+that computes the offset shall evaluate to zero.
 
 Operation::
 [source,sail]


### PR DESCRIPTION
Rework the text to be much more explicit about the behaviour when rs1 is not aligned to the cache block size.

I also moved & slightly reworded the note about the assembly syntax since it's not relevant to the instruction semantics.

Fixes #1263 