### PR TITLE
machine.adoc: fix table title

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -967,6 +967,8 @@ unconfigure or disable/enable instructions.
 
 <<<
 
+[[fsxsstates]]
+.FS, VS, and XS state transitions.
 [width=75,align=center,float=center,cols="<,<,<,<,<"]
 |===
 |Current State +
@@ -1070,9 +1072,7 @@ Off
 Off
 |===
 
-[[fsxsstates]]
 [width=75,align=center,float=center,cols="<,<,<,<,<"]
-.FS, FS, and XS state transitions.
 |===
 5+^|Execute instruction to enable unit
 


### PR DESCRIPTION
- move title before the table
- replace redundant FS by VS