### PR TITLE
Correct typos

### DIFF
--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -275,9 +275,9 @@ accessing the hart's IMSIC the same as setting `hstatus.`VGEIN = 0.
 ====
 
 The AIA bit in `mstateen0` controls access to all state introduced by the
-Ssaia extension and is not controlled by either the CSRIND or the IMSIC
+Ssaia extension and not controlled by either the CSRIND or the IMSIC
 bits. The AIA bit in `hstateen0` controls access to all state introduced by the
-Ssaia extension and is not controlled by either the CSRIND or the IMSIC
+Ssaia extension and not controlled by either the CSRIND or the IMSIC
 bits of `hstateen0`.
 
 The CONTEXT bit in `mstateen0` controls access to the `scontext` and


### PR DESCRIPTION
The original expression of this sentence is ambiguous.  According to 'Parter 2.5 Access control by the state-enable CSRs' in The RISC-V Advanced Interrupt Architecture Version 1.0, bit 59(AIA) in stateen controls access to all other state added by the AIA and not controlled by bits 60(CSRIND) and 58(IMSIC).But “is not controlled by either the CSRIND or the IMSIC bits of mstateen0“ seems more like it's restricting "the AIA bit" rather than "state".