### PR TITLE
Make uses of 'pseudo' consistent

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -2300,7 +2300,7 @@ earlier.
 Standard +
 Instruction
 ^.>|Custom Value
-^.>|Pseudo-instruction Value
+^.>|Pseudoinstruction Value
 |Instruction address misaligned |Yes |No |Yes |No
 |Instruction access fault +
 Illegal instruction +

--- a/src/mm-formal.adoc
+++ b/src/mm-formal.adoc
@@ -432,7 +432,7 @@ The operational model, together with a fragment of the RISC-V ISA
 semantics (RV64I and A), are integrated into the `rmem` exploration tool
 (https://github.com/rems-project/rmem). `rmem` can explore litmus tests
 (see <<litmustests>>) and small ELF binaries
-exhaustively, pseudo-randomly and interactively. In `rmem`, the ISA
+exhaustively, pseudorandomly and interactively. In `rmem`, the ISA
 semantics is expressed explicitly in Sail (see
 https://github.com/rems-project/sail for the Sail language, and
 https://github.com/rems-project/sail-riscv for the RISC-V ISA model),

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4256,7 +4256,7 @@ The <<zbkb-sc>>, <<zbkc-sc>> and <<zbkx-sc>> extensions are included in their en
 .Note to implementers
 [NOTE,caption="SH"]
 ====
-Recall that `rev`, `zip` and `unzip` are pseudo-instructions representing
+Recall that `rev`, `zip` and `unzip` are pseudoinstructions representing
 specific instances of `grevi`, `shfli` and `unshfli` respectively.
 ====
 
@@ -4395,7 +4395,7 @@ manipulating the bit and byte endianness of data.
 They are all parameterisations of the Generalised Reverse with Immediate
 (`grevi` instruction.
 The scalar cryptography extension requires _only_ the above instances
-of `grevi` be implemented, which can be invoked via their pseudo-ops.
+of `grevi` be implemented, which can be invoked via their pseudoinstructions.
 
 The full specification of the `grevi` instruction is available in
 cite:[riscv:bitmanip:draft] (Section 2.2.2).
@@ -4415,11 +4415,11 @@ RV32:
     unzip   rd, rs1 // unshfli rd, rs1, 15 - Bit de-interleave
 ----
 
-The `zip` and `unzip` pseudo-ops are specific instances of
+The `zip` and `unzip` pseudoinstructions are specific instances of
 the more general `shfli` and `unshfli` instructions.
 The scalar cryptography extension requires _only_ the above instances
 of `[un]shfli` be implemented, which can be invoked via their
-pseudo-ops.
+pseudoinstructions.
 Only RV32 implementations require these instructions.
 
 The full specification of the `shfli` instruction is available in

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -83,7 +83,7 @@ However, the Vector Crypto Sail model needs the Vector Sail model as a
 basis on which to build. This Vector Cryptography extensions specification
 was completed before there was an approved RISC-V Vector Sail Model.
 Therefore, we don't have any Sail code to include in the instruction
-descriptions. Instead we have included Sail-like pseudo code. While we have
+descriptions. Instead we have included Sail-like pseudocode. While we have
 endeavored to adhere to Sail syntax, we have taken some liberties for the
 sake of simplicity where we believe that that our intent is clear to the
 reader.
@@ -97,13 +97,13 @@ register with `a` having the highest element index of the group and `f` having t
 lowest index of the group.
 ====
 
-For the sake of brevity, our pseudo code does not include the handling of
+For the sake of brevity, our pseudocode does not include the handling of
 masks or tail elements. We follow the _undisturbed_ and _agnostic_ policies
 for masks and tails  as described in the *RISC-V "V" Vector Extension*
 specification. Furthermore, the code does not explicitly handle overlap and SEW
 constraints; these are, however, explicitly stated in the text.
 
-In many cases the pseudo code includes
+In many cases the pseudocode includes
 calls to supporting functions which are too verbose to include directly
 in the specification.
 This supporting code is listed in

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -135,7 +135,7 @@ The _c.mul_ encoding uses the CA register format along with other instructions s
 
 [NOTE]
 
-  _c.sext.w_ is a pseudo-instruction for _c.addiw rd, 0_ (RV64)
+  _c.sext.w_ is a pseudoinstruction for _c.addiw rd, 0_ (RV64)
 
 [%header,cols="^1,^1,4,8"]
 |===
@@ -382,7 +382,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 X(rdc) = EXTZ(mem[X(rs1c)+EXTZ(uimm)][7..0]);
 ----
@@ -443,7 +443,7 @@ Operation:
 
 [source,sail]
 --
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 X(rdc) = EXTZ(load_mem[X(rs1c)+EXTZ(uimm)][15..0]);
 --
@@ -504,7 +504,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 X(rdc) = EXTS(load_mem[X(rs1c)+EXTZ(uimm)][15..0]);
 ----
@@ -565,7 +565,7 @@ Operation:
 
 [source,sail]
 --
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 mem[X(rs1c)+EXTZ(uimm)][7..0] = X(rs2c)
 --
@@ -626,7 +626,7 @@ None
 Operation:
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 mem[X(rs1c)+EXTZ(uimm)][15..0] = X(rs2c)
 ----
@@ -1189,7 +1189,7 @@ NOTE: It is implementation defined whether interrupts can also be taken during t
 
 From a software perspective the PUSH sequence appears as:
 
-* A sequence of stores writing the bytes required by the pseudo-code
+* A sequence of stores writing the bytes required by the pseudocode
 ** The bytes may be written in any order.
 ** The bytes may be grouped into larger accesses.
 ** Any of the bytes may be written multiple times.
@@ -1240,7 +1240,7 @@ addi sp, sp, -64
 
 From a software perspective the POP/POPRET sequence appears as:
 
-* A sequence of loads reading the bytes required by the pseudo-code.
+* A sequence of loads reading the bytes required by the pseudocode.
 ** The bytes may be loaded in any order.
 ** The bytes may be grouped into larger accesses.
 ** Any of the bytes may be loaded multiple times.
@@ -1554,11 +1554,11 @@ No direct equivalent encoding exists
 
 Operation:
 
-The first section of pseudo-code may be executed multiple times before the instruction successfully completes.
+The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 if (XLEN==32) bytes=4; else bytes=8;
 
@@ -1575,11 +1575,11 @@ for(i in 27,26,25,24,23,22,21,20,19,18,9,8,1)  {
 }
 ----
 
-The final section of pseudo-code executes atomically, and only executes if the section above completes without any exceptions or interrupts.
+The final section of pseudocode executes atomically, and only executes if the section above completes without any exceptions or interrupts.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 sp-=stack_adj;
 ----
@@ -1748,11 +1748,11 @@ No direct equivalent encoding exists
 
 Operation:
 
-The first section of pseudo-code may be executed multiple times before the instruction successfully completes.
+The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 if (XLEN==32) bytes=4; else bytes=8;
 
@@ -1769,11 +1769,11 @@ for(i in 27,26,25,24,23,22,21,20,19,18,9,8,1)  {
 }
 ----
 
-The final section of pseudo-code executes atomically, and only executes if the section above completes without any exceptions or interrupts.
+The final section of pseudocode executes atomically, and only executes if the section above completes without any exceptions or interrupts.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 sp+=stack_adj;
 ----
@@ -1939,11 +1939,11 @@ No direct equivalent encoding exists
 
 Operation:
 
-The first section of pseudo-code may be executed multiple times before the instruction successfully completes.
+The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 if (XLEN==32) bytes=4; else bytes=8;
 
@@ -1960,7 +1960,7 @@ for(i in 27,26,25,24,23,22,21,20,19,18,9,8,1)  {
 }
 ----
 
-The final section of pseudo-code executes atomically, and only executes if the section above completes without any exceptions or interrupts.
+The final section of pseudocode executes atomically, and only executes if the section above completes without any exceptions or interrupts.
 
 [NOTE]
 ====
@@ -1969,7 +1969,7 @@ The _li a0, 0_ *could* be executed more than once, but is included in the atomic
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 asm("li a0, 0");
 sp+=stack_adj;
@@ -2138,11 +2138,11 @@ No direct equivalent encoding exists
 
 Operation:
 
-The first section of pseudo-code may be executed multiple times before the instruction successfully completes.
+The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 if (XLEN==32) bytes=4; else bytes=8;
 
@@ -2159,11 +2159,11 @@ for(i in 27,26,25,24,23,22,21,20,19,18,9,8,1)  {
 }
 ----
 
-The final section of pseudo-code executes atomically, and only executes if the section above completes without any exceptions or interrupts.
+The final section of pseudocode executes atomically, and only executes if the section above completes without any exceptions or interrupts.
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 sp+=stack_adj;
 asm("ret");
@@ -2213,7 +2213,7 @@ This instruction moves _a0_ into _r1s'_ and _a1_ into _r2s'_.  _r1s'_ and _r2s'_
 The execution is atomic, so it is not possible to observe state where only one of _r1s'_ or _r2s'_ has been updated.
 
 The encoding uses _sreg_ number specifiers instead of _xreg_ number specifiers to save encoding space. 
-The mapping between them is specified in the pseudo-code below.
+The mapping between them is specified in the pseudocode below.
 
 [NOTE]
 ====
@@ -2232,7 +2232,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 if (RV32E && (r1sc>1 || r2sc>1)) {
   reserved();
 }
@@ -2281,7 +2281,7 @@ This instruction moves _r1s'_ into _a0_ and _r2s'_ into _a1_.
 The execution is atomic, so it is not possible to observe state where only one of _a0_ or _a1_ have been updated.
 
 The encoding uses _sreg_ number specifiers instead of _xreg_ number specifiers to save encoding space. 
-The mapping between them is specified in the pseudo-code below.
+The mapping between them is specified in the pseudocode below.
 
 [NOTE]
 ====
@@ -2300,7 +2300,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 if (RV32E && (r1sc>1 || r2sc>1)) {
   reserved();
 }
@@ -2491,7 +2491,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 # target_address is temporary internal state, it doesn't represent a real register
 # InstMemory is byte indexed
@@ -2570,7 +2570,7 @@ Operation:
 
 [source,sail]
 ----
-//This is not SAIL, it's pseudo-code. The SAIL hasn't been written yet.
+//This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
 # target_address is temporary internal state, it doesn't represent a real register
 # InstMemory is byte indexed


### PR DESCRIPTION
There are a couple of classes of misuse of "pseudo" within the document that conflict with uses elsewhere in the overall RISC-V ISA Specification:

1. All uses of "pseudo-ops" should instead be "pseudoinstructions".
1. "pseudosomething" sometimes has a space or hyphen separating "pseudo" from the rest of the word. We should pick one usage. I think the most common is with no separation. "pseudorandom" is in the dictionary, as an example.