### PR TITLE
Update extending.adoc to delete extension name 'L' and 'T'

### DIFF
--- a/src/extending.adoc
+++ b/src/extending.adoc
@@ -31,7 +31,7 @@ categories: _standard_ versus _non-standard_.
 
 * A standard extension is one that is generally useful and that is
 designed to not conflict with any other standard extension. Currently,
-"MAFDQCBPV", described in other chapters of this manual, are either
+"MAFDQCBTPV", described in other chapters of this manual, are either
 complete or planned standard extensions.
 * A non-standard extension may be highly specialized and may conflict
 with other standard or non-standard extensions. We anticipate a wide

--- a/src/extending.adoc
+++ b/src/extending.adoc
@@ -31,7 +31,7 @@ categories: _standard_ versus _non-standard_.
 
 * A standard extension is one that is generally useful and that is
 designed to not conflict with any other standard extension. Currently,
-"MAFDQLCBTPV", described in other chapters of this manual, are either
+"MAFDQCBPV", described in other chapters of this manual, are either
 complete or planned standard extensions.
 * A non-standard extension may be highly specialized and may conflict
 with other standard or non-standard extensions. We anticipate a wide


### PR DESCRIPTION
The 'L' and 'T' extensions were placeholders but later removed.
Most changes were done by https://github.com/riscv/riscv-isa-manual/pull/655.
So the sentence here should be adapted as well.
Otherwise it would cause confusion for a new hand.
Because 'L' and 'T' extensions are neither complete nor planned standard extensions now.