### PR TITLE
Clarify mandate of htimedelta

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -726,6 +726,9 @@ When XLEN=32, `htimedeltah` is a 32-bit read/write register
 that aliases bits 63:32 of `htimedelta`.
 Register `htimedeltah` does not exist when XLEN=64.
 
+If `time` CSR is implemented, `htimedelta` and `htimedeltah` (only for XLEN=32)
+must be implemented.
+
 ==== Hypervisor Trap Value (`htval`) Register 
 
 The `htval` register is an HSXLEN-bit read/write register formatted as


### PR DESCRIPTION
According to #481, htimedelta CSR is tide with time CSR. Implementations should either implement both CSRs or skip both.