### PR TITLE
Fix C.NOP hint condition

### DIFF
--- a/src/images/bytefield/rvc-instr-quad1.adoc
+++ b/src/images/bytefield/rvc-instr-quad1.adoc
@@ -14,7 +14,7 @@
 (draw-box "0" {:span 5})
 (draw-box "imm[4:0]" {:span 5})
 (draw-box "01" {:span 2})
-(draw-box (text "C.NOP" :math [:sub "(HINT, imm=0)"]) {:span 3 :text-anchor "start" :borders {}})
+(draw-box (text "C.NOP" :math [:sub "(HINT, imm≠0)"]) {:span 3 :text-anchor "start" :borders {}})
 
 (draw-box "000" {:span 3})
 (draw-box "imm[5]") {:span 1}


### PR DESCRIPTION
This patch fixes an error in the instruction listing tables for the C extension. The definition of the C.NOP instruction specifies that using an immediate other than zero encodes a hint. The table was wrongly stating the opposite: that a zero immediate encodes a hint.