### PR TITLE
Clarify SFENCE.VMA for invalid virtual addresses

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1107,8 +1107,8 @@ virtual address in _rs1_ and that match the address space identified by
 integer register _rs2_, except for entries containing global mappings.
 
 If the value held in _rs1_ is not a valid virtual address, then the
-SFENCE.VMA instruction has no effect. No exception is raised in this
-case.
+SFENCE.VMA is not required to have any effect. No exception is raised
+in this case.
 
 When __rs2__&#8800;``x0``, bits SXLEN-1:ASIDMAX of the value held
 in _rs2_ are reserved for future standard use. Until their use is


### PR DESCRIPTION
The existing wording sounds like the instruction is *required* to have no effect, but SFENCE.VMA is allowed to over-fence, so it still can have an effect even for invalid addresses.