### PR TITLE
Consolidates Zbkb, Zbkc, and Zbkx into he Bitmanip chapter.

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -836,7 +836,7 @@ a single bit in a register. The bit is specified by its index.
 
 |===
 
-[#zbkb,reftext="Bit-manipulation for Cryptography"]
+[[zbkb,Bit-manipulation for Cryptography]]
 ==== Zbkb: Bit-manipulation for Cryptography
 
 This extension contains instructions essential for implementing
@@ -932,7 +932,7 @@ common operations in cryptographic workloads.
 
 |===
 
-[#zbkc,reftext="Carry-less multiplication for Cryptography"]
+[[zbkc,Carry-less multiplication for Cryptography]]
 ==== Zbkc: Carry-less multiplication for Cryptography
 
 Carry-less multiplication is the multiplication in the polynomial ring over
@@ -960,7 +960,7 @@ efficiently implement the GHASH operation, which is part of this workload.
 
 |===
 
-[#zbkx,reftext="Crossbar permutations"]
+[[zbkx,Crossbar permutations]]
 ==== Zbkx: Crossbar permutations
 
 These instructions implement a "lookup table" for 4 and 8 bit elements

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -211,118 +211,28 @@ protocols, while ShangMi ciphers are required for use in China.
 ==== `Zbkb` - Bitmanip instructions for Cryptography
 
 These are a subset of the Bitmanipulation Extension `Zbb` which are
-particularly useful for Cryptography.
-
-NOTE: Some of these instructions are defined in the first Bitmanip
-ratification package, and some are not (
-<<insns-pack-sc,pack>>,
-<<insns-packh-sc,packh>>,
-<<insns-packw-sc,packw>>,
-<<insns-brev8,brev8>>,
-<<insns-zip-sc,zip>>,
-<<insns-unzip-sc,unzip>>).
-All of the instructions in <<zbkb-sc>> have their complete specification included
-in this document, including those _not_ present in the initial
-Bitmanip ratification package.
-This is to make the present specification complete as a standalone document.
-Inevitably there might be small divergences between the Bitmanip and
-Scalar Cryptography specification documents as they move at different
-paces.
-When this happens, assume that the Bitmanip specification has the
-most up-to-date version of Bitmanip instructions.
-This is an unfortunate but necessary stop-gap while Scalar Cryptography
-and Bitmanip are being rapidly iterated on prior to public review.
-
-[%header,cols="^1,^1,4,8"]
-|===
-|RV32
-|RV64
-|Mnemonic
-|Instruction
-
-| &#10003; | &#10003; |  ror         | <<insns-ror-sc>>
-| &#10003; | &#10003; |  rol         | <<insns-rol-sc>>
-| &#10003; | &#10003; |  rori        | <<insns-rori-sc>>
-|          | &#10003; |  rorw        | <<insns-rorw-sc>>
-|          | &#10003; |  rolw        | <<insns-rolw-sc>>
-|          | &#10003; |  roriw       | <<insns-roriw-sc>>
-| &#10003; | &#10003; |  andn        | <<insns-andn-sc>>
-| &#10003; | &#10003; |  orn         | <<insns-orn-sc>>
-| &#10003; | &#10003; |  xnor        | <<insns-xnor-sc>>
-| &#10003; | &#10003; |  pack        | <<insns-pack-sc>>
-| &#10003; | &#10003; |  packh       | <<insns-packh-sc>>
-|          | &#10003; |  packw       | <<insns-packw-sc>>
-| &#10003; | &#10003; |  brev8       | <<insns-brev8>>
-| &#10003; | &#10003; |  rev8        | <<insns-rev8-sc>>
-| &#10003; |          |  zip         | <<insns-zip-sc>>
-| &#10003; |          |  unzip       | <<insns-unzip-sc>>
-|===
+particularly useful for Cryptography. Please refer to <<b-st-ext.adoc#zbkb>>.
 
 [[zbkc-sc,Zbkc-sc]]
 ==== `Zbkc` - Carry-less multiply instructions
 
 Constant time carry-less multiply for Galois/Counter Mode.
-These are separated from the <<zbkb-sc>> because they
+These are separated from the <<b-st-ext.adoc#zbkb>> because they
 have a considerable implementation overhead which cannot be amortised
 across other instructions.
 
-NOTE: These instructions are defined in the first Bitmanip
-ratification package for the `Zbc` extension.
-All of the instructions in <<zbkc-sc>> have their complete specification included
-in this document, including those _not_ present in the initial
-Bitmanip ratification package.
-This is to make the present specification complete as a standalone document.
-Inevitably there might be small divergences between the Bitmanip and
-Scalar Cryptography specification documents as they move at different
-paces.
-When this happens, assume that the Bitmanip specification has the
-most up-to-date version of Bitmanip instructions.
-This is an unfortunate but necessary stop-gap while Scalar Cryptography
-and Bitmanip are being rapidly iterated on prior to public review.
-
-[%header,cols="^1,^1,4,8"]
-|===
-|RV32
-|RV64
-|Mnemonic
-|Instruction
-
-| &#10003; | &#10003; |  clmul       | <<insns-clmul>>
-| &#10003; | &#10003; |  clmulh      | <<insns-clmulh-sc>>
-|===
+Please refer to <<b-st-ext.adoc#zbkc>>.
 
 [[zbkx-sc,Zbkx-sc]]
 ==== `Zbkx` - Crossbar permutation instructions
 
 These instructions are useful for implementing SBoxes in constant time, and
 potentially with DPA protections.
-These are separated from the <<zbkb-sc>> because they
+These are separated from the <<b-st-ext.adoc#zbkbc>> because they
 have an implementation overhead which cannot be amortised
 across other instructions.
 
-NOTE: All of these instructions are missing from the first Bitmanip
-ratification package.
-Hence,  all of the instructions in <<zbkx-sc>> have their complete specification
-included in this document.
-This is to make the present specification complete as a standalone document.
-Inevitably there might be small divergences between the Bitmanip and
-Scalar Cryptography specification documents as they move at different
-paces.
-When this happens, assume that the Bitmanip specification has the
-most up-to-date version of Bitmanip instructions.
-This is an unfortunate but necessary stop-gap while Scalar Cryptography
-and Bitmanip are being rapidly iterated on prior to public review.
-
-[%header,cols="^1,^1,4,8"]
-|===
-|RV32
-|RV64
-|Mnemonic
-|Instruction
-
-| &#10003; | &#10003; |  xperm8      | <<insns-xperm8>>
-| &#10003; | &#10003; |  xperm4      | <<insns-xperm4>>
-|===
+Please refer to <<b-st-ext.adoc#zbkx>>.
 
 [[zknd,Zknd]]
 ==== `Zknd` - NIST Suite: AES Decryption


### PR DESCRIPTION
Deleted duplicate data from Scalar Crypto chapter and added xrefs to the content in the Bitmanip chapter.
Fixed up the IDs and alternate text in the Bitmanip chapter.