### PR TITLE
Cleanup for of XPERM4, XPERM8, BREV8  ( https://github.com/riscv/riscv-isa-manual/issues/1518 )

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -913,7 +913,7 @@ common operations in cryptographic workloads.
 | &#10003; 
 | &#10003; 
 |  brev8       
-| <<insns-revb>>
+| <<insns-brev8>>
 
 | &#10003; 
 | &#10003; 
@@ -985,12 +985,12 @@ latency does not depend on the (secret) data being operated on.
 |&#10003;
 |&#10003;
 |xperm4 _rd_, _rs1_, _rs2_
-|<<#insns-xpermn>>
+|<<#insns-xperm4>>
 
 |&#10003;
 |&#10003;
 |xperm8 _rd_, _rs1_, _rs2_
-|<<#insns-xpermb>>
+|<<#insns-xperm8>>
 
 |===
 
@@ -2568,7 +2568,7 @@ Included in::
 |===
 
 <<<
-[#insns-revb,reftext="Reverse bits in bytes"]
+[#insns-brev8,reftext="Reverse bits in bytes"]
 ==== brev8
 
 Synopsis::
@@ -3471,7 +3471,7 @@ Included in::
 |===
 
 <<<
-[#insns-xpermb,reftext="Crossbar permutation (bytes)"]
+[#insns-xperm8,reftext="Crossbar permutation (bytes)"]
 ==== xperm8
 
 Synopsis::
@@ -3504,15 +3504,15 @@ or zero if the index into _rs2_ is out of bounds.
 Operation::
 [source,sail]
 --
-val xpermb_lookup : (bits(8), xlenbits) -> bits(8)
-function xpermb_lookup (idx, lut) = {
+val xperm8_lookup : (bits(8), xlenbits) -> bits(8)
+function xperm8_lookup (idx, lut) = {
     (lut >> (idx @ 0b000))[7..0]
 }
 
-function clause execute ( XPERM_B (rs2,rs1,rd)) = {
+function clause execute ( XPERM8 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
     foreach(i from 0 to xlen by 8) {
-        result[i+7..i] = xpermn_lookup(X(rs2)[i+7..i], X(rs1));
+        result[i+7..i] = xperm8_lookup(X(rs2)[i+7..i], X(rs1));
     };
     X(rd) = result;
     RETIRE_SUCCESS
@@ -3532,7 +3532,7 @@ Included in::
 |===
 
 <<<
-[#insns-xpermn,reftext="Crossbar permutation (nibbles)"]
+[#insns-xperm4,reftext="Crossbar permutation (nibbles)"]
 ==== xperm4
 
 Synopsis::
@@ -3565,15 +3565,15 @@ or zero if the index into _rs2_ is out of bounds.
 Operation::
 [source,sail]
 --
-val xpermn_lookup : (bits(4), xlenbits) -> bits(4)
-function xpermn_lookup (idx, lut) = {
+val xperm4_lookup : (bits(4), xlenbits) -> bits(4)
+function xperm4_lookup (idx, lut) = {
     (lut >> (idx @ 0b00))[3..0]
 }
 
-function clause execute ( XPERM_N (rs2,rs1,rd)) = {
+function clause execute ( XPERM4 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
     foreach(i from 0 to xlen by 4) {
-        result[i+3..i] = xpermn_lookup(X(rs2)[i+3..i], X(rs1));
+        result[i+3..i] = xperm4_lookup(X(rs2)[i+3..i], X(rs1));
     };
     X(rd) = result;
     RETIRE_SUCCESS

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -1231,14 +1231,14 @@ Included in::
 
 <<<
 
-[#insns-brev8,reftext="Reverse bits in bytes"]
+[#insns-brev8-sc,reftext="Reverse bits in bytes"]
 ==== brev8
 
 Synopsis::
 Reverse the bits in each byte of a source register.
 
 Mnemonic::
-brev8, _rd_, _rs_
+brev8 _rd_, _rs_
 
 Encoding::
 [wavedrom, , svg]
@@ -1246,29 +1246,21 @@ Encoding::
 {reg:[
     { bits:  7, name: 0x13, attr: ['OP-IMM'] },
     { bits:  5, name: 'rd' },
-    { bits:  3, name: 0x65 },
+    { bits:  3, name: 0x5 },
     { bits:  5, name: 'rs' },
-    { bits:  12, name: 0x687 },
+    { bits: 12, name: 0x687 }
 ]}
 ....
 
 Description:: 
 This instruction reverses the order of the bits in every byte of a register.
 
-[NOTE]
-====
-This instruction is a specific encoding of a more generic instruction which was originally
-proposed as part of the RISC-V Bitmanip extension (grevi). Eventually, the more generic
-instruction may be standardised. Until then, only the most common instances of it, such as
-this, are being included in specifications.
-====
-
 Operation::
 [source,sail]
 --
 result : xlenbits = EXTZ(0b0);
 foreach (i from 0 to sizeof(xlen) by 8) {
-result[i+7..i] = reverse_bits_in_byte(X(rs1)[i+7..i]);
+    result[i+7..i] = reverse_bits_in_byte(X(rs1)[i+7..i]);
 };
 X(rd) = result;
 --
@@ -3346,48 +3338,51 @@ Included in::
 |===
 
 <<<
-[#insns-xperm8,reftext="Crossbar permutation (bytes)"]
+[#insns-xperm8-sc,reftext="Crossbar permutation (bytes)"]
 ==== xperm8
 
 Synopsis::
-Byte-wise lookup of indicies into a vector.
+Byte-wise lookup of indices into a vector in registers.
 
 Mnemonic::
-xprem8 _rd_, _rs1_, _rs2_
+xperm8 _rd_, _rs1_, _rs2_
 
 Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  2, name: 0x3 },
-    { bits:  5, name: 0xC },
-    { bits:  5, name: 'rd'},
-    { bits:  3, name: 0x4 },
-    { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
-    { bits:  7, name: 0x14 },
+{bits: 2, name: 0x3},
+{bits: 5, name: 0xc},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x4},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x14},
 ]}
 ....
 
 Description:: 
-The xperm8 instruction operates on bytes. The rs1 register contains a vector of XLEN/8 8-bit elements. The
-rs2 register contains a vector of XLEN/8 8-bit indexes. The result is each element in rs2 replaced by the
-indexed element in rs1, or zero if the index into rs2 is out of bounds.
+The xperm8 instruction operates on bytes.
+The _rs1_ register contains a vector of XLEN/8 8-bit elements.
+The _rs2_ register contains a vector of XLEN/8 8-bit indexes.
+The result is each element in _rs2_ replaced by the indexed element in _rs1_,
+or zero if the index into _rs2_ is out of bounds.
 
 Operation::
 [source,sail]
 --
 val xperm8_lookup : (bits(8), xlenbits) -> bits(8)
 function xperm8_lookup (idx, lut) = {
-(lut >> (idx @ 0b000))[7..0]
+    (lut >> (idx @ 0b000))[7..0]
 }
-function clause execute ( XPERM_8 (rs2,rs1,rd)) = {
-result : xlenbits = EXTZ(0b0);
-foreach(i from 0 to xlen by 8) {
-result[i+7..i] = xperm8_lookup(X(rs2)[i+7..i], X(rs1));
-};
-X(rd) = result;
-RETIRE_SUCCESS
+
+function clause execute ( XPERM8 (rs2,rs1,rd)) = {
+    result : xlenbits = EXTZ(0b0);
+    foreach(i from 0 to xlen by 8) {
+        result[i+7..i] = xperm8_lookup(X(rs2)[i+7..i], X(rs1));
+    };
+    X(rd) = result;
+    RETIRE_SUCCESS
 }
 --
 
@@ -3398,18 +3393,18 @@ Included in::
 |Minimum version
 |Lifecycle state
 
-|Zbkx (<<#zbkx-sc>>)
-|v1.0.0-rc4
+|Zbkx (<<#zbkx>>)
+|v1.0
 |Ratified
 |===
 
 <<<
 
-[#insns-xperm4,reftext="Crossbar permutation (nibbles)"]
+[#insns-xperm4-sc,reftext="Crossbar permutation (nibbles)"]
 ==== xperm4
 
 Synopsis::
-Nibble-wise lookup of indicies into a vector.
+Nibble-wise lookup of indices into a vector.
 
 Mnemonic::
 xperm4 _rd_, _rs1_, _rs2_
@@ -3418,35 +3413,38 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  2, name: 0x3 },
-    { bits:  5, name: 0xC },
-    { bits:  5, name: 'rd'},
-    { bits:  3, name: 0x2 },
-    { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
-    { bits:  7, name: 0x14 },
+{bits: 2, name: 0x3},
+{bits: 5, name: 0xc},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x2},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x14},
 ]}
 ....
 
 Description:: 
-The xperm4 instruction operates on nibbles. The rs1 register contains a vector of XLEN/4 4-bit elements.
-The rs2 register contains a vector of XLEN/4 4-bit indexes. The result is each element in rs2 replaced by the
-indexed element in rs1, or zero if the index into rs2 is out of bounds.
+The xperm4 instruction operates on nibbles.
+The _rs1_ register contains a vector of XLEN/4 4-bit elements.
+The _rs2_ register contains a vector of XLEN/4 4-bit indexes.
+The result is each element in _rs2_ replaced by the indexed element in _rs1_,
+or zero if the index into _rs2_ is out of bounds.
 
 Operation::
 [source,sail]
 --
 val xperm4_lookup : (bits(4), xlenbits) -> bits(4)
 function xperm4_lookup (idx, lut) = {
-(lut >> (idx @ 0b00))[3..0]
+    (lut >> (idx @ 0b00))[3..0]
 }
-function clause execute ( XPERM_4 (rs2,rs1,rd)) = {
-result : xlenbits = EXTZ(0b0);
-foreach(i from 0 to xlen by 4) {
-result[i+3..i] = xperm4_lookup(X(rs2)[i+3..i], X(rs1));
-};
-X(rd) = result;
-RETIRE_SUCCESS
+
+function clause execute ( XPERM4 (rs2,rs1,rd)) = {
+    result : xlenbits = EXTZ(0b0);
+    foreach(i from 0 to xlen by 4) {
+        result[i+3..i] = xperm4_lookup(X(rs2)[i+3..i], X(rs1));
+    };
+    X(rd) = result;
+    RETIRE_SUCCESS
 }
 --
 
@@ -3457,8 +3455,8 @@ Included in::
 |Minimum version
 |Lifecycle state
 
-|Zbkx (<<#zbkx-sc>>)
-|v1.0.0-rc4
+|Zbkx (<<#zbkx>>)
+|v1.0
 |Ratified
 |===
 
@@ -4179,8 +4177,8 @@ specific instances of `grevi`, `shfli` and `unshfli` respectively.
 
 | &#10003; | &#10003; |  clmul       | <<insns-clmul-sc>>
 | &#10003; | &#10003; |  clmulh      | <<insns-clmulh-sc>>
-| &#10003; | &#10003; |  xperm4      | <<insns-xperm4>>
-| &#10003; | &#10003; |  xperm8      | <<insns-xperm8>>
+| &#10003; | &#10003; |  xperm4      | <<insns-xperm4-sc>>
+| &#10003; | &#10003; |  xperm8      | <<insns-xperm8-sc>>
 | &#10003; | &#10003; |  ror         | <<insns-ror-sc>>
 | &#10003; | &#10003; |  rol         | <<insns-rol-sc>>
 | &#10003; | &#10003; |  rori        | <<insns-rori-sc>>
@@ -4193,7 +4191,7 @@ specific instances of `grevi`, `shfli` and `unshfli` respectively.
 | &#10003; | &#10003; |  pack        | <<insns-pack-sc>>
 | &#10003; | &#10003; |  packh       | <<insns-packh-sc>>
 |          | &#10003; |  packw       | <<insns-packw-sc>>
-| &#10003; | &#10003; |  brev8       | <<insns-brev8>>
+| &#10003; | &#10003; |  brev8       | <<insns-brev8-sc>>
 | &#10003; | &#10003; |  rev8        | <<insns-rev8-sc>>
 | &#10003; |          |  zip         | <<insns-zip-sc>>
 | &#10003; |          |  unzip       | <<insns-unzip-sc>>


### PR DESCRIPTION
Related to https://github.com/riscv/riscv-isa-manual/issues/1518
- synced contents of xperm4,xperm8,brev8 but didn't combine them yet
- consistent internal labels, function names
- misc typos. xprem8 -> perm8,  removed -rc4 from versions, apparent bug in xperm8 sailcode (called xperm_n)
