### PR TITLE
Add notes about semihosting NOPs; clarify there is only one semihosting exit NOP

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -1064,6 +1064,5 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 |SLTU |_rd_=`x0` |latexmath:[$2^{10}$]
 |===
 
-NOTE: Vendors that allocate `slli x0, x0, 0x1f` or `srai x0, x0, 7` as custom
-HINTs should take note of their use in semihosting calls, as described in
-<<ecall-ebreak>>.
+TIP: When allocating `slli x0, x0, 0x1f` or `srai x0, x0, 7` as custom HINTs,
+take note of their use in semihosting calls, as described in <<ecall-ebreak>>.

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -865,6 +865,7 @@ ignore the _predecessor_ and _successor_ fields and always execute a
 conservative fence on all operations.
 ====
 
+[[ecall-ebreak]]
 === Environment Call and Breakpoints
 `SYSTEM` instructions are used to access system functionality that might
 require privileged access and are encoded using the I-type instruction
@@ -924,7 +925,7 @@ to distinguish a semihosting EBREAK from a debugger inserted EBREAK.
 ....
     slli x0, x0, 0x1f   # Entry NOP
     ebreak              # Break to debugger
-    srai x0, x0, 7      # NOP encoding the semihosting call number 7
+    srai x0, x0, 7      # Exit NOP
 ....
 
 Note that these three instructions must be 32-bit-wide instructions,
@@ -1063,3 +1064,6 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 |SLTU |_rd_=`x0` |latexmath:[$2^{10}$]
 |===
 
+NOTE: Vendors that allocate `slli x0, x0, 0x1f` or `srai x0, x0, 7` as custom
+HINTs should take note of their use in semihosting calls, as described in
+<<ecall-ebreak>>.


### PR DESCRIPTION
These non-normative clarifications were made in response to architecture review of the semihosting spec.