### PR TITLE
Clarify that only read-only accesses to the seed CSR are forbidden

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -3569,8 +3569,8 @@ The write value (in `rs1` or `uimm`) must be ignored by implementations.
 The purpose of the write is to signal polling and flushing.
 
 The instruction `csrrw rd, seed, x0` can be used for fetching seed status
-and entropy values. It is available on both RV32 and RV64 base architectures
-and will zero-extend the 32-bit word to XLEN bits.
+and entropy values.
+It is available on both RV32 and RV64 base architectures.
 
 Encoding::
 [wavedrom, , svg]

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -3562,14 +3562,15 @@ The 32-bit contents of `seed` are as follows:
 |`15: 0` |`entropy` |16 bits of randomness, only when `OPST=ES16`.
 |=======================================================================
 
-The `seed` CSR must be accessed with a read-write instruction. A read-only
-instruction such as `CSRRS/CSRRC` with `rs1=x0` or `CSRRSI/CSRRCI` with
-`uimm=0` will raise an illegal instruction exception.
+Attempts to access the `seed` CSR using a read-only CSR-access instruction
+(`CSRRS`/`CSRRC` with `rs1=x0` or `CSRRSI`/`CSRRCI` with `uimm=0`) raise an
+illegal instruction exception; any other CSR-access instruction may be used
+to access `seed`.
 The write value (in `rs1` or `uimm`) must be ignored by implementations.
 The purpose of the write is to signal polling and flushing.
 
-The instruction `csrrw rd, seed, x0` can be used for fetching seed status
-and entropy values.
+Software normally uses the instruction `csrrw rd, seed, x0` to read the `seed`
+CSR.
 
 Encoding::
 [wavedrom, , svg]

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -3570,7 +3570,6 @@ The purpose of the write is to signal polling and flushing.
 
 The instruction `csrrw rd, seed, x0` can be used for fetching seed status
 and entropy values.
-It is available on both RV32 and RV64 base architectures.
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
Write-only accesses are legal (though not useful).

See https://github.com/riscv-software-src/riscv-isa-sim/issues/1728