### PR TITLE
Clarify that MXR affects explicit memory accesses only

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1233,7 +1233,7 @@ controls the privilege level of the access. The explicit memory access
 is done as though in VU-mode when SPVP=0, and as though in VS-mode when
 SPVP=1. As usual when V=1, two-stage address translation is applied, and
 the HS-level `sstatus`.SUM is ignored. HS-level `sstatus`.MXR makes
-execute-only pages readable for both stages of address translation
+execute-only pages readable by explicit loads for both stages of address translation
 (VS-stage and G-stage), whereas `vsstatus`.MXR affects only the first
 translation stage (VS-stage).
 
@@ -1601,7 +1601,7 @@ there is no option to disable two-stage address translation when V=1,
 either stage of translation can be effectively disabled by zeroing the
 corresponding `vsatp` or `hgatp` register.
 
-The `vsstatus` field MXR, which makes execute-only pages readable, only
+The `vsstatus` field MXR, which makes execute-only pages readable by explicit loads, only
 overrides VS-stage page protection. Setting MXR at VS-level does not
 override guest-physical page protections. Setting MXR at HS-level,
 however, overrides both VS-stage and G-stage execute-only permissions.

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -118,6 +118,7 @@ be set to a nonzero value but sometimes not.
 * Replaced the concept of vacant memory regions with inaccessible memory or I/O regions.
 * Clarified that timer and count-overflow interrupts' arrival in
   interrupt-pending registers is not immediate.
+* Clarified that MXR affects only explicit memory accesses.
 
 [.big]*_Preface to Version 20211203_*
 


### PR DESCRIPTION
This matches what the sstatus.MXR field definition already says: it affects loads, rather than reads.

Resolves #1061

cc @elithist