### PR TITLE
Typo change imm to nzimm.

### DIFF
--- a/src/images/wavedrom/c-integer-const-gen.adoc
+++ b/src/images/wavedrom/c-integer-const-gen.adoc
@@ -4,7 +4,7 @@
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C1', 'C1']},
-  {bits: 5, name: 'imm[4:0]',    attr: ['5','imm[4:0]','imm[16:12]']},
+  {bits: 5, name: 'imm[4:0]',    attr: ['5','imm[4:0]','nzimm[16:12]']},
   {bits: 5, name: 'rd',     attr: ['5','dest != 0', 'dest != {0, 2}']},
   {bits: 1, name: 'imm[5]',    attr: ['1','imm[5]', 'nzimm[17]'],},
   {bits: 3, name: 'funct3',    attr: ['3','C.LI', 'C.LUI'],},


### PR DESCRIPTION
For C.LUI, imm[16:12] should be nzimm[16:12].  This matches the LaTeX spec and was a typo.