### PR TITLE
Typos fix in naming.adoc and hypervisor.adoc

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -803,7 +803,7 @@ are documented in <<tinst-vals>>.
 .Hypervisor trap instruction (`htinst`) register.
 include::images/bytefield/htinstreg.edn[]
 
-`htinst` is a *WARL* register that need only be able to hold the values that
+`htinst` is a *WARL* register that only needs to be able to hold the values that
 the implementation may automatically write to it on a trap.
 
 [[hgatp]]
@@ -1583,7 +1583,7 @@ are documented in <<tinst-vals>>.
 .Machine trap instruction (`mtinst`) register.
 include::images/bytefield/mtinstreg.edn[]
 
-`mtinst` is a *WARL* register that need only be able to hold the values that
+`mtinst` is a *WARL* register that only needs to be able to hold the values that
 the implementation may automatically write to it on a trap.
 
 [[two-stage-translation]]

--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -115,7 +115,7 @@ with the letters "Sh".
 If multiple hypervisor-level extensions are listed, they should be ordered
 alphabetically.
 
-NOTE: Many augmentations to the hypervisor-level archtecture are more
+NOTE: Many augmentations to the hypervisor-level architecture are more
 naturally defined as supervisor-level extensions, following the scheme
 described in the previous section.
 The "Sh" prefix is used by the few hypervisor-level extensions that have no


### PR DESCRIPTION
Fixes #1550 