### PR TITLE
Partially revert "Typos fix in naming.adoc and hypervisor.adoc"

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -803,7 +803,7 @@ are documented in <<tinst-vals>>.
 .Hypervisor trap instruction (`htinst`) register.
 include::images/bytefield/htinstreg.edn[]
 
-`htinst` is a *WARL* register that only needs to be able to hold the values that
+`htinst` is a *WARL* register that need only be able to hold the values that
 the implementation may automatically write to it on a trap.
 
 [[hgatp]]
@@ -1583,7 +1583,7 @@ are documented in <<tinst-vals>>.
 .Machine trap instruction (`mtinst`) register.
 include::images/bytefield/mtinstreg.edn[]
 
-`mtinst` is a *WARL* register that only needs to be able to hold the values that
+`mtinst` is a *WARL* register that need only be able to hold the values that
 the implementation may automatically write to it on a trap.
 
 [[two-stage-translation]]


### PR DESCRIPTION
This partially reverts commit 7880c719c1331eb6951baadeb20f442a7bb214c6.

"X need only be Y" is grammatically correct.