### PR TITLE
Define JR, RET pseudoinstructions

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -456,6 +456,12 @@ instruction following the jump (`pc`+4) is written to register _rd_.
 Register `x0` can be used as the destination if the result is not
 required.
 
+Plain unconditional indirect jumps (assembler pseudoinstruction JR) are
+encoded as a JALR with _rd_=`x0`.
+Procedure returns in the standard calling convention (assembler
+pseudoinstruction RET) are encoded as a JALR with _rd_=`x0`, _rs1_=`x1`, and
+_imm_=0.
+
 include::images/wavedrom/ct-unconditional-2.adoc[]
 [[ct-unconditional-2]]
 //.The indirect unconditional-jump instruction, JALR


### PR DESCRIPTION
Symmetric with defining J pseudoinstruction earlier in the same section.

Resolves #1253