### PR TITLE
[scalar-crypto] Fix typo issue

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4659,7 +4659,7 @@ a write operation on this particular CSR.
 A blocking instruction may have been easier to use, but most users should
 be querying a (D)RBG instead of an entropy source.
 Without a polling-style mechanism, the entropy source could hang for
-thousands of cycles under some circumstances. A `wfi` ot `pause`
+thousands of cycles under some circumstances. A `wfi` or `pause`
 mechanism (at least potentially) allows energy-saving sleep on MCUs
 and context switching on higher-end CPUs.
 


### PR DESCRIPTION
Original text: "A wfi ot pause mechanism..."
The 'ot' should be changed to 'or'