### PR TITLE
Clarify that misaligned atomicity granule PMA applies to the compress…

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2783,11 +2783,12 @@ MAG16 indicates the misaligned atomicity granule is at least 16 bytes.
 
 The misaligned atomicity granule PMA applies only to AMOs, loads and stores
 defined in the base ISAs, and loads and stores of no more than MXLEN bits
-defined in the F, D, and Q extensions.
-For an instruction in that set, if all accessed bytes lie within the same
-misaligned atomicity granule, the instruction will not raise an exception for
-reasons of address alignment, and the instruction will give rise to only one
-memory operation for the purposes of RVWMO--i.e., it will execute atomically.
+defined in the F, D, and Q extensions. It also applies to the compressed
+encodings of them. For an instruction in that set, if all accessed bytes lie
+within the same misaligned atomicity granule, the instruction will not raise
+an exception for reasons of address alignment, and the instruction will give
+rise to only one memory operation for the purposes of RVWMO--i.e., it will
+execute atomically.
 
 If a misaligned AMO accesses a region that does not specify a misaligned
 atomicity granule PMA, or if not all accessed bytes lie within the same


### PR DESCRIPTION
We are supporting zama16b in QEMU. A comment from QEMU commnunity that we should clarify that it applies to compressed encodings(https://mail.gnu.org/archive/html/qemu-riscv/2024-07/msg00411.html). Current specification is a little confusing. 