### PR TITLE
Add missing "else" in SSAMOSWAP pseudocode

### DIFF
--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -773,7 +773,7 @@ data values.
 ----
   if privilege_mode != M && menvcfg.SSE == 0
       raise illegal-instruction exception
-  if S-mode not implemented
+  else if S-mode not implemented
       raise illegal-instruction exception
   else if privilege_mode == U && senvcfg.SSE == 0
       raise illegal-instruction exception
@@ -797,7 +797,7 @@ address in `rs1`.
 ----
   if privilege_mode != M && menvcfg.SSE == 0
       raise illegal-instruction exception
-  if S-mode not implemented
+  else if S-mode not implemented
       raise illegal-instruction exception
   else if privilege_mode == U && senvcfg.SSE == 0
       raise illegal-instruction exception


### PR DESCRIPTION
This doesn't change the meaning of the pseudocode because "raise" is presumably a terminal statement, but it makes the code easier to read.

h/t @tsaiyenting