### PR TITLE
Parallelize the CI builds

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -53,7 +53,7 @@ jobs:
       if: steps.pull_container_image.outcome == 'success'
       run: |
         docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-        /bin/sh -c 'make'
+        /bin/sh -c "make -j$(nproc)"
 
     # Upload the riscv-privileged PDF file
     - name: Upload riscv-privileged.pdf

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -36,7 +36,7 @@ jobs:
       if: steps.pull_container_image.outcome == 'success'
       run: |
           docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-          /bin/sh -c 'make'
+          /bin/sh -c "make -j$(nproc)"
 
     # Upload the riscv-privileged PDF file
     - name: Upload riscv-privileged.pdf


### PR DESCRIPTION
GitHub Actions runners are multicores; take advantage of that.