### PR TITLE
Fix Typos on hypervisor.adoc

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -2481,7 +2481,7 @@ with the encodings of basic loads and stores, as illustrated by
 <<pseudoinsts-basis>>.
 
 [[pseudoinsts-basis]]
-.Standard instructions corresponding to the special psudoinstructions of <<pseudoinsts>>.
+.Standard instructions corresponding to the special pseudoinstructions of <<pseudoinsts>>.
 [%autowidth,float="center",align="center",cols="<,<",options="header"]
 |===
 |Encoding |Instruction


### PR DESCRIPTION
I forgot to change this typo mentioned by @somyadashora in #1550 in last PR, sorry for that.