### PR TITLE
Clarify interaction of CBOs and PBMTs

### DIFF
--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -772,6 +772,13 @@ The following instructions comprise the Zicbom extension:
 
 |===
 
+[NOTE]
+====
+_Cache-block management instructions ignore cacheability attributes and operate
+on the cache block irrespective of the PMA cacheable attribute and any Page-Based
+Memory Type (PBMT) downgrade from cacheable to non-cacheable._
+====
+
 [#Zicboz,reftext="Cache-Block Zero Instructions"]
 ==== Cache-Block Zero Instructions
 


### PR DESCRIPTION
The behaviour can be technically inferred from this paragraph - as noted in one of the comments on that issue:

> Accessing the same location using different cacheability attributes may cause loss of coherence. Executing the following sequence between such accesses prevents both loss of coherence and loss of memory ordering: `fence iorw, iorw`, followed by `cbo.flush` to an address of that location, followed by a `fence iorw, iorw`.

However this is subtle, which means implementation bugs are likely. Making it explicit removes the risk of confusion and the resulting bugs.