### PR TITLE
Update smcntrpmf.adoc

### DIFF
--- a/src/smcntrpmf.adoc
+++ b/src/smcntrpmf.adoc
@@ -34,7 +34,7 @@ mcyclecfg and minstretcfg are 64-bit registers that configure privilege mode fil
 
 When all __x__INH bits are zero, event counting is enabled in all modes.
 
-For each bit in 61:58, if the associated privilege mode is not implemented, the bit is read-only zero.  Bits 57:56 are reserved for possible future modes.  
+For each bit in 61:58, if the associated privilege mode is not implemented, the bit is read-only zero.
 
 For RV32, bits 63:32 of mcyclecfg can be accessed via the mcyclecfgh CSR, and bits 63:32 of minstretcfg can be accessed via the minstretcfgh CSR.
 


### PR DESCRIPTION
Remove claim that minstretcfg/mcyclecfg bits 57:56 are reserved for future priv modes