### PR TITLE
Use standard "depends upon" verbage rather than "requires"

### DIFF
--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -308,7 +308,7 @@ This extension provides the minimal set of instructions needed to enable scalar 
 of the BF16 format. It enables BF16 as an interchange format as it provides conversion
 between BF16 values and FP32 values. 
 
-This extension requires the single-precision floating-point extension
+This extension depends upon the single-precision floating-point extension
 `F`, and the `FLH`, `FSH`, `FMV.X.H`, and `FMV.H.X` instructions as
 defined in the `Zfh` extension.
 
@@ -372,7 +372,7 @@ This extension provides the minimal set of instructions needed to enable vector 
 format. It enables BF16 as an interchange format as it provides conversion between BF16 values
 and FP32 values.
 
-This extension requires either the
+This extension depends upon either the
 "V" extension or the `Zve32f` embedded vector extension.
 
 [NOTE]
@@ -428,7 +428,7 @@ the desired rounding mode.
 This extension provides
 a vector widening BF16 mul-add instruction that accumulates into FP32. 
 
-This extension requires the `Zvfbfmin` extension and the `Zfbfmin` extension.
+This extension depends upon the `Zvfbfmin` extension and the `Zfbfmin` extension.
 
 [%autowidth]
 [%header,cols="2,4"]

--- a/src/zfinx.adoc
+++ b/src/zfinx.adoc
@@ -64,7 +64,7 @@ registers is compatible with the existing RV64 calling conventions, which leave 
 === Zdinx
 
 The Zdinx extension provides analogous double-precision floating-point
-instructions. The Zdinx extension requires the Zfinx extension.
+instructions. The Zdinx extension depends upon the Zfinx extension.
 
 The Zdinx extension adds all of the instructions that the D extension
 adds, _except_ for the transfer instructions FLD, FSD, FMV.D.X, FMV.X.D,
@@ -105,7 +105,7 @@ however.
 === Zhinx
 
 The Zhinx extension provides analogous half-precision floating-point
-instructions. The Zhinx extension requires the Zfinx extension.
+instructions. The Zhinx extension depends upon the Zfinx extension.
 
 The Zhinx extension adds all of the instructions that the Zfh extension
 adds, _except_ for the transfer instructions FLH, FSH, FMV.H.X, and
@@ -120,7 +120,7 @@ number.
 
 The Zhinxmin extension provides minimal support for 16-bit
 half-precision floating-point instructions that operate on the `x`
-registers. The Zhinxmin extension requires the Zfinx extension.
+registers. The Zhinxmin extension depends upon the Zfinx extension.
 
 The Zhinxmin extension includes the following instructions from the
 Zhinx extension: FCVT.S.H and FCVT.H.S. If the Zdinx extension is

--- a/src/zimop.adoc
+++ b/src/zimop.adoc
@@ -74,7 +74,7 @@ are defined to _not_ write any register.
 Their encoding allows future extensions to define them to read register
 `x[__n__]`.
 
-The Zcmop extension requires the Zca extension.
+The Zcmop extension depends upon the Zca extension.
 
 include::images/wavedrom/c-mop.adoc[]
 [[c-mop]]


### PR DESCRIPTION
This fixes the few instances of "requires" I found in the spec.

References:
https://github.com/riscv/riscv-v-spec/issues/723#issuecomment-949542444
https://github.com/riscv/riscv-v-spec/commit/e8594a7b9f4c22d3c02e2cdf81ad5db8d0bb8c01
https://github.com/riscv/riscv-isa-manual/blob/399c9a759eb4540a65c60e2cc236164821ff2346/src/naming.tex#L46

cc @aswaterman 