### PR TITLE
Remove references from titles.

### DIFF
--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -27,15 +27,16 @@ include::../docs-resources/global-config.adoc[]
 :example-caption: Example
 :listing-caption: Listing
 :sectnums:
+:sectnumlevels: 5
 :toc: left
-:toclevels: 5
+:toclevels: 5 
 :source-highlighter: pygments
 ifdef::backend-pdf[]
 :source-highlighter: rouge
 endif::[]
 :table-caption: Table
 :figure-caption: Figure
-:xrefstyle: short
+:xrefstyle: full 
 :chapter-refsig: Chapter
 :section-refsig: Section
 :appendix-refsig: Appendix

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -36,7 +36,7 @@ ifdef::backend-pdf[]
 endif::[]
 :table-caption: Table
 :figure-caption: Figure
-:xrefstyle: full 
+:xrefstyle: short 
 :chapter-refsig: Chapter
 :section-refsig: Section
 :appendix-refsig: Appendix

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4633,7 +4633,9 @@ refreshed (reseeded) for forward and backward security.
 
 ==== Specific Rationale and Considerations
 
-===== (<<crypto_scalar_seed_csr>>) The `seed` CSR 
+=====  The `seed` CSR 
+
+See <<crypto_scalar_seed_csr>>.
 
 The interface was designed to be simple so that a vendor- and
 device-independent driver component (e.g., in Linux kernel,
@@ -4669,7 +4671,9 @@ conditioning discussed in <<crypto_scalar_appx_es_crypto-cond>>),
 and the desire to have all of the bits "in the same place" on
 both RV32 and RV64 architectures for programming convenience.
 
-===== (<<crypto_scalar_es_req_90b>>) NIST SP 800-90B
+===== NIST SP 800-90B
+
+See <<crypto_scalar_es_req_90b>>.
 
 SP 800-90C cite:[BaKeRo:21] states that each conditioned block of n bits
 is required to have n+64 bits of input entropy to attain full entropy.
@@ -4700,7 +4704,9 @@ Section 4.4 of cite:[TuBaKe:18]: the repetition count test and adaptive
 proportion test, or show that the same flaws will be detected
 by vendor-defined tests.
 
-===== (<<crypto_scalar_es_req_ptg2>>) BSI AIS-31
+===== BSI AIS-31
+
+See <<crypto_scalar_es_req_ptg2>>.
 
 PTG.2 is one of the security and functionality classes defined in
 BSI AIS 20/31 cite:[KiSc11]. The PTG.2 source requirements work as a
@@ -4733,7 +4739,9 @@ PTG.2 modules built and certified to the AIS-31 standard can also meet the
 "full entropy" condition after 2:1 cryptographic conditioning, but not
 necessarily so. The technical validation process is somewhat different.
 
-===== (<<crypto_scalar_es_req_virt>>) Virtual Sources
+===== Virtual Sources
+
+<<crypto_scalar_es_req_virt>>.
 
 All sources that are not direct physical sources (meeting the SP 800-90B
 or the AIS-31 PTG.2 requirements) need to meet the security requirements
@@ -4749,7 +4757,9 @@ standards and applications. The 256-bit requirement maps to
 in Suite B and the newer U.S. Government CNSA Suite cite:[NS15].
 
 [[crypto_scalar_appx_es_access]]
-===== (<<crypto_scalar_es_access>>) Security Considerations for Direct Hardware Access
+===== Security Considerations for Direct Hardware Access
+
+<<crypto_scalar_es_access>>.
 
 The ISA implementation and system design must try to ensure that the
 hardware-software interface minimizes avenues for adversarial


### PR DESCRIPTION
Moving references from titles as they break section numbering and the TOC.  Moved the reference beneath the title it was in.

See section 34.8.3.1, 34.8.3.2, 34.8.3.3, and 34.8.3.4