### PR TITLE
Add missing values to mepc values table

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1813,6 +1813,9 @@ _Designated for platform use_
 0 +
 0 +
 0 +
+0 +
+0 +
+0 +
 0
 |0 +
 1 +


### PR DESCRIPTION
Apparently, values in the first column were not specified when several rows were added to the table.

Right now, this table looks like this:
<details>

![firefox_1BVBnHAuDj](https://github.com/user-attachments/assets/7fc2b4fd-c4c7-4d10-9254-2f86b9c530a5)

</details>