### PR TITLE
Fix scountovf exception behavior in smcdeleg.adoc

### DIFF
--- a/src/smcdeleg.adoc
+++ b/src/smcdeleg.adoc
@@ -130,7 +130,7 @@ raise a virtual instruction exception.
 === Virtualizing `scountovf`
 
 For implementations that support Smcdeleg/Ssccfg, Sscofpmf, and the H
-extension, when `menvcfg`.CDE=1, attempts to access `scountovf` from VS-mode
+extension, when `menvcfg`.CDE=1, attempts to read `scountovf` from VS-mode
 or VU-mode raise a virtual instruction exception.
 
 === Virtualizing Local Counter Overflow Interrupts 


### PR DESCRIPTION
Fix bug, only get VIE on VS-mode reads, not VS-mode writes (which get IIE)