### PR TITLE
Update intro.adoc: Missreferenced chapters

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -224,7 +224,7 @@ the width of an integer register in bits (either 32 or 64).
 <<rv32e, Chapter 3>> describes the RV32E and RV64E subset variants of the
 RV32I or RV64I base instruction sets respectively, which have been added to support small
 microcontrollers, and which have half the number of integer registers.
-<<rv128, Chapter 8>> sketches a future RV128I variant of the
+<<rv128, Chapter 5>> sketches a future RV128I variant of the
 base integer instruction set supporting a flat 128-bit address space
 (XLEN=128). The base integer instruction sets use a two's-complement
 representation for signed integer values.

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -221,7 +221,7 @@ integer variants, RV32I and RV64I, described in
 <<rv32>> and <<rv64>>, which provide 32-bit
 or 64-bit address spaces respectively. We use the term XLEN to refer to
 the width of an integer register in bits (either 32 or 64).
-<<rv32e, Chapter 6>> describes the RV32E and RV64E subset variants of the
+<<rv32e, Chapter 3>> describes the RV32E and RV64E subset variants of the
 RV32I or RV64I base instruction sets respectively, which have been added to support small
 microcontrollers, and which have half the number of integer registers.
 <<rv128, Chapter 8>> sketches a future RV128I variant of the

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -221,10 +221,10 @@ integer variants, RV32I and RV64I, described in
 <<rv32>> and <<rv64>>, which provide 32-bit
 or 64-bit address spaces respectively. We use the term XLEN to refer to
 the width of an integer register in bits (either 32 or 64).
-<<rv32e, Chapter 3>> describes the RV32E and RV64E subset variants of the
+<<rv32e>> describes the RV32E and RV64E subset variants of the
 RV32I or RV64I base instruction sets respectively, which have been added to support small
 microcontrollers, and which have half the number of integer registers.
-<<rv128, Chapter 5>> sketches a future RV128I variant of the
+<<rv128>> sketches a future RV128I variant of the
 base integer instruction set supporting a flat 128-bit address space
 (XLEN=128). The base integer instruction sets use a two's-complement
 representation for signed integer values.


### PR DESCRIPTION
In section "1.3. RISC-V ISA Overview," chapters 6 and 8 are mentioned when they should have been 3 and 5, respectively. They are referenced differently from other chapters. Unlike other chapters, these have an explicit title. This modification can break the text with future changes. I don't know if this is on purpose. 
Please look into it. 
Thank you.