### PR TITLE
Fix immediate types font size for figure 2.3

### DIFF
--- a/src/images/wavedrom/immediate-variants.edn
+++ b/src/images/wavedrom/immediate-variants.edn
@@ -11,7 +11,7 @@
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 7,  name: 'funct7'}
-], config: {label: {right: 'R-Type'}}}
+], config: {fontsize: 12, label: {right: 'R-Type'}}}
 ....
 
 [wavedrom, ,svg]
@@ -22,7 +22,7 @@
   {bits: 3,  name: 'funct3'},
   {bits: 5,  name: 'rs1'},
   {bits: 12, name: 'imm[11:0]'},
-], config: {label: {right: 'I-Type'}}}
+], config: {fontsize: 12, label: {right: 'I-Type'}}}
 ....
 
 [wavedrom, ,svg]
@@ -34,7 +34,7 @@
   {bits: 5,  name: 'rs1'},
   {bits: 5,  name: 'rs2'},
   {bits: 7,  name: 'imm[11:5]'}
-], config: {label: {right: 'S-Type'}}}
+], config: {fontsize: 12, label: {right: 'S-Type'}}}
 ....
 
 [wavedrom, ,svg]
@@ -57,7 +57,7 @@
   {bits: 7,  name: 'opcode'},
   {bits: 5,  name: 'rd'},
   {bits: 20, name: 'imm[31:12]'}
-], config: {label: {right: 'U-Type'}}}
+], config: {fontsize: 12, label: {right: 'U-Type'}}}
 ....
 
 [wavedrom, ,svg]


### PR DESCRIPTION
The font size is inconsistent between different types of immediates in the figure below (compare the b and j-types with the others):

<details>

<summary> current figure 2.3 </summary>

![firefox_loANPOHf8l](https://github.com/user-attachments/assets/9e852c08-5228-4024-b177-eb11a24e43cf)

</details>

This might have been done intentionally, but in the next figure, all types have the 'fontsize: 12' setting. Note that even with this size, the brackets of some fields still collide with the bit borders. I've checked at which size the collision doesn't occur, and that size is 10 (in this figure, all types use size 11, except for the j-type, which uses size 10):

<details>

<summary> figure 2.3 size experiments</summary>

![firefox_sx1Cbkmblp](https://github.com/user-attachments/assets/7249c20d-725e-40e0-a9d8-a37712655cd6)

</details>

However, I don't think it's worth changing.

---

Additionally, I want to bring to your attention an issue with figure names. Most of them are missing now, even though they were present in the v20191213 version. However, there's a strange figure name in Figure 2.4:

<details>

<summary> current figure 2.4 </summary>

![firefox_oUiqUJrxA8](https://github.com/user-attachments/assets/1a67629f-2e35-4e16-9494-28e97f256fbf)

</details>

It appears in an odd location with a strange number. I don't understand how these names are generated, so I can't fix it by myself.