### PR TITLE
Run docker as the current user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,18 @@ ifneq ($(SKIP_DOCKER),true)
         $(shell ! docker -v 2>&1 | grep podman >/dev/null ; echo $$?)
     ifeq "$(DOCKER_IS_PODMAN)" "1"
         DOCKER_VOL_SUFFIX = :z
+    else
+        # Real Docker requires this flag so that the files it creates
+        # are owned by the current user instead of root. Podman does
+        # that by default so this flag isn't necessary.
+        DOCKER_USER_ARG := --user $(shell id -u)
     endif
 
     DOCKER_CMD = \
         docker run --rm \
             -v ${PWD}/$@.workdir:/build${DOCKER_VOL_SUFFIX} \
             -w /build \
+            $(DOCKER_USER_ARG) \
             ${DOCKER_IMG} \
             /bin/sh -c
     DOCKER_QUOTE := "


### PR DESCRIPTION
If you have real Docker (not Podman) then by default it will run everything as root, so your build directory is owned by root and the Makefile will not work at all because it tries to modify the build directory.

This adds a flag so that Asciidoctor runs as the current user in Docker instead of root.