### PR TITLE
Separate immediates into separate wavedrom files.

### DIFF
--- a/src/images/wavedrom/b-immediate.edn
+++ b/src/images/wavedrom/b-immediate.edn
@@ -1,0 +1,12 @@
+//#### B-immediate
+
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1,  name: '0'},
+  {bits: 4,  name: 'inst[11:8]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 1,  name: '[7]'},
+  {bits: 20, name: '— inst[31] —'},
+], config:{fontsize: 12, label:{right: 'B-immediate'}}}
+....

--- a/src/images/wavedrom/i-immediate.edn
+++ b/src/images/wavedrom/i-immediate.edn
@@ -12,6 +12,3 @@
 ], config:{fontsize: 12, label:{right: 'I-immediate'}}}
 ....
 
-
-
-

--- a/src/images/wavedrom/j-immediate.edn
+++ b/src/images/wavedrom/j-immediate.edn
@@ -1,0 +1,13 @@
+//#### J-immediate
+
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1,  name: '0'},
+  {bits: 4,  name: 'inst[24:21]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 1,  name: '[20]'},
+  {bits: 8,  name: 'inst[19:12]'},
+  {bits: 12, name: '— inst[31] —'},
+], config:{fontsize: 12, label:{right: 'J-immediate'}}}
+....

--- a/src/images/wavedrom/s-immediate.edn
+++ b/src/images/wavedrom/s-immediate.edn
@@ -1,0 +1,11 @@
+//#### S-immediate
+
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1,  name: '[7]'},
+  {bits: 4,  name: 'inst[11:8]'},
+  {bits: 6,  name: 'inst[30:25]'},
+  {bits: 21,  name: '— inst[31] —'},
+], config:{fontsize: 12, label:{right: 'S-immediate'}}}
+....

--- a/src/images/wavedrom/u-immediate.edn
+++ b/src/images/wavedrom/u-immediate.edn
@@ -1,0 +1,11 @@
+//#### U-immediate
+
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 12, name: '0'},
+  {bits: 8,  name: 'inst[19:12]'},
+  {bits: 11, name: 'inst[30:20]'},
+  {bits: 1,  name: '[31]'},
+], config:{fontsize: 12, label:{right: 'U-immediate'}}}
+....

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -222,9 +222,21 @@ formats and with each other.
 <<immtypes>> shows the immediates produced by
 each of the base instruction formats, and is labeled to show which
 instruction bit (inst[_y_]) produces each bit of the immediate value.
+
+<<<
+
 [[immtypes, Immediate types]]
-.Types of immediate produced by RISC-V instructions. 
-include::images/wavedrom/immediate.edn[]
+include::images/wavedrom/i-immediate.edn[]
+
+include::images/wavedrom/s-immediate.edn[]
+
+include::images/wavedrom/b-immediate.edn[]
+
+include::images/wavedrom/u-immediate.edn[]
+
+.Types of immediate produced by RISC-V instructions.
+include::images/wavedrom/j-immediate.edn[]
+
 
 The fields are labeled with the instruction bits used to construct their value.  Sign extensions always uses inst[31].
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -223,8 +223,6 @@ formats and with each other.
 each of the base instruction formats, and is labeled to show which
 instruction bit (inst[_y_]) produces each bit of the immediate value.
 
-<<<
-
 [[immtypes, Immediate types]]
 include::images/wavedrom/i-immediate.edn[]
 


### PR DESCRIPTION
This separates the immediates into separate wavedrom files which allows us to add the caption to the last immediate on the page (j-immediate) which puts it after the grouping of wavedroms correctly.