### PR TITLE
Fix range representation for C.ADDI16SP immediate

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -608,7 +608,7 @@ only valid when `_rd_≠x0`; the code points with
 C.ADDI16SP shares the opcode with C.LUI, but has a destination field of
 `x2`. C.ADDI16SP adds the non-zero sign-extended 6-bit immediate to the
 value in the stack pointer (`sp=x2`), where the immediate is scaled to
-represent multiples of 16 in the range (-512,496). C.ADDI16SP is used to
+represent multiples of 16 in the range [-512, 496]. C.ADDI16SP is used to
 adjust the stack pointer in procedure prologues and epilogues. It
 expands into `addi x2, x2, nzimm[9:4]`. C.ADDI16SP is only valid when
 _nzimm_≠0; the code point with _nzimm_=0 is reserved.


### PR DESCRIPTION
It's an inclusive range, and it should have a space after the comma.

Fixes #1633 