### PR TITLE
Fix descriptions/encodings of zip/unzip instructions

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -3382,7 +3382,8 @@ This instruction is the same as *slli* with *zext.w* performed on _rs1_ before s
 ==== unzip
 
 Synopsis::
-Implements the inverse of the zip instruction.
+Place odd and even bits of the source register into upper and lower halves of
+the destination register, respectively.
 
 Mnemonic::
 unzip _rd_, _rs_
@@ -3395,15 +3396,15 @@ Encoding::
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x5},
 {bits: 5, name: 'rs1'},
-{bits: 5, name: 0x1f},
+{bits: 5, name: 0xf},
 {bits: 7, name: 0x4},
 ]}
 ....
 
 Description:: 
-This instruction gathers bits from the high and low halves of the source
-word into odd/even bit positions in the destination word.
-It is the inverse of the <<insns-zip,zip>> instruction.
+This instruction scatters all of the odd and even bits of a source word into
+the high and low halves of a destination word.
+It is the inverse of the <<insns-zip-sc,zip>> instruction.
 This instruction is available only on RV32.
 
 Operation::
@@ -3674,8 +3675,8 @@ Included in::
 ==== zip
 
 Synopsis::
-Gather odd and even bits of the source word into upper/lower halves of the
-destination.
+Interleave upper and lower halves of the source register into odd and even
+bits of the destination register, respectivley.
 
 Mnemonic::
 zip _rd_, _rs_
@@ -3688,15 +3689,15 @@ Encoding::
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x1},
 {bits: 5, name: 'rs1'},
-{bits: 5, name: 0x1e},
+{bits: 5, name: 0xf},
 {bits: 7, name: 0x4},
 ]}
 ....
 
 Description:: 
-This instruction scatters all of the odd and even bits of a source word into
-the high and low halves of a destination word.
-It is the inverse of the <<insns-unzip,unzip>> instruction.
+This instruction gathers bits from the high and low halves of the source
+word into odd/even bit positions in the destination word.
+It is the inverse of the <<insns-unzip-sc,unzip>> instruction.
 This instruction is available only on RV32.
 
 Operation::

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -3227,7 +3227,8 @@ Included in::
 ==== unzip
 
 Synopsis::
-Implements the inverse of the zip instruction.
+Place odd and even bits of the source register into upper and lower halves of
+the destination register, respectively.
 
 Mnemonic::
 unzip _rd_, _rs_
@@ -3241,14 +3242,14 @@ Encoding::
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x5},
 {bits: 5, name: 'rs1'},
-{bits: 5, name: 0x1f},
+{bits: 5, name: 0xf},
 {bits: 7, name: 0x4},
 ]}
 ....
 
 Description:: 
-This instruction gathers bits from the high and low halves of the source
-word into odd/even bit positions in the destination word.
+This instruction scatters all of the odd and even bits of a source word into
+the high and low halves of a destination word.
 It is the inverse of the <<insns-zip-sc,zip>> instruction.
 This instruction is available only on RV32.
 
@@ -3460,8 +3461,8 @@ Included in::
 ==== zip
 
 Synopsis::
-Gather odd and even bits of the source word into upper/lower halves of the
-destination.
+Interleave upper and lower halves of the source register into odd and even
+bits of the destination register, respectivley.
 
 Mnemonic::
 zip _rd_, _rs_
@@ -3475,14 +3476,14 @@ Encoding::
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x1},
 {bits: 5, name: 'rs1'},
-{bits: 5, name: 0x1e},
+{bits: 5, name: 0xf},
 {bits: 7, name: 0x4},
 ]}
 ....
 
 Description:: 
-This instruction scatters all of the odd and even bits of a source word into
-the high and low halves of a destination word.
+This instruction gathers bits from the high and low halves of the source
+word into odd/even bit positions in the destination word.
 It is the inverse of the <<insns-unzip-sc,unzip>> instruction.
 This instruction is available only on RV32.
 


### PR DESCRIPTION
Something went wrong when these specs were integrated into the main ISA manual.  This PR restores the definitions of these instructions to the ratified ones.

Resolves #1632