### PR TITLE
change ambiguous statement in cfi section

### DIFF
--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -55,7 +55,7 @@ instruction where `rs1` is not `x1` or `x5` (i.e., not a return) is an
 _indirect-jump_.
 
 The Zicfiss and Zicfilp extensions build on these conventions and hints and
-provide backward-edge and forward-edge control flow integrity respectively. 
+provide backward-edge and forward-edge control flow integrity respectively.
 
 The Unprivileged ISA for Zicfilp extension is specified in <<unpriv-forward>>
 and for the Unprivileged ISA for Zicfiss extension is specified in
@@ -337,15 +337,15 @@ the shadow stack are compared. A mismatch of the two values is indicative of a
 subversion of the return address control variable and causes a software-check
 exception.
 
-The Zicfiss instructions are encoded using a subset of May-Be-Operation
-instructions defined by the Zimop and Zcmop extensions. This subset
-of instructions revert to their Zimop/Zcmop defined behavior when the Zicfiss
-extension is not implemented or if the extension has not been activated. A
-program that is built with Zicfiss instructions can thus continue to operate
-correctly, but without backward-edge control-flow integrity, on processors that
-do not support the Zicfiss extension or if the Zicfiss extension is not active.
-The Zicfiss extension may be activated for use individually and independently
-for each privilege mode.
+The Zicfiss instructions Pop, Push and, Read are encoded using a subset of
+May-Be-Operation instructions defined by the Zimop and Zcmop extensions.
+This subset of instructions revert to their Zimop/Zcmop defined behavior when
+the Zicfiss extension is not implemented or if the extension has not been
+activated. A program that is built with Zicfiss instructions can thus continue
+to operate correctly, but without backward-edge control-flow integrity, on
+processors that do not support the Zicfiss extension or if the Zicfiss extension
+is not active. The Zicfiss extension may be activated for use individually and
+independently for each privilege mode.
 
 Compilers should flag each object file (for example, using flags in the ELF
 attributes) to indicate if the object file has been compiled with the Zicfiss

--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -337,7 +337,7 @@ the shadow stack are compared. A mismatch of the two values is indicative of a
 subversion of the return address control variable and causes a software-check
 exception.
 
-The Zicfiss instructions Pop, Push and, Read are encoded using a subset of
+The Zicfiss instructions, except `SSAMOSWAP.W/D`, are encoded using a subset of
 May-Be-Operation instructions defined by the Zimop and Zcmop extensions.
 This subset of instructions revert to their Zimop/Zcmop defined behavior when
 the Zicfiss extension is not implemented or if the extension has not been


### PR DESCRIPTION
The Zicfiss extension add two amo instructions that are outside of the Zimop / Zcmop encoding space

Correcting the Statement so there is no ambiguity.