### PR TITLE
Update description of mtval2 in CSR table

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -273,10 +273,10 @@ SRO
 `stval` +
 `sip` +
 `scountovf`
-|Scratch register for supervisor trap handlers. +
+|Supervisor scratch register. +
 Supervisor exception program counter. +
 Supervisor trap cause. +
-Supervisor bad address or instruction. +
+Supervisor trap value. +
 Supervisor interrupt pending. +
 Supervisor count overflow.
 
@@ -366,7 +366,7 @@ HRO
 `hvip` + 
 `htinst` +
 `hgeip`
-|Hypervisor bad guest physical address. +
+|Hypervisor trap value. +
 Hypervisor interrupt pending. +
 Hypervisor virtual interrupt pending. +
 Hypervisor trap instruction (transformed). +
@@ -471,7 +471,7 @@ Virtual supervisor trap handler base address. +
 Virtual supervisor scratch register. +
 Virtual supervisor exception program counter. +
 Virtual supervisor trap cause. +
-Virtual supervisor bad address or instruction. +
+Virtual supervisor trap value. +
 Virtual supervisor interrupt pending. +
 Virtual supervisor address translation and protection.
 
@@ -570,13 +570,13 @@ MRW
 `mip` +
 `mtinst` +
 `mtval2` 
-|Scratch register for machine trap handlers. +
+|Machine scratch register. +
 Machine exception program counter. +
 Machine trap cause. +
-Machine bad address or instruction. +
+Machine trap value. +
 Machine interrupt pending. +
 Machine trap instruction (transformed). +
-Machine bad guest physical address.
+Machine second trap value.
 
 4+^|Machine Configuration
 


### PR DESCRIPTION
While it is always a guest physical address for the hypervisor
traps, when used by a double trap it holds an mcause value.

Change the description to "second trap value" to match the description
used in the section heading. While touching this line also sync the
description of the other CSRs in this part of the table as well as the
*tval registers for the other privilege levels.