### PR TITLE
In MAG definition, use XLEN rather than MXLEN

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2785,7 +2785,7 @@ Specific supported values for this PMA are represented by MAG__NN__, e.g.,
 MAG16 indicates the misaligned atomicity granule is at least 16 bytes.
 
 The misaligned atomicity granule PMA applies only to AMOs, loads and stores
-defined in the base ISAs, and loads and stores of no more than MXLEN bits
+defined in the base ISAs, and loads and stores of no more than XLEN bits
 defined in the F, D, and Q extensions.
 For an instruction in that set, if all accessed bytes lie within the same
 misaligned atomicity granule, the instruction will not raise an exception for


### PR DESCRIPTION
...because it's an unprivileged concept.  Also, in mixed-XLEN environments, the weaker constraint should prevail, the less-privileged environment doesn't even know about MXLEN.