### PR TITLE
Add a non-normative comment to clarify MXR behavior for pointer masking.

### DIFF
--- a/src/zpm.adoc
+++ b/src/zpm.adoc
@@ -150,6 +150,11 @@ MPRV and SPVP affect pointer masking as well, causing the pointer masking settin
 
 [NOTE]
 ====
+Note that this includes cases where page-based virtual memory is not in effect; i.e., although MXR has no effect on permissions checks when page-based virtual memory is not in effect, it is still used in determining whether or not pointer masking should be applied.
+====
+
+[NOTE]
+====
 Cache Management Operations (CMOs) must respect and take into account pointer masking. Otherwise, a few serious security problems can appear, including:
 
 * CBO.ZERO may work as a STORE operation. If pointer masking is not respected, it would be possible to write to memory bypassing the mask enforcement.


### PR DESCRIPTION
Adding a non-normative comment to clarify a question about the interaction of pointer masking with other portions of the privileged spec. See here for the original discussion:

https://github.com/riscv/riscv-j-extension/issues/84