### PR TITLE
Remove pseudoinstructions from B instruction table

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -452,7 +452,7 @@ The shift and add instructions do a left shift of 1, 2, or 3 because these are c
 
 While the shift and add instructions are limited to a maximum left shift of 3, the slli instruction (from the base ISA) can be used to perform similar shifts for indexing into arrays of wider elements. The slli.uw -- added in this extension -- can be used when the index is to be interpreted as an unsigned word.
 
-The following instructions (and pseudoinstructions) comprise the Zba extension:
+The following instructions comprise the Zba extension:
 
 [%header,cols="^1,^1,4,8"]
 |===
@@ -500,11 +500,6 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
 |&#10003;
 |slli.uw _rd_, _rs1_, _imm_
 |<<#insns-slli_uw>>
-
-|
-|&#10003;
-|zext.w _rd_, _rs_
-|<<#insns-add_uw>>
 
 |===
 


### PR DESCRIPTION
The defn of zext.w still exists in the add.uw section.

See #1321 