### PR TITLE
remove redundant 'rd == x0'

### DIFF
--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -46,7 +46,7 @@ register as destination, i.e., `rd != x0`. Conventionally, the link register is
 `C.JALR` is termed an _indirect-call_.
 
 The term _return_ is used to refer to a `JALR` instruction with `rd == x0` and
-with `rs1 == x1` or `rs1 == x5` and `rd == x0`. A `C.JR` instruction expands to
+with `rs1 == x1` or `rs1 == x5`. A `C.JR` instruction expands to 
 `JALR x0, 0(rs1)` and is a _return_ if `rs1 == x1` or `rs1 == x5`.
 
 The term _indirect-jump_ is used to refer to a `JALR` instruction with `rd == x0`


### PR DESCRIPTION
remove redundancy for rd == x0 in def of return

This cosmetic fix was suggested here: https://github.com/riscv/riscv-cfi/pull/229
