### PR TITLE
Improve table: Compressed instruction formats

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -243,7 +243,7 @@ encoding space for other instructions requiring fewer operand bits.
 |
 [float="left",align="left",cols="1,1,1,1,1,1,1",options="noheader"]
 !===
-2+^!15 14 13 12 2+^!11 10 9 8 7 2+^!6 5 4 3 2 ^!1 0
+^!15 14 13 ^!12 ^!11 10 ^!9 8 7 ^!6 5 ^!4 3 2 ^!1 0
 2+^!funct4 2+^!rd/rs1 2+^!rs2 ^!  op
 ^!funct3 ^!imm 2+^!rd/rs1  2+^!imm ^!  op
 ^!funct3 3+^!imm  2+^!rs2 ^!  op


### PR DESCRIPTION
Table "Compressed 16-bit RVC instruction formats" header indicating the bits corresponding to each column only aligns properly with the first row (CR format), but doesn't reflect the boundaries of other rows (for example, funct3 or rs1'), making it hard to read.

This PR fixes that by distributing the bit indexes on the table header across the "actual" table columns (unmerged cells), so that it's clear which bits each field spans in every compressed instruction format, not just CR.

This is a really minor stylistic edit that you may want to squash into a future commit (or even just apply the change manually in a future edit).