### PR TITLE
Fix list of vector crypto extensions that require SEW=64

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -477,7 +477,7 @@ The section introduces all of the  extensions in the Vector Cryptography
 Instruction Set Extension Specification.
 
 The <<zvknh,Zvknhb>> and <<zvbc>> Vector Crypto Extensions
---and accordingly the composite extensions <<Zvkn>> and <<Zvks>>--
+--and accordingly the composite extensions <<Zvkn>>, <<Zvknc>>, <<Zvkng>>, and <<Zvksc>>--
 require a Zve64x base,
 or application ("V") base Vector Extension.
 


### PR DESCRIPTION
The list of extensions that include Zvknhb and Zvbc (and therefore require support for SEW=64) was incorrect.  Fix it.