### PR TITLE
Add Ssqosid to extensions table in preface

### DIFF
--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -27,6 +27,7 @@ modules:
 *Sstc* +
 *Sscofpmf* +
 *Ssdbltrp* +
+*Ssqosid* +
 *Hypervisor ISA* +
 *Shlcofideleg* +
 *Svvptc*
@@ -50,6 +51,7 @@ _1.14_ +
 *1.0* +
 *1.0* +
 *1.0* +
+*1.0* +
 *1.0*
 
 |_Draft_ +
@@ -61,6 +63,7 @@ _1.14_ +
 *Ratified* +
 *Ratified* +
 _Draft_ +
+*Ratified* +
 *Ratified* +
 *Ratified* +
 *Ratified* +


### PR DESCRIPTION
@aswaterman - the table lists extensions in two forms. Some are listed with " Extension" following the extension string and others with just the extension string. Is one preferred? If so I can update the remaining rows to the preferred form in this PR as welll.