### PR TITLE
Clarify note that compilers may need to change vtype for vmv<nr>r.v

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4807,7 +4807,7 @@ copy.  The instructions operate as if EEW=SEW, EMUL = NREG, effective
 length `evl`= EMUL * VLEN/SEW.
 
 NOTE: These instructions are intended to aid compilers to shuffle
-vector registers without needing to know or change `vl` or `vtype`.
+vector registers without needing to know or change `vl`.
 
 NOTE: The usual property that no elements are written if `vstart` {ge} `vl`
 does not apply to these instructions.


### PR DESCRIPTION
In a similar vein to https://github.com/riscvarchive/riscv-v-spec/commit/856fe5bd1cb135c39258e6ca941bf234ae63e1b1, this note states that compilers don't need to "know or change vtype" for whole vector register moves.

There's some truth to this in that compilers can largely ignore SEW and LMUL, but ultimately they do depend on vtype and the current wording might be misleading. A compiler may in fact need to change vtype to clear vill, see: https://github.com/llvm/llvm-project/issues/114518
