### PR TITLE
Add the Missing Vector CSR in listing table

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -153,6 +153,16 @@ URW
 Floating-Point Dynamic Rounding Mode. +
 Floating-Point Control and Status Register (`frm` +`fflags`).
 
+4+^|Unprivileged Vector CSR
+
+| `0x008` | URW | `vstart` | Vector start position
+| `0x009` | URW | `vxsat`  | Fixed-Point Saturate Flag
+| `0x00A` | URW | `vxrm`   | Fixed-Point Rounding Mode
+| `0x00F` | URW | `vcsr`   | Vector control and status register
+| `0xC20` | URO | `vl`     | Vector length
+| `0xC21` | URO | `vtype`  | Vector data type register
+| `0xC22` | URO | `vlenb`  | VLEN/8 (vector register length in bytes)
+
 4+^|Unprivileged Zicfiss extension CSR
 |`0x011` +
 |URW +


### PR DESCRIPTION
Issue #1671 indicates that the listing table does not include the vector registers, so I have added them.

My source : https://github.com/riscvarchive/riscv-v-spec/blob/master/v-spec.adoc#3-vector-extension-programmers-model