### PR TITLE
Minor style fix for packh description

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -2412,7 +2412,7 @@ Encoding::
 ....
 
 Description:: 
-And the packh instruction packs the least-significant bytes of
+The packh instruction packs the least-significant bytes of
 _rs1_ and _rs2_ into the 16 least-significant bits of _rd_,
 zero extending the rest of _rd_.
 


### PR DESCRIPTION
The packh description starts with "And", likely copied over from a previous format where this description was shared with  pack. 