### PR TITLE
Explain `sscratch` is only swapped by software

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -490,8 +490,10 @@ access a counter if the corresponding bits in `scounteren` and
 The `sscratch` CSR is an SXLEN-bit read/write register, dedicated
 for use by the supervisor. Typically, `sscratch` is used to hold a
 pointer to the hart-local supervisor context while the hart is executing
-user code. At the beginning of a trap handler, `sscratch` is swapped
-with a user register to provide an initial working register.
+user code.
+
+At the beginning of a trap handler, software may use instructions like `csrrw`
+to swap `sscratch` with a user register, obtaining an initial working register.
 
 .Supervisor Scratch Register
 include::images/bytefield/sscratch.edn[]

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -491,9 +491,9 @@ The `sscratch` CSR is an SXLEN-bit read/write register, dedicated
 for use by the supervisor. Typically, `sscratch` is used to hold a
 pointer to the hart-local supervisor context while the hart is executing
 user code.
-
-At the beginning of a trap handler, software may use instructions like `csrrw`
-to swap `sscratch` with a user register, obtaining an initial working register.
+At the beginning of a trap handler, software normally uses a CSRRW
+instruction to swap `sscratch` with an integer register to obtain an
+initial working register.
 
 .Supervisor Scratch Register
 include::images/bytefield/sscratch.edn[]


### PR DESCRIPTION
Someone familiar with the interrupt handlers of other ISAs may incorrectly imagine that the current description means that RISCV cores will automatically perform the swap of `sscratch` with a user register.

This is not the case: it is a recommendation disguised as a description. Flesh it out a bit so it is less ambiguous.