### PR TITLE
docker: mount source and resources as read-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ ifneq ($(SKIP_DOCKER),true)
     DOCKER_CMD = \
         docker run --rm \
             -v ${PWD}/$@.workdir:/build${DOCKER_VOL_SUFFIX} \
+            -v ${PWD}/src:/src:ro \
+            -v ${PWD}/docs-resources:/docs-resources:ro \
             -w /build \
             $(DOCKER_USER_ARG) \
             ${DOCKER_IMG} \
@@ -58,7 +60,7 @@ endif
 WORKDIR_SETUP = \
     rm -rf $@.workdir && \
     mkdir -p $@.workdir && \
-    cp -r src docs-resources $@.workdir
+    ln -sfn ../../src ../../docs-resources $@.workdir/
 
 WORKDIR_TEARDOWN = \
     mv $@.workdir/$@ $@ && \

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -19,7 +19,7 @@ include::../docs-resources/global-config.adoc[]
 // Settings:
 :experimental:
 :reproducible:
-:imagesoutdir: images
+:imagesoutdir: {docdir}/../build/images-out
 :bibtex-file: src/resources/riscv-spec.bib
 :bibtex-order: alphabetical
 :bibtex-style: apa

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -16,7 +16,7 @@ include::../docs-resources/global-config.adoc[]
 // Settings:
 :experimental:
 :reproducible:
-:imagesoutdir: images
+:imagesoutdir: {docdir}/../build/images-out
 :bibtex-file: src/resources/riscv-spec.bib
 :bibtex-order: alphabetical
 :bibtex-style: apa


### PR DESCRIPTION
This avoids writing output files into the source tree by changing the imagesoutdir variable to point at the build tree. We can bind mount source and docs-resources as read-only into the build directory and then create symlinks to ensure the docker container sees the appropriate directory layout.

Note: imagesoutdir must be an absolute path since otherwise asciidoctor-mathemtical interprets it as a path relative to the source dir rather than the current working directory (asciidoctor-diagram does the expected thing and interprets it relative to the cwd).