### PR TITLE
[RVWMO Explanatory] Fix the figure used to illustrate atomicity axiom rule

### DIFF
--- a/src/mm-eplan.adoc
+++ b/src/mm-eplan.adoc
@@ -402,7 +402,7 @@ original hart holds the reservation.
 
 |(c) sc.d t3, t2, 0(s0) |(c) sc.d t3, t2, 0(s0) |(c) sc.w t3, t2, 0(s0) |(c) addi s0, s0, 8 
 
-|(d) sc.w t3, t2, 8(s0)|||
+||||(d) sc.w t3, t2, 0(s0)
 |====
 [[litmus_lrsdsc]]
 <<litmus_lrsdsc, Figure 4>>: In all four (independent) instances, the final  store-conditional instruction is permitted but not guaranteed to succeed.


### PR DESCRIPTION
In the latest unprivileged version, there is a bug in Figure 4 of A.3.3. Atomicity axiom.

The wrong picture is as follows:

![1](https://github.com/user-attachments/assets/ebd1464e-00bd-4cd1-9a37-13b84a005fbc)

The right picture should be:

![2](https://github.com/user-attachments/assets/a02dcee6-4a24-4309-a182-5added6bd61d)

Fix it.