### PR TITLE
Remove outdated statement that Sscofpmf is written as a diff

### DIFF
--- a/src/sstc.adoc
+++ b/src/sstc.adoc
@@ -17,10 +17,6 @@ overheads for emulating S/HS-mode timers and timer interrupt generation up in
 M-mode. Further, this extension adds a similar facility to the Hypervisor
 extension for VS-mode.
 
-To make it easy to understand the deltas from the current Priv 1.11/1.12 specs,
-this is written as the actual exact changes to be made to existing paragraphs
-of Priv spec text (or additional paragraphs within the existing text).
-
 The extension name is "Sstc" ('Ss' for Privileged arch and Supervisor-level
 extensions, and 'tc' for timecmp). This extension adds the S-level stimecmp CSR
 and the VS-level vstimecmp CSR.


### PR DESCRIPTION
This may have been true once but it doesn't appear to be the case now.

Fixes #1732 