### PR TITLE
fix field pattern of CSR mstateen0 and hstateen0 in smstateen

### DIFF
--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -182,7 +182,7 @@ read-only).
 {bits: 1, name: 'C'},
 {bits: 1, name: 'FCSR'},
 {bits: 1, name: 'JVT'},
-{bits: 52, name: 'WPRI'},
+{bits: 51, name: 'WPRI'},
 {bits: 1, name: 'CTR'},
 {bits: 1, name: 'P1P14'},
 {bits: 1, name: 'P1P13'},
@@ -203,7 +203,7 @@ read-only).
 {bits: 1, name: 'C'},
 {bits: 1, name: 'FCSR'},
 {bits: 1, name: 'JVT'},
-{bits: 52, name: 'WPRI'},
+{bits: 51, name: 'WPRI'},
 {bits: 1, name: 'CTR'},
 {bits: 2, name: 'WPRI'},
 {bits: 1, name: 'CONTEXT'},
@@ -213,7 +213,6 @@ read-only).
 {bits: 1, name: 'WPRI'},
 {bits: 1, name: 'ENVCFG'},
 {bits: 1, name: 'SE0'},
-{bits: 1, name: 'CTR'},
 ], config: {bits: 64, lanes: 4, hspace:1024}}
 ....
 


### PR DESCRIPTION
In newest [Release riscv-isa-release-f3f8a93-2024-11-28](https://github.com/riscv/riscv-isa-manual/releases/tag/riscv-isa-release-f3f8a93-2024-11-28) , the figures of `mstateen0` and `hstateen0` is incorrect, missing `SE0` field.

![image](https://github.com/user-attachments/assets/d0a4ba21-c632-400e-8b2a-b103b2e66044)
