### PR TITLE
Remove Outdated  CMO CSR note

### DIFF
--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -533,13 +533,6 @@ mechanism.
 [#csr_state,reftext="Control and Status Register State"]
 === Control and Status Register State
 
-[NOTE]
-====
-_The CMO extensions rely on state in {csrname} CSRs that will be defined in a
-future update to the privileged architecture. If this CSR update is not
-ratified, the CMO extension will define its own CSRs._
-====
-
 Three CSRs control the execution of CMO instructions:
 
 * `m{csrname}`


### PR DESCRIPTION
Fixes #1759. These changes have been incorporated into the priv manual so the note is no longer relevant or accurate. 