### PR TITLE
Check Mergeable by Label

### DIFF
--- a/.github/workflows/check-ready-to-merge.yml
+++ b/.github/workflows/check-ready-to-merge.yml
@@ -1,0 +1,21 @@
+name: 'Check Mergeable by Label'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  fail-by-label:
+    if: contains(github.event.pull_request.labels.*.name, 'Pending Ratification')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is labeled "Pending Ratification"
+        run: |
+          echo "Error: This PR is labeled as 'Pending Ratification' and cannot be merged."
+          exit 1


### PR DESCRIPTION
Check if can be merged based on the tag set. In this case, PRs with Pending Ratification cannot be merged.