### PR TITLE
Fix formatting in "RISC-V base unprivileged register state" table

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -85,10 +85,7 @@ holds the address of the current instruction.
 3+^| [.small]#x29#
 3+^| [.small]#x30#
 3+^| [.small]#x31#
-3+^| [.small]#XLEN#
-| [.small]#XLEN-1#| >| [.small]#0#
-3+^|  [.small]#pc#
-3+^| [.small]#XLEN#
+3+^| [.small]#pc#
 |===
 [NOTE]
 ====


### PR DESCRIPTION
I don't understand how those XLENs even got there.