### PR TITLE
mseccfg: Add PMM field in mseccfg CSR

### DIFF
--- a/src/images/wavedrom/mseccfg.edn
+++ b/src/images/wavedrom/mseccfg.edn
@@ -9,6 +9,8 @@
   {bits:  1, name: 'USEED'},
   {bits:  1, name: 'SSEED'},
   {bits:  1, name: 'MLPE'},
-  {bits: 53, name: 'WPRI'},
+  {bits: 21, name: 'WPRI'},
+  {bits:  2, name: 'PMM'},
+  {bits: 30, name: 'WPRI'},
 ], config:{lanes: 4, hspace:1024}}
 ....


### PR DESCRIPTION
Machine ISA says that PMM field is furnished by the Smmpm extension. However `mseccfg` CSR definition is missing `PMM` field. This commit fixes that.