### PR TITLE
Designate semihosting entry/exit HINTs as standard, not custom

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -1039,6 +1039,10 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 (_rs2_=`x4`) NTL.S1 +
 (_rs2_=`x5`) NTL.ALL
 
+|SLLI |_rd_=`x0`, _rs1_=`x0`, _shamt_=31 |1|Semihosting entry marker
+
+|SRAI |_rd_=`x0`, _rs1_=`x0`, _shamt_=7 |1|Semihosting exit marker
+
 |SUB |_rd_=`x0` |latexmath:[$2^{10}$] .11+<.^m|_Designated for future standard use_
 
 |AND |_rd_=`x0` |latexmath:[$2^{10}$]
@@ -1069,16 +1073,19 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 
 |SLTIU|_rd_=`x0` |latexmath:[$2^{17}$]
 
-|SLLI |_rd_=`x0` |latexmath:[$2^{10}$]
+|SLLI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;31 |latexmath:[$2^{10}-1$]
 
 |SRLI |_rd_=`x0` |latexmath:[$2^{10}$]
 
-|SRAI |_rd_=`x0` |latexmath:[$2^{10}$]
+|SRAI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;7 |latexmath:[$2^{10}-1$]
 
 |SLT |_rd_=`x0` |latexmath:[$2^{10}$]
 
 |SLTU |_rd_=`x0` |latexmath:[$2^{10}$]
 |===
 
-TIP: When allocating `slli x0, x0, 0x1f` or `srai x0, x0, 7` as custom HINTs,
-take note of their use in semihosting calls, as described in <<ecall-ebreak>>.
+NOTE: `slli x0, x0, 0x1f` and `srai x0, x0, 7` were previously designated as
+custom HINTs, but they have been appropriated for use in semihosting calls, as
+described in <<ecall-ebreak>>.
+To reflect their usage in practice, the base ISA spec has been changed to
+designate them as standard HINTs.

--- a/src/rv64.adoc
+++ b/src/rv64.adoc
@@ -194,6 +194,10 @@ no standard HINTs will ever be defined in this subspace.
  (_rs2_=_x4_) NTL.S1 +
  (_rs2_=_x5_) NTL.ALL
 
+|SLLI |_rd_=`x0`, _rs1_=`x0`, _shamt_=31 |1|Semihosting entry marker
+
+|SRAI |_rd_=`x0`, _rs1_=`x0`, _shamt_=7 |1|Semihosting exit marker
+
 |SUB |_rd_=_x0_ |latexmath:[$2^{10}$] .16+.^| _Designated for future standard use_
 
 |AND |_rd_=_x0_ |latexmath:[$2^{10}$]
@@ -232,11 +236,11 @@ no standard HINTs will ever be defined in this subspace.
 
 |SLTIU |_rd_=_x0_ |latexmath:[$2^{17}$]
 
-|SLLI |_rd_=_x0_ |latexmath:[$2^{11}$]
+|SLLI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;31 |latexmath:[$2^{11}-1$]
 
-|SRLI |_rd_=_x0_ |latexmath:[$2^{11}$]
+|SRLI |_rd_=`x0` |latexmath:[$2^{11}$]
 
-|SRAI |_rd_=_x0_ |latexmath:[$2^{11}$]
+|SRAI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;7 |latexmath:[$2^{11}-1$]
 
 |SLLIW |_rd_=_x0_ |latexmath:[$2^{10}$]
 
@@ -249,3 +253,8 @@ no standard HINTs will ever be defined in this subspace.
 |SLTU |_rd_=_x0_ |latexmath:[$2^{10}$]
 |===
 
+NOTE: `slli x0, x0, 0x1f` and `srai x0, x0, 7` were previously designated as
+custom HINTs, but they have been appropriated for use in semihosting calls, as
+described in <<ecall-ebreak>>.
+To reflect their usage in practice, the base ISA spec has been changed to
+designate them as standard HINTs.


### PR DESCRIPTION
See discussion on https://lists.riscv.org/g/tech-unprivileged/message/968 and https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/MudQz5KF78I/m/zII13eWIAAAJ