### PR TITLE
Fix parentheses in mstatus SD description

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1135,7 +1135,7 @@ additional microarchitectural bits might be maintained in the extension
 to further reduce context save and restore overhead.
 
 The SD bit is read-only and is set when either the FS, VS, or XS bits
-encode a Dirty state (i.e., SD=\((FS==11) OR (XS==11) OR (VS==11))). This
+encode a Dirty state (i.e., `SD=(FS==0b11 OR XS==0b11 OR VS==0b11)`). This
 allows privileged code to quickly determine when no additional context
 save is required beyond the integer register set and `pc`.
 

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1135,7 +1135,7 @@ additional microarchitectural bits might be maintained in the extension
 to further reduce context save and restore overhead.
 
 The SD bit is read-only and is set when either the FS, VS, or XS bits
-encode a Dirty state (i.e., SD=((FS==11) OR (XS==11) OR (VS==11))). This
+encode a Dirty state (i.e., SD=\((FS==11) OR (XS==11) OR (VS==11))). This
 allows privileged code to quickly determine when no additional context
 save is required beyond the integer register set and `pc`.
 


### PR DESCRIPTION
Repeated parentheses were not escaped, so they were not displayed correctly.