### PR TITLE
fix: alloy6 language migration

### DIFF
--- a/src/mm-formal.adoc
+++ b/src/mm-formal.adoc
@@ -243,7 +243,7 @@ pred restrict_to_current_encodings {
 // =Alloy shortcuts=
 pred acyclic[rel: Event->Event] { no iden & ^rel }
 pred total[rel: Event->Event, bag: Event] {
-  all disj e, e': bag | e->e' in rel + ~rel
+  all disj e, f: bag | e->f in rel + ~rel
   acyclic[rel]
 }
 ....


### PR DESCRIPTION
The alloy tool for specifying the formal memory model has been updated to [version 6](https://alloytools.org/alloy6.html). The single quote has been introduced as a new operator, so the old notation no longer compiles. This ensures the formal memory spec still works under the new alloy 6.