### PR TITLE
Fix hard-coded section references

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -909,7 +909,7 @@ valid for certain operands; when invalid, they are marked either _RES_
 to indicate that the opcode is reserved for future standard extensions;
 _Custom_ to indicate that the opcode is designated for custom
 extensions; or _HINT_ to indicate that the opcode is reserved for
-microarchitectural hints (see <<rvc-hints, Section 18.7>>).
+microarchitectural hints (see <<rvc-hints>>).
 
 <<<
 

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -172,7 +172,7 @@ responsibility ends if the hart is terminated. The following events
 constitute forward progress:
 
 * The retirement of an instruction.
-* A trap, as defined in <<trap-defn, Section 1.6>>.
+* A trap, as defined in <<trap-defn>>.
 * Any other event defined by an extension to constitute forward
 progress.
 

--- a/src/mm-formal.adoc
+++ b/src/mm-formal.adoc
@@ -8,11 +8,10 @@ discrepancies are unintended; the expectation is that the models
 describe exactly the same sets of legal behaviors.
 
 This appendix should be treated as commentary; all normative material is
-provided in <<memorymodel, Chapter 17>> and in the rest of
-the main body of the ISA specification. All currently known
-discrepancies are listed in
-<<discrepancies, Section A.7>>. Any other
-discrepancies are unintentional.
+provided in <<memorymodel>> and in the rest of
+the main body of the ISA specification.
+All currently known discrepancies are listed in <<discrepancies>>.
+Any other discrepancies are unintentional.
 
 [[alloy]]
 === Formal Axiomatic Specification in Alloy

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -2017,7 +2017,7 @@ Included in::
 
 Synopsis::
 Implements the Sigma0 transformation function as used in
-the SHA2-256 hash function cite:[nist:fips:180:4] (Section 4.1.2).
+the SHA2-256 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha256sig0 rd, rs1
@@ -2083,7 +2083,7 @@ Included in::
 
 Synopsis::
 Implements the Sigma1 transformation function as used in
-the SHA2-256 hash function cite:[nist:fips:180:4] (Section 4.1.2).
+the SHA2-256 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha256sig1 rd, rs1
@@ -2149,7 +2149,7 @@ Included in::
 
 Synopsis::
 Implements the Sum0 transformation function as used in
-the SHA2-256 hash function cite:[nist:fips:180:4] (Section 4.1.2).
+the SHA2-256 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha256sum0 rd, rs1
@@ -2215,7 +2215,7 @@ Included in::
 
 Synopsis::
 Implements the Sum1 transformation function as used in
-the SHA2-256 hash function cite:[nist:fips:180:4] (Section 4.1.2).
+the SHA2-256 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha256sum1 rd, rs1
@@ -2281,7 +2281,7 @@ Included in::
 
 Synopsis::
 Implements the _high half_ of the Sigma0 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig0h rd, rs1, rs2
@@ -2355,7 +2355,7 @@ Included in::
 
 Synopsis::
 Implements the _low half_ of the Sigma0 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig0l rd, rs1, rs2
@@ -2429,7 +2429,7 @@ Included in::
 
 Synopsis::
 Implements the _high half_ of the Sigma1 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig1h rd, rs1, rs2
@@ -2503,7 +2503,7 @@ Included in::
 
 Synopsis::
 Implements the _low half_ of the Sigma1 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig1l rd, rs1, rs2
@@ -2577,7 +2577,7 @@ Included in::
 
 Synopsis::
 Implements the Sum0 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sum0r rd, rs1, rs2
@@ -2651,7 +2651,7 @@ Included in::
 
 Synopsis::
 Implements the Sum1 transformation, as
-used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+used in the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sum1r rd, rs1, rs2
@@ -2725,7 +2725,7 @@ Included in::
 
 Synopsis::
 Implements the Sigma0 transformation function as used in
-the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig0 rd, rs1
@@ -2785,7 +2785,7 @@ Included in::
 
 Synopsis::
 Implements the Sigma1 transformation function as used in
-the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sig1 rd, rs1
@@ -2845,7 +2845,7 @@ Included in::
 
 Synopsis::
 Implements the Sum0 transformation function as used in
-the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sum0 rd, rs1
@@ -2905,7 +2905,7 @@ Included in::
 
 Synopsis::
 Implements the Sum1 transformation function as used in
-the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
+the SHA2-512 hash function cite:[nist:fips:180:4].
 
 Mnemonic::
 sha512sum1 rd, rs1

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4237,7 +4237,7 @@ contributed to the RISC-V cryptography extension.
 
 Many of the primitive operations used in symmetric key cryptography
 and cryptographic hash functions are well supported by the
-RISC-V Bitmanip cite:[riscv:bitmanip:repo] extensions.
+RISC-V Bitmanip extensions (see <<bits>>).
 
 NOTE: This section repeats much of the information in
 <<zbkb-sc>>,
@@ -4267,8 +4267,7 @@ RV32, RV64:                         RV64 only:
     rori   rd, rs1, imm                 roriw  rd, rs1, imm
 ----
 
-See cite:[riscv:bitmanip:draft] (Section 3.1.1) for details of
-these instructions.
+See <<zbkb>> for details of these instructions.
 
 .Notes to software developers
 [NOTE,caption="SH"]
@@ -4286,24 +4285,12 @@ class of block ciphers and stream ciphers.
 ===== Bit & Byte Permutations
 
 ----
-RV32:
-    brev8   rd, rs1 // grevi rd, rs1,  7 - Reverse bits in bytes
-    rev8    rd, rs1 // grevi rd, rs1, 24 - Reverse bytes in 32-bit word
-
-RV64:
-    brev8   rd, rs1 // grevi rd, rs1,  7 - Reverse bits in bytes
-    rev8    rd, rs1 // grevi rd, rs1, 56 - Reverse bytes in 64-bit word
+RV32, RV64:
+    brev8   rd, rs1
+    rev8    rd, rs1
 ----
 
-The scalar cryptography extension provides the following instructions for
-manipulating the bit and byte endianness of data.
-They are all parameterisations of the Generalised Reverse with Immediate
-(`grevi` instruction.
-The scalar cryptography extension requires _only_ the above instances
-of `grevi` be implemented, which can be invoked via their pseudoinstructions.
-
-The full specification of the `grevi` instruction is available in
-cite:[riscv:bitmanip:draft] (Section 2.2.2).
+See <<zbkb>> for details of these instructions.
 
 .Notes to software developers
 [NOTE,caption="SH"]
@@ -4316,19 +4303,11 @@ of Galois/Counter Mode (GCM) cite:[nist:gcm].
 
 ----
 RV32:
-    zip     rd, rs1 // shfli   rd, rs1, 15 - Bit interleave
-    unzip   rd, rs1 // unshfli rd, rs1, 15 - Bit de-interleave
+    zip     rd, rs1
+    unzip   rd, rs1
 ----
 
-The `zip` and `unzip` pseudoinstructions are specific instances of
-the more general `shfli` and `unshfli` instructions.
-The scalar cryptography extension requires _only_ the above instances
-of `[un]shfli` be implemented, which can be invoked via their
-pseudoinstructions.
-Only RV32 implementations require these instructions.
-
-The full specification of the `shfli` instruction is available in
-cite:[riscv:bitmanip:draft] (Section 2.2.3).
+See <<zbkb>> for details of these instructions.
 
 .Notes to software developers
 [NOTE,caption="SH"]
@@ -4349,8 +4328,7 @@ RV32, RV64:
     clmulh rd, rs1, rs2
 ----
 
-See cite:[riscv:bitmanip:draft] (Section 2.6) for details of
-this instruction.
+See <<zbkc>> for details of these instructions.
 See <<crypto_scalar_zkt>> for additional implementation
 requirements for these instructions, related to data independent
 execution latency.
@@ -4374,8 +4352,7 @@ RV32, RV64:
     xnor rd, rs1, rs2
 ----
 
-See cite:[riscv:bitmanip:draft] (Section 2.1.3) for details of
-these instructions.
+See <<zbkb>> for details of these instructions.
 These instructions are useful inside hash functions, block ciphers and
 for implementing software based side-channel countermeasures like masking.
 The `andn` instruction is also useful for constant time word-select
@@ -4398,8 +4375,7 @@ RV32, RV64:                         RV64:
     packh  rd, rs1, rs2
 ----
 
-See cite:[riscv:bitmanip:draft] (Section 2.1.4) for details of
-these instructions.
+See <<zbkb>> for details of these instructions.
 
 .Notes to software developers
 [NOTE,caption="SH"]
@@ -4422,8 +4398,7 @@ RV32, RV64:
     xperm8 rd, rs1, rs2
 ----
 
-See cite:[riscv:bitmanip:draft] (Section 2.2.4) for a complete
-description of this instruction.
+See <<zbkx>> for a complete description of these instructions.
 
 The `xperm4` instruction operates on nibbles.
 `GPR[rs1]` contains a vector of `XLEN/4` 4-bit elements.

--- a/src/zpm.adoc
+++ b/src/zpm.adoc
@@ -17,7 +17,7 @@ While we describe the high-level concepts of pointer masking as if it was a sing
 
 ==== Definitions
 
-We now define basic terms. Note that these rely on the definition of an “ignore” transformation, which is defined in Chapter 2.2.
+We now define basic terms. Note that these rely on the definition of an “ignore” transformation, which is defined in <<sec-ignore-transform>>.
 
 * **Effective address (as defined in the RISC-V Base ISA):** A load/store effective address sent to the memory subsystem (e.g., as generated during the execution of load/store instructions). This does not include addresses corresponding to implicit accesses, such as page table walks.
 
@@ -33,6 +33,7 @@ We now define basic terms. Note that these rely on the definition of an “ignor
 
 * **VBITS:** The bits within a virtual address that affect which memory is addressed. These are the bits of an address which are used to index into page tables.
 
+[[sec-ignore-transform]]
 ==== The “Ignore” Transformation
 
 The ignore transformation differs depending on whether it applies to a virtual or physical address. For virtual addresses, it replaces the upper PMLEN bits with the sign extension of the PMLEN+1st bit.


### PR DESCRIPTION
Always use the `<<section-reference>>` style instead of writing a particular number, since the number will become incorrect before your next breath.

For scalar crypto, this resulted in some stylistic changes and removal of outdated contextual information (e.g. references to the never-ratified `grevi` bit-manipulation instruction).

In most other cases, the changes were mechanical.