### PR TITLE
Undo special formatting of compressed integer reg-reg expansions

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -733,34 +733,34 @@ These instructions use the CA format.
 `C.AND` computes the bitwise `AND` of the values in registers
 _rd′_ and _rs2′_, then writes the result
 to register _rd′_. `C.AND` expands into
-*`_and rd′, rd′, rs2′_`*.
+`and rd′, rd′, rs2′`.
 
 `C.OR` computes the bitwise `OR` of the values in registers
 _rd′_ and _rs2′_, then writes the result
 to register _rd′_. `C.OR` expands into
-*`_or rd&#8242;, rd&#8242;, rs2&#8242;_`*.
+`or rd′, rd′, rs2′`.
 
 `C.XOR` computes the bitwise `XOR` of the values in registers
 _rd′_ and _rs2′_, then writes the result
 to register _rd′_. `C.XOR` expands into
-*`_xor rd′, rd′, rs2′_`*.
+`xor rd′, rd′, rs2′`.
 
 `C.SUB` subtracts the value in register _rs2′_ from the
 value in register _rd′_, then writes the result to
 register _rd′_. `C.SUB` expands into
-*`_sub rd′, rd′, rs2′_`*.
+`sub rd′, rd′, rs2′`.
 
 `C.ADDW` is an RV64C/RV128C-only instruction that adds the values in
 registers _rd′_ and _rs2′_, then
 sign-extends the lower 32 bits of the sum before writing the result to
 register _rd′_. `C.ADDW` expands into
-*`_addw rd′, rd′, rs2′_`*.
+`addw rd′, rd′, rs2′`.
 
 `C.SUBW` is an RV64C/RV128C-only instruction that subtracts the value in
 register _rs2′_ from the value in register
 _rd′_, then sign-extends the lower 32 bits of the
 difference before writing the result to register _rd′_.
-`C.SUBW` expands into *`_subw rd′, rd′, rs2′_`*.
+`C.SUBW` expands into `subw rd′, rd′, rs2′`.
 
 [NOTE]
 ====


### PR DESCRIPTION
No reason for these six instructions to be formatted differently.