### PR TITLE
Move non-normative parts of "A" extensions (atomics) into NOTE block

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -227,8 +227,6 @@ instruction unless the _rl_ bit is also set. LR._rl_ and SC._aq_
 instructions are not guaranteed to provide any stronger ordering than
 those with both bits clear, but may result in lower performance.
 
-<<<
-
 [NOTE]
 ====
 [[cas]]
@@ -446,8 +444,6 @@ order the lock acquisition before the critical section, and the second
 AMO is marked _rl_ to order the critical section before the lock
 relinquishment.
 
-<<<
-
 [[critical]]
 [source,asm]
 .Sample code for mutual exclusion. `a0` contains the address of the lock.
@@ -462,7 +458,7 @@ relinquishment.
         # ...
         amoswap.w.rl x0, x0, (a0) # Release lock by storing 0.
 
-We recommend the use of the AMO Swap idiom shown above for both lock
+We recommend the use of the AMO Swap idiom shown in <<critical>> for both lock
 acquire and release to simplify the implementation of speculative lock
 elision. cite:[Rajwar:2001:SLE]
 ====

--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -229,6 +229,8 @@ those with both bits clear, but may result in lower performance.
 
 <<<
 
+[NOTE]
+====
 [[cas]]
 [source,asm]
 .Sample code for compare-and-swap function using LR/SC.
@@ -250,6 +252,7 @@ those with both bits clear, but may result in lower performance.
 LR/SC can be used to construct lock-free data structures. An example
 using LR/SC to implement a compare-and-swap function is shown in
 <<cas>>. If inlined, compare-and-swap functionality need only take four instructions.
+====
 
 [[sec:lrscseq]]
 === Eventual Success of Store-Conditional Instructions
@@ -434,6 +437,8 @@ both imply additional unnecessary ordering as compared to AMOs with the
 corresponding _aq_ or _rl_ bit set.
 ====
 
+[NOTE]
+====
 An example code sequence for a critical section guarded by a
 test-and-test-and-set spinlock is shown in
 Example <<critical>>. Note the first AMO is marked _aq_ to
@@ -457,8 +462,6 @@ relinquishment.
         # ...
         amoswap.w.rl x0, x0, (a0) # Release lock by storing 0.
 
-[NOTE]
-====
 We recommend the use of the AMO Swap idiom shown above for both lock
 acquire and release to simplify the implementation of speculative lock
 elision. cite:[Rajwar:2001:SLE]


### PR DESCRIPTION
Most of the series moves non-normative text into notes, but the last patch also removes page breaks before examples as I found it hard to read otherwise.

It doesn't bring the ISA manual any closer to being ISO worthy, but I hope it'll at least be easier to understand until then.
I stumbled upon this issue thanks to https://github.com/riscv/riscv-isa-manual/issues/1814 and tried hard to avoid any controversial changes.