### PR TITLE
Fetch Instruction/Category clarification

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -833,10 +833,10 @@ FENCE.
 [float="center",align="center",cols="^1,^1,<3",options="header"]
 .Fence mode encoding
 |===
-|_fm_ field |Mnemonic |Meaning
+|_fm_ field |Mnemonic suffix|Meaning
 |0000 |_none_ |Normal Fence
-|1000 |TSO |With `FENCE RW,RW`: exclude write-to-read ordering; otherwise: _Reserved for future use._
-2+|_other_ |_Reserved for future use._
+|1000 |.TSO |With `FENCE RW,RW`: exclude write-to-read ordering; otherwise: _Reserved for future use._
+|_other_|_other_ |_Reserved for future use._
 |===
 
 The fence mode field _fm_ defines the semantics of the `FENCE`. A `FENCE`

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -792,7 +792,7 @@ include::images/wavedrom/mem-order.edn[]
 [[mem-order]]
 //.Memory ordering instructions
 
-The FENCE instruction is used to order device I/O and memory accesses as
+FENCE instructions are used to order device I/O and memory accesses as
 viewed by other RISC-V harts and external devices or coprocessors. Any
 combination of device input (I), device output (O), memory reads \(R),
 and memory writes (W) may be ordered with respect to any combination of
@@ -802,9 +802,9 @@ any operation in the _predecessor_ set preceding the FENCE.
 <<memorymodel>> provides a precise description
 of the RISC-V memory consistency model.
 
-The FENCE instruction also orders memory reads and writes made by the
+FENCE instructions also order memory reads and writes made by the
 hart as observed by memory reads and writes made by an external device.
-However, FENCE does not order observations of events made by an external
+However, FENCE instructions do not order observations of events made by an external
 device using any other signaling mechanism.
 
 [NOTE]
@@ -813,7 +813,7 @@ A device might observe an access to a memory location via some external
 communication mechanism, e.g., a memory-mapped control register that
 drives an interrupt signal to an interrupt controller. This
 communication is outside the scope of the FENCE ordering mechanism and
-hence the FENCE instruction can provide no guarantee on when a change in
+hence FENCE instructions can provide no guarantee on when a change in
 the interrupt signal is visible to the interrupt controller. Specific
 devices might provide additional ordering guarantees to reduce software
 overhead but those are outside the scope of the RISC-V memory model.
@@ -827,7 +827,7 @@ memory-mapped I/O devices will typically be accessed with uncached loads
 and stores that are ordered using the I and O bits rather than the R and
 W bits. Instruction-set extensions might also describe new I/O
 instructions that will also be ordered using the I and O bits in a
-FENCE.
+FENCE instruction.
 
 [[fm]]
 [float="center",align="center",cols="^1,^1,<3",options="header"]
@@ -839,11 +839,11 @@ FENCE.
 |_other_|_other_ |_Reserved for future use._
 |===
 
-The fence mode field _fm_ defines the semantics of the `FENCE`. A `FENCE`
-with _fm_=`0000` orders all memory operations in its predecessor set
+The FENCE mode field _fm_ defines the semantics of the FENCE instruction. A `FENCE`
+(with _fm_=`0000`) orders all memory operations in its predecessor set
 before all memory operations in its successor set.
 
-The `FENCE.TSO` instruction is encoded as a `FENCE` instruction
+A `FENCE.TSO` instruction is encoded as a FENCE instruction
 with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`. `FENCE.TSO` orders
 all load operations in its predecessor set before all memory operations
 in its successor set, and all store operations in its predecessor set
@@ -853,17 +853,17 @@ store operations in the `FENCE.TSO's` predecessor set unordered with
 
 [NOTE]
 ====
-Because FENCE RW,RW imposes a superset of the orderings that FENCE.TSO
-imposes, it is correct to ignore the _fm_ field and implement FENCE.TSO as FENCE RW,RW.
+Because `FENCE RW,RW` imposes a superset of the orderings that `FENCE.TSO`
+imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as `FENCE RW,RW`.
 ====
 
-The unused fields in the `FENCE` instructions--_rs1_ and _rd_--are reserved
+The unused fields in the FENCE instructions--_rs1_ and _rd_--are reserved
 for finer-grain fences in future extensions. For forward compatibility,
 base implementations shall ignore these fields, and standard software
 shall zero these fields. Likewise, many _fm_ and predecessor/successor
-set settings in <<fm>> are also reserved for future use.
+set settings are also reserved for future use.
 Base implementations shall treat all such reserved configurations as
-normal fences with _fm_=0000, and standard software shall use only
+`FENCE` instructions (with _fm_=`0000`), and standard software shall use only
 non-reserved configurations.
 
 [NOTE]

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -875,7 +875,7 @@ ordering to avoid unnecessary serialization within a device-driver hart
 and also to support alternative non-memory paths to control added
 coprocessors or I/O devices. Simple implementations may additionally
 ignore the _predecessor_ and _successor_ fields and always execute a
-conservative fence on all operations.
+conservative FENCE on all operations.
 ====
 
 [[ecall-ebreak]]


### PR DESCRIPTION
I think that opcode change here makes it clear enough that FENCE instruction requires  `fm=0000 ` and given the previous wavedrom, I also think it is clear that there is room for further future uses.

@ThinkOpenly @aswaterman Do you think I should clarify the difference between Category vs Instruction more clearly?

Resolves #1782 