### PR TITLE
vstart definition clarification

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -65,7 +65,7 @@ base scalar RISC-V ISA.
 |===
 | Address | Privilege | Name   | Description
 
-| 0x008 | URW | vstart | Vector start position
+| 0x008 | URW | vstart | Vector start element index
 | 0x009 | URW | vxsat  | Fixed-Point Saturate Flag
 | 0x00A | URW | vxrm   | Fixed-Point Rounding Mode
 | 0x00F | URW | vcsr   | Vector control and status register


### PR DESCRIPTION
After reading through the RVV spec, I found "vector start position" unclear with what it refered to.

Thanks!