### PR TITLE
vmadc/vmsbc instruction clarification

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2482,9 +2482,9 @@ Encodings corresponding to the unmasked versions (`vm=1`) are reserved.
 
 `vmadc` and `vmsbc` add or subtract the source operands, optionally
 add the carry-in or subtract the borrow-in if masked (`vm=0`), and
-write the result back to mask register `vd`.  If unmasked (`vm=1`),
-there is no carry-in or borrow-in.  These instructions operate on and
-write back all body elements, even if masked.  Because these
+write the resulting carry-out or borrow-out back to mask register `vd`.  
+If unmasked (`vm=1`), there is no carry-in or borrow-in.  These instructions 
+operate on and write back all body elements, even if masked.  Because these
 instructions produce a mask value, they always operate with a
 tail-agnostic policy.
 


### PR DESCRIPTION
There appears to be a typo that suggests the instruction writes back the result of the operation rather than the carry/borrow out