### PR TITLE
Applying style guidelines and spelling to M

### DIFF
--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -1,9 +1,9 @@
 [[mstandard]]
-== "M" Extension for Integer Multiplication and Division, Version 2.0
+== `M` Extension for Integer Multiplication and Division, Version 2.0
 
-This chapter describes the standard integer multiplication and division
-instruction extension, which is named "M" and contains instructions
-that multiply or divide values held in two integer registers.
+The standard integer multiplication and division instruction extension, called 
+`M`, contains instructions that multiply or divide values held in two integer 
+registers.
 
 [NOTE]
 ====
@@ -23,12 +23,12 @@ include::images/wavedrom/m-st-ext-for-int-mult.edn[]
 (((MUL, MULHSU)))
 
 MUL performs an XLEN-bit×XLEN-bit multiplication of
-_rs1_ by _rs2_ and places the lower XLEN bits in the destination
+`rs1` by `rs2` and places the lower XLEN bits in the destination
 register. MULH, MULHU, and MULHSU perform the same multiplication but
 return the upper XLEN bits of the full 2×XLEN-bit
 product, for signed×signed,
-unsigned×unsigned, and _rs1_×unsigned _rs2_ multiplication, respectively.
-If both the high and low bits of the same product are required, then the recommended code sequence is: MULH[[S]U] _rdh, rs1, rs2_; MUL _rdl, rs1, rs2_ (source register specifiers must be in same order and _rdh_ cannot be the same as _rs1_ or _rs2_). Microarchitectures can then fuse these into a single multiply operation instead of performing two separate multiplies.
+unsigned×unsigned, and `rs1`×unsigned `rs2` multiplication.
+If both the high and low bits of the same product are required, then the recommended code sequence is: `MULH[[S]U]` `rdh`, `rs1`, `rs2`; `MUL rdl`, `rs1`, `rs2` (source register specifiers must be in same order and `rdh` cannot be the same as `rs1` or `rs2`). Microarchitectures can then fuse these into a single multiply operation instead of performing two separate multiplies.
 
 [NOTE]
 ====
@@ -59,7 +59,7 @@ include::images/wavedrom/division-op.edn[]
 (((MUL, DIVU)))
 
 DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned
-integer division of _rs1_ by _rs2_, rounding towards zero. REM and REMU
+integer division of `rs1` by `rs2`, rounding towards zero. REM and REMU
 provide the remainder of the corresponding division operation. For REM,
 the sign of a nonzero result equals the sign of the dividend.
 
@@ -71,17 +71,17 @@ latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \tex
 ====
 
 If both the quotient and remainder are required from the same division,
-the recommended code sequence is: DIV[U] _rdq, rs1, rs2_; REM[U] _rdr,
-rs1, rs2_ (_rdq_ cannot be the same as _rs1_ or _rs2_).
+the recommended code sequence is: `DIV[U]` `rdq`, `rs1`, `rs2`; `REM[U]` `rdr`,
+`rs1`, `rs2` (`rdq` cannot be the same as `rs1` or `rs2`).
 Microarchitectures can then fuse these into a single divide operation
 instead of performing two separate divides.
 
 DIVW and DIVUW are RV64 instructions that divide the lower 32 bits of
-_rs1_ by the lower 32 bits of _rs2_, treating them as signed and
-unsigned integers respectively, placing the 32-bit quotient in _rd_,
+`rs1` by the lower 32 bits of `rs2`, treating them as signed and
+unsigned integers, placing the 32-bit quotient in `rd`,
 sign-extended to 64 bits. REMW and REMUW are RV64 instructions that
-provide the corresponding signed and unsigned remainder operations
-respectively. Both REMW and REMUW always sign-extend the 32-bit result
+provide the corresponding signed and unsigned remainder operations. Both 
+REMW and REMUW always sign-extend the 32-bit result
 to 64 bits, including on a divide by zero.
 (((MUL, div by zero)))
 
@@ -119,7 +119,7 @@ We considered raising exceptions on integer divide by zero, with these
 exceptions causing a trap in most execution environments. However, this
 would be the only arithmetic trap in the standard ISA (floating-point
 exceptions set flags and write default values, but do not cause traps)
-and would require language implementors to interact with the execution
+and would require language implementers to interact with the execution
 environment's trap handlers for this case. Further, where language
 standards mandate that a divide-by-zero exception must cause an
 immediate control flow change, only a single branch instruction needs to
@@ -136,18 +136,18 @@ unsigned division circuit and specifying the same overflow result
 simplifies the hardware.
 ====
 
-=== Zmmul Extension, Version 1.0
+=== `Zmmul` Extension, Version 1.0
 
-The Zmmul extension implements the multiplication subset of the M
+The `Zmmul` extension implements the multiplication subset of the M
 extension. It adds all of the instructions defined in
 <<Multiplication Operations>>, namely: MUL, MULH, MULHU,
 MULHSU, and (for RV64 only) MULW. The encodings are identical to those
-of the corresponding M-extension instructions. M implies Zmmul.
+of the corresponding M-extension instructions. `M` implies `Zmmul`.
 (((MUL, Zmmul)))
 
 [NOTE]
 ====
-The *Zmmul* extension enables low-cost implementations that require
+The `Zmmul` extension enables low-cost implementations that require
 multiplication operations but not division. For many microcontroller
 applications, division operations are too infrequent to justify the cost
 of divider hardware. By contrast, multiplication operations are more

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -72,7 +72,7 @@ latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \tex
 
 If both the quotient and remainder are required from the same division,
 the recommended code sequence is: `DIV[U] rdq, rs1, rs2; REM[U] rdr`,
-`rs1`, `rs2` (`rdq` cannot be the same as `rs1` or `rs2`).
+`rs1, rs2` (`rdq` cannot be the same as `rs1` or `rs2`).
 Microarchitectures can then fuse these into a single divide operation
 instead of performing two separate divides.
 

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -71,7 +71,7 @@ latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \tex
 ====
 
 If both the quotient and remainder are required from the same division,
-the recommended code sequence is: `DIV[U]` `rdq`, `rs1`, `rs2`; `REM[U]` `rdr`,
+the recommended code sequence is: `DIV[U] rdq, rs1, rs2; REM[U] rdr`,
 `rs1`, `rs2` (`rdq` cannot be the same as `rs1` or `rs2`).
 Microarchitectures can then fuse these into a single divide operation
 instead of performing two separate divides.

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -28,7 +28,7 @@ register. MULH, MULHU, and MULHSU perform the same multiplication but
 return the upper XLEN bits of the full 2×XLEN-bit
 product, for signed×signed,
 unsigned×unsigned, and `rs1`×unsigned `rs2` multiplication.
-If both the high and low bits of the same product are required, then the recommended code sequence is: `MULH[[S]U]` `rdh`, `rs1`, `rs2`; `MUL rdl`, `rs1`, `rs2` (source register specifiers must be in same order and `rdh` cannot be the same as `rs1` or `rs2`). Microarchitectures can then fuse these into a single multiply operation instead of performing two separate multiplies.
+If both the high and low bits of the same product are required, then the recommended code sequence is: `MULH[[S]U] rdh, rs1, rs2; MUL rdl, rs1, rs2` (source register specifiers must be in same order and `rdh` cannot be the same as `rs1` or `rs2`). Microarchitectures can then fuse these into a single multiply operation instead of performing two separate multiplies.
 
 [NOTE]
 ====

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -1,9 +1,9 @@
 [[mstandard]]
 == `M` Extension for Integer Multiplication and Division, Version 2.0
 
-The standard integer multiplication and division instruction extension, called 
-`M`, contains instructions that multiply or divide values held in two integer 
-registers.
+This chapter describes the standard integer multiplication and division
+instruction extension, which is named `M` and contains instructions
+that multiply or divide values held in two integer registers.
 
 [NOTE]
 ====

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -71,7 +71,7 @@ latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \tex
 ====
 
 If both the quotient and remainder are required from the same division,
-the recommended code sequence is: `DIV[U] rdq, rs1, rs2; REM[U] rdr`,
+the recommended code sequence is: `DIV[U] rdq, rs1, rs2; REM[U] rdr,`
 `rs1, rs2` (`rdq` cannot be the same as `rs1` or `rs2`).
 Microarchitectures can then fuse these into a single divide operation
 instead of performing two separate divides.


### PR DESCRIPTION
This PR contains changes for the style guidelines that were discussed in the doc-sig. Style guidelines say that extension names and registers, among others should be in back ticks. 

This also fixes the old spelling of "implementors".

One thing to discuss is the code sequences. Because they are code sequences, I put the pieces into back ticks to indicate code, as you can see if the following section:

`MULH[[S]U]` `rdh`, `rs1`, `rs2`; `MUL rdl`, `rs1`, `rs2` (source register specifiers must be in same order and `rdh` cannot be the same as `rs1` or `rs2`).

but I can be convinced otherwise.
