### PR TITLE
Add initial Sail snippets

### DIFF
--- a/sail.json.url
+++ b/sail.json.url
@@ -1,0 +1,1 @@
+https://github.com/riscv/sail-riscv/releases/download/0.7/riscv_model_rv64d.json

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -55,6 +55,7 @@ endif::[]
 :approx: &#8776;
 :inf: &#8734;
 :imagesdir: images
+:sail-doc: sail.json
 
 _Contributors to all versions of the spec in alphabetical order (please contact
 editors to suggest corrections): Krste Asanović, Peter Ashenden, Rimas

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -53,6 +53,7 @@ endif::[]
 :inf: &#8734;
 :csrname: envcfg
 :imagesdir: images
+:sail-doc: sail.json
 
 _Contributors to all versions of the spec in alphabetical order (please contact editors to suggest
 corrections): Derek Atkins,

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -2997,15 +2997,8 @@ This instruction is based on work done in cite:[MJS:LWSHA:20].
 ====
 
 Operation::
-[source,sail]
---
-function clause execute (SM3P0(rs1, rd)) = {
-  let r1     : bits(32) = X(rs1)[31..0];
-  let result : bits(32) =  r1 ^ rol32(r1,  9) ^ rol32(r1, 17);
-  X(rd) = EXTS(result);
-  RETIRE_SUCCESS
-}
---
++
+sail::execute[clause="SM3P0(_, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]
@@ -3061,15 +3054,9 @@ This instruction is based on work done in cite:[MJS:LWSHA:20].
 ====
 
 Operation::
-[source,sail]
---
-function clause execute (SM3P1(rs1, rd)) = {
-  let r1     : bits(32) = X(rs1)[31..0];
-  let result : bits(32) =  r1 ^ rol32(r1, 15) ^ rol32(r1, 23);
-  X(rd) = EXTS(result);
-  RETIRE_SUCCESS
-}
---
++
+sail::execute[clause="SM3P1(_, _)",part=body,unindent]
+
 
 Included in::
 [%header,cols="4,2,2"]
@@ -3124,21 +3111,8 @@ This instruction must _always_ be implemented such that its execution
 latency does not depend on the data being operated on.
 
 Operation::
-[source,sail]
---
-function clause execute (SM4ED (bs,rs2,rs1,rd)) = {
-  let shamt : bits(5)  = bs @ 0b000; /* shamt = bs*8 */
-  let sb_in : bits(8)  = (X(rs2)[31..0] >> shamt)[7..0];
-  let x     : bits(32) = 0x000000 @ sm4_sbox(sb_in);
-  let y     : bits(32) = x ^ (x               <<  8) ^ ( x               <<  2) ^
-                             (x               << 18) ^ ((x & 0x0000003F) << 26) ^
-                             ((x & 0x000000C0) << 10);
-  let z     : bits(32) = rol32(y, unsigned(shamt));
-  let result: bits(32) = z ^ X(rs1)[31..0];
-  X(rd)                = EXTS(result);
-  RETIRE_SUCCESS
-}
---
++
+sail::execute[clause="SM4ED(_, _, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]
@@ -3193,20 +3167,8 @@ This instruction must _always_ be implemented such that its execution
 latency does not depend on the data being operated on.
 
 Operation::
-[source,sail]
---
-function clause execute (SM4KS (bs,rs2,rs1,rd)) = {
-  let shamt : bits(5)  = (bs @ 0b000); /* shamt = bs*8 */
-  let sb_in : bits(8)  = (X(rs2)[31..0] >> shamt)[7..0];
-  let x     : bits(32) = 0x000000 @ sm4_sbox(sb_in);
-  let y     : bits(32) = x ^ ((x & 0x00000007) << 29) ^ ((x & 0x000000FE) <<  7) ^
-                             ((x & 0x00000001) << 23) ^ ((x & 0x000000F8) << 13) ;
-  let z     : bits(32) = rol32(y, unsigned(shamt));
-  let result: bits(32) = z ^ X(rs1)[31..0];
-  X(rd) = EXTS(result);
-  RETIRE_SUCCESS
-}
---
++
+sail::execute[clause="SM4KS(_, _, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]


### PR DESCRIPTION
Add Makefile targets to download the Sail JSON bundle from Github releases (it's a few MB so this avoids bloating the repo).

I updated a few scalar crypto functions that already had copy & pasted Sail code to use the model source instead. The result is almost identical.

See #1369.