### PR TITLE
Changes to support building priv & unpriv as adoc "parts" in a larger adoc "book"

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -1,6 +1,12 @@
 [colophon]
-= Preface
-
+== Preface
+// Had to make the above a level 1 heading (two equals signs) to avoid error when building
+// the ISA manual as a book with other "parts". This is opposite to what the adoc says to do
+// but otherwise asciidoctor creates the error messsage:
+//
+// asciidoctor: ERROR: ext/riscv-isa-manual/src/colophon.adoc: line 2: invalid part, must have at least one section (e.g., chapter, appendix, etc.)
+//
+// See asciidoctor doc which seems wrong: https://docs.asciidoctor.org/asciidoc/latest/sections/colophon/
 
 This document describes the RISC-V unprivileged architecture.
 

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -1,5 +1,12 @@
 [colophon]
-= Preface
+== Preface
+// Had to make the above a level 1 heading (two equals signs) to avoid error when building
+// the ISA manual as a book with other "parts". This is opposite to what the adoc says to do
+// but otherwise asciidoctor creates the error messsage:
+//
+// asciidoctor: ERROR: ext/riscv-isa-manual/src/priv-preface.adoc: line 2: invalid part, must have at least one section (e.g., chapter, appendix, etc.)
+//
+// See asciidoctor doc which seems wrong: https://docs.asciidoctor.org/asciidoc/latest/sections/colophon/
 
 [.big]*_Preface to Version 20241101_*
 

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -1,4 +1,4 @@
-[[risc-v-isa]]
+[[manual:priv,RISC-V ISA Manual Volume II: Privileged Architecture]]
 = The RISC-V Instruction Set Manual: Volume II: Privileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Volume II - Privileged Architecture

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -1,4 +1,4 @@
-[[risc-v-isa]]
+[[manual:unpriv,RISC-V ISA Manual Volume I: Unprivileged Architecture]]
 = The RISC-V Instruction Set Manual Volume I: Unprivileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Unprivileged Architecture


### PR DESCRIPTION
Changed priv/unpriv manual colophons to use level 1 adoc heading (were using level 0) and created unique anchors at top of each manual (were using the same anchor).

This is required for the CSC.