### PR TITLE
Clarify that misa.S and misa.U are optionally writable

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -187,21 +187,24 @@ The design of the RV128I base ISA is not yet complete, and while much of
 the remainder of this specification is expected to apply to RV128, this
 version of the document focuses only on RV32 and RV64.
 
-The "U" and "S" bits will be set if there is support for user and
-supervisor modes respectively.
-
 The "X" bit will be set if there are any non-standard extensions.
 
 When the "B" bit is 1, the implementation supports the instructions provided by the
 Zba, Zbb, and Zbs extensions. When the "B" bit is 0, it indicates that the
-implementation may not support one or more of the Zba, Zbb, or Zbs extensions.
+implementation might not support one or more of the Zba, Zbb, or Zbs extensions.
 
 When the "M" bit is 1, the implementation supports all multiply and
 division instructions defined by the M extension. When the "M" bit
-is 0, it indicates that the implementation may not support those
+is 0, it indicates that the implementation might not support those
 instructions. However if the Zmmul extension is supported then
 the multiply instructions it specifies are supported irrespective
 of the value of the "M" bit.
+
+When the "S" bit is 1, the implementation supports supervisor mode.
+When the "S" bit is 0, the implementation might not support supervisor mode.
+
+When the "U" bit is 1, the implementation supports user mode.
+When the "U" bit is 0, the implementation might not support user mode.
 
 [NOTE]
 ====
@@ -226,6 +229,8 @@ If an ISA feature _x_ depends on an ISA feature _y_, then attempting to
 enable feature _x_ but disable feature _y_ results in both features
 being disabled. For example, setting "F"=0 and "D"=1 results in both
 "F" and "D" being cleared.
+Similarly, setting "U"=0 and "S"=1" results in both "U" and "S" being
+cleared.
 
 An implementation may impose additional constraints on the collective
 setting of two or more `misa` fields, in which case they function


### PR DESCRIPTION
This has long been the intent, but the spec didn't make this especially clear.

The proposed resolution is to clarify that these bits are writable, which is maximally inclusive of both classes of implementations: those that choose to hardwire the bits and those that choose to make them writable.

Resolves #1837 