### PR TITLE
Move anchor to fix Zvfh description

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -3718,7 +3718,6 @@ register value is copied to the destination element.
 vfmerge.vfm vd, vs2, rs1, v0  # vd[i] = v0.mask[i] ? f[rs1] : vs2[i]
 ----
 
-[[sec-vector-float-move]]
 ==== Vector Floating-Point Move Instruction
 
 The vector floating-point move instruction __splats__ a floating-point
@@ -4458,6 +4457,7 @@ destination vector register group, regardless of `vstart`.
 The encodings corresponding to the masked versions (`vm=0`) of `vmv.x.s`
 and `vmv.s.x` are reserved.
 
+[[sec-vector-float-move]]
 ==== Floating-Point Scalar Move Instructions
 
 The floating-point scalar read/write instructions transfer a single


### PR DESCRIPTION
The anchor was placed so as to suggest that vfmv.f.s/vfmv.s.f were excluded from Zvfh, which they obviously aren't.

Resolves #1853