### PR TITLE
Update machine.adoc

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -418,6 +418,7 @@ setting of the global __y__IE bit for the higher-privilege mode.
 Higher-privilege-level code can use separate per-interrupt enable bits
 to disable selected higher-privilege-mode interrupts before ceding
 control to a lower-privilege mode.
+If supervisor mode is not implemented, then SIE and SPIE are read-only 0.
 
 [NOTE]
 ====


### PR DESCRIPTION
Added a statement to clarify the behavior of mstatus.SIE and mstatus.SPIE when supervisor mode is not supported. This makes the section consistent with SPP being read-only zero when supervisor mode is not supported.

If this statement is not the intended behavior, it would be helpful to add text such as "If supervisor mode is not implemented, SIE and SPIE may be writable but have no effect on system behavior."