### PR TITLE
Clarify that the NMIs referred to in the RNMI spec are RNMIs

### DIFF
--- a/src/rnmi.adoc
+++ b/src/rnmi.adoc
@@ -39,14 +39,14 @@ non-maskable interrupt (RNMI).
 include::images/bytefield/mnscratch.edn[]
 
 The `mnscratch` CSR holds an MXLEN-bit read-write register which enables
-the NMI trap handler to save and restore the context that was
+the RNMI trap handler to save and restore the context that was
 interrupted.
 
 .Resumable NMI program counter `mnepc`.
 include::images/bytefield/mnepc.edn[]
 
 The `mnepc` CSR is an MXLEN-bit read-write register which on entry to
-the NMI trap handler holds the PC of the instruction that took the
+the RNMI trap handler holds the PC of the instruction that took the
 interrupt.
 
 The low bit of `mnepc` (`mnepc[0]`) is always zero. On implementations
@@ -68,10 +68,10 @@ of holding.
 .Resumable NMI cause `mncause`.
 include::images/bytefield/mncause.edn[]
 
-The `mncause` CSR holds the reason for the NMI.
-If the reason is an interrupt, bit MXLEN-1 is set to 1, and the NMI
+The `mncause` CSR holds the reason for the RNMI.
+If the reason is an interrupt, bit MXLEN-1 is set to 1, and the RNMI
 cause is encoded in the least-significant bits.
-If the reason is an interrupt and NMI causes are not supported, bit MXLEN-1 is
+If the reason is an interrupt and RNMI causes are not supported, bit MXLEN-1 is
 set to 1, and zero is written to the least-significant bits.
 If the reason is an exception within M-mode that results in a double trap as
 specified in the Smdbltrp extension, bit MXLEN-1 is set to 0 and the


### PR DESCRIPTION
(As opposed to UNMIs.)

Now, all references to "NMI" in this chapter are fully qualified.

Fixes https://github.com/riscv/riscv-debug-spec/issues/1107#issuecomment-2667488240