### PR TITLE
Confusing Grammer regarding frm field in vector

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2204,7 +2204,7 @@ All standard vector floating-point arithmetic operations follow the
 IEEE-754/2008 standard.  All vector floating-point operations use the
 dynamic rounding mode in the `frm` register.  Use of the `frm` field
 when it contains an invalid rounding mode by any vector floating-point
-instruction--even those that do not depend on the rounding mode, or
+instruction--even those that do not depend on the rounding mode--or
 when `vl`=0, or when `vstart` {ge} `vl`--is reserved.
 
 NOTE: All vector floating-point code will rely on a valid value in


### PR DESCRIPTION
To my understanding this section seems to be saying "use of the frm field when it contains an invalid rounding mode, vl = 0 or when vstart ≥ vl is reserved - even for instructions that dont depend on the rounding mode," but the current grammer suggests otherwise.