### PR TITLE
[#1887] clarifying Zvfbfmin/vector-crypto extension dependencies

### DIFF
--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -372,8 +372,7 @@ This extension provides the minimal set of instructions needed to enable vector 
 format. It enables BF16 as an interchange format as it provides conversion between BF16 values
 and FP32 values.
 
-This extension depends upon either the
-"V" extension or the `Zve32f` embedded vector extension.
+This extension depends upon `Zve32f` vector extension.
 
 [NOTE]
 ====

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -478,11 +478,12 @@ Instruction Set Extension Specification.
 
 The <<zvknh,Zvknhb>> and <<zvbc>> Vector Crypto Extensions
 --and accordingly the composite extensions <<Zvkn>>, <<Zvknc>>, <<Zvkng>>, and <<Zvksc>>--
-require a Zve64x base,
-or application ("V") base Vector Extension.
+depend on Zve64x.
 
-All of the other Vector Crypto Extensions can be built
-on _any_ embedded (Zve*) or application ("V") base Vector Extension.
+All of the other Vector Crypto Extensions depend on `Zve32x`.
+
+Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 8, 16, and 32. If `Zve64x` is supported then `Zvkb` or `Zvbb` also add support for EEW 64.
+
 
 // See <<crypto-vector-element-groups>> for more details on vector element groups and the drawbacks of
 // small `VLEN` values.


### PR DESCRIPTION
Addressing https://github.com/riscv/riscv-isa-manual/issues/1877

Clarifying dependencies structure for `Zvfbfmin` and the vector crypto extensions.