### PR TITLE
Clarify that hgatp field zeroing is software's responsibility

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -834,7 +834,10 @@ HSXLEN=32 and HSXLEN=64. When MODE=Bare, guest physical addresses are
 equal to supervisor physical addresses, and there is no further memory
 protection for a guest virtual machine beyond the physical memory
 protection scheme described in <<pmp>>. In this
-case, the remaining fields in `hgatp` must be set to zeros.
+case, software must write zero to the remaining fields in `hgatp`.
+Attempting to select MODE=Bare with a nonzero pattern in the remaining fields
+has an UNSPECIFIED effect on the value that the remaining fields assume and an
+UNSPECIFIED effect on G-stage address translation and protection behavior.
 
 When HSXLEN=32, the only other valid setting for MODE is Sv32x4, which
 is a modification of the usual Sv32 paged virtual-memory scheme,


### PR DESCRIPTION
Passive vs. active voice issue.

See https://github.com/riscv-software-src/riscv-isa-sim/issues/1928#issuecomment-2702746508