### PR TITLE
Fix typo on sscofpmf.adoc

### DIFF
--- a/src/sscofpmf.adoc
+++ b/src/sscofpmf.adoc
@@ -63,7 +63,7 @@ that there is no loss of information after an overflow since the counter wraps
 around and keeps counting while the sticky OF bit remains set.
 
 If supervisor mode is implemented, the 32-bit scountovf register contains
-read-only shadow copies of the OF bits in all 32 mhpmevent registers.
+read-only shadow copies of the OF bits in all 29 mhpmevent registers.
 
 If an hpmcounter overflows while the associated OF bit is zero, then a "count
 overflow interrupt request" is generated. If the OF bit is one, then no


### PR DESCRIPTION
As mentioned a few lines below the one changed, scountovf only contains the OF bits of 29 mhpmevent registers, as only 29 exist.