### PR TITLE
Change VROR_VI immediate field from imm to uimm

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -3107,10 +3107,10 @@ function clause execute (VROR_VX(vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (VROR_VI(vs2, imm[5:0], vd)) = {
+function clause execute (VROR_VI(vs2, uimm[5:0], vd)) = {
   foreach (i from vstart to vl - 1) {
     set_velem(vd, EEW=SEW, i, 
-      get_velem(vs2, i) >>> (imm[5:0] & (SEW-1))
+      get_velem(vs2, i) >>> (uimm[5:0] & (SEW-1))
     )
   }
   RETIRE_SUCCESS


### PR DESCRIPTION
The Sail code for `vror.vi` uses `imm` instead of `uimm`,  even though "uimm" is specified in the encoding.  

A correct reference is `vwsll.vi`, which properly uses `uimm`.

Please cross-check the correctness of this proposed change.
