### PR TITLE
Remove note that the Zvl*b extension names may change.

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4988,10 +4988,6 @@ NOTE: Longer vector length extensions should follow the same pattern.
 NOTE: Every vector length extension effectively includes all shorter
 vector length extensions.
 
-NOTE: The syntax for extension names is being revised, and these names
-are subject to change.  The trailing "b" will be required to
-disambiguate numeric fields from version numbers.
-
 NOTE: Explicit use of the Zvl32b extension string is not required for
 any standard vector extension as they all effectively mandate at least
 this minimum, but the string can be useful when stating hardware


### PR DESCRIPTION
The part about the trailing "b" being required is true, but I'm not sure it provides any value in this section.