### PR TITLE
Deploy a snapshot of the specification to GitHub pages

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -129,3 +129,36 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
 
+    # Create directory structure pages sites for privileged and unprivileged specs.
+    - name: Make GitHub pages directory
+      run: |
+        mkdir -p dist/snapshot/unprivileged dist/snapshot/privileged
+        cp build/riscv-unprivileged.html dist/snapshot/unprivileged/index.html
+        cp build/riscv-privileged.html dist/snapshot/privileged/index.html
+      if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    - name: Upload pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: dist
+      if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+  # Deploy HTML to Github pages.
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The RISC-V Instruction Set Manual is organized into the following volumes:
 
 - **Official versions** of the specifications are available at the [RISC-V International website](https://riscv.org/specifications/).
 - **Compiled versions of the most recent drafts** of the specifications can be found on the [GitHub releases page](https://github.com/riscv/riscv-isa-manual/releases/latest).
+- **HTML snapshots of the latest commit** can be viewed at the following locations:
+  - [Unprivileged spec](https://riscv.github.io/riscv-isa-manual/snapshot/unprivileged/)
+  - [Privileged spec](https://riscv.github.io/riscv-isa-manual/snapshot/privileged/)
 - **Older official versions** of the specifications are archived at the [GitHub releases archive](https://github.com/riscv/riscv-isa-manual/releases/tag/archive).
 
 The canonical list of **open-source RISC-V implementations' marchid CSR values** is available in the [marchid.md file](https://github.com/riscv/riscv-isa-manual/blob/main/marchid.md).


### PR DESCRIPTION
This makes it easier to view the latest snapshot without having to download a
PDF from the releases page.

I've deployed this to my github fork, so it will look as follows once deployed:
- [Unprivileged spec](https://arichardson.github.io/riscv-isa-manual/snapshot/unprivileged/).
- [Privileged spec](https://arichardson.github.io/riscv-isa-manual/snapshot/privileged/).

The HTML is deployed to a snapshot/ subdirectory to make it possible to also
deploy versioned releases in the future.

This has been very useful for the CHERI spec so far (https://riscv.github.io/riscv-cheri/). In the CHERI spec I added a warning at the top of the document that it is not a valid release:

> This document is a specification snapshot built from github.com/riscv/riscv-cheri/commit/cf51732e0bf6b2775516d168642f05dcca54652d and is not a versioned release. The latest versioned PDF release can be downloaded from github.com/riscv/riscv-cheri/releases.

If you are happy to accept this change I could also add a similar warning to the start of the document for these pages?