### PR TITLE
Fix a step reference for Sv32 address translation.

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -192,7 +192,7 @@ code with SUM clear; the few code segments that should access user
 memory can temporarily set SUM.
 
 The SUM mechanism does not avail S-mode software of permission to
-execute instructions in user code pages. Legitimate uses cases for
+execute instructions in user code pages. Legitimate use cases for
 execution from user memory in supervisor context are rare in general and
 nonexistent in POSIX environments. However, bugs in supervisors that
 lead to arbitrary code execution are much easier to exploit if the
@@ -1589,7 +1589,7 @@ _global_ mapping. To ensure that implicit reads observe writes to the
 same memory locations, an SFENCE.VMA instruction must be executed after
 the writes to flush the relevant cached translations.
 
-The address-translation cache cannot be used in step 7; accessed and
+The address-translation cache cannot be used in step 9; accessed and
 dirty bits may only be updated in memory directly.
 [NOTE]
 ====


### PR DESCRIPTION
This got out of sync due to steps added in #1742.

Also fix an unrelated typo.