### PR TITLE
[#1933] Fixed Smcntrpmf heading not showing up in riscv-privileged.pdf

### DIFF
--- a/src/smcntrpmf.adoc
+++ b/src/smcntrpmf.adoc
@@ -1,4 +1,5 @@
 [[smcntrpmf]]
+
 == "Smcntrpmf" Cycle and Instret Privilege Mode Filtering, Version 1.0
 
 === Introduction


### PR DESCRIPTION
Fixes Issue: #1933 
Fixes: 1929d45a059979c55b070fba414d97d530a44c99
Author: mmoizhussain

 On branch mmhus/fix-smcntrpmf-heading
 Changes to be committed:
	modified:   src/smcntrpmf.adoc