### PR TITLE
Add a flag to allow faster (but unreliable) incremental builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ else
         cd $@.workdir &&
 endif
 
+ifdef UNRELIABLE_BUT_FASTER_INCREMENTAL_BUILDS
+WORKDIR_SETUP = mkdir -p $@.workdir && ln -sfn ../../src ../../docs-resources $@.workdir/
+WORKDIR_TEARDOWN = mv $@.workdir/$@ $@
+else
 WORKDIR_SETUP = \
     rm -rf $@.workdir && \
     mkdir -p $@.workdir && \
@@ -66,6 +70,7 @@ WORKDIR_SETUP = \
 WORKDIR_TEARDOWN = \
     mv $@.workdir/$@ $@ && \
     rm -rf $@.workdir
+endif
 
 SRC_DIR := src
 BUILD_DIR := build


### PR DESCRIPTION
Setting UNRELIABLE_BUT_FASTER_INCREMENTAL_BUILDS=1 on the make command line
will avoid wiping the entire build directory before builds. Since each
output file uses a different build directory there should be no
need to wipe the whole build directory. The Makefile already triggers a
rebuild if any file under the source directory is modified so this should
be safe.
This significantly speeds up the build for me since we no longer regenerate
all the diagrams for each build. For the unprivileged manual the build time
goes from about 4:30 to 3:40.

However, it has been shown that non-clean builds don't always produce the
same output PDF, so this is gated by an opt-in flag.