### PR TITLE
Clarify description of constrained LR/SC loops for Zca++

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -271,9 +271,9 @@ instructions placed sequentially in memory.
 instruction. The dynamic code executed between the LR and SC
 instructions can only contain instructions from the base ''I''
 instruction set, excluding loads, stores, backward jumps, taken backward
-branches, JALR, FENCE, and SYSTEM instructions. If the ''C'' extension
-is supported, then compressed forms of the aforementioned ''I''
-instructions are also permitted.
+branches, JALR, FENCE, and SYSTEM instructions.
+Compressed forms of the aforementioned ''I'' instructions in the Zca and Zcb
+extensions are also permitted.
 * The code to retry a failing LR/SC sequence can contain backwards jumps
 and/or branches to repeat the LR/SC sequence, but otherwise has the same
 constraint as the code between the LR and SC.


### PR DESCRIPTION
This PR fixes an editing error in which "C" should have been changed to "Zca" when the various Zc extensions were incorporated.  It also clarifies that any compressed instruction, not just those in Zca, that map to one of the permitted "I" instructions can be used in a constrained LR/SC loop.  This was always the case, but it was stated obliquely.

Resolves #1938