### PR TITLE
Rename mstateen0.P1P14 to mstateen0.SRMCFG

### DIFF
--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -17,7 +17,7 @@ modules:
 [%autowidth,float="center",align="center",cols="^,<,^",options="header",]
 |===
 |Module |Version |Status
-|_Machine ISA_ +
+|*Machine ISA* +
 *Smstateen Extension* +
 *Smcsrind/Sscsrind Extension* +
 *Smepmp Extension* +
@@ -25,7 +25,7 @@ modules:
 *Smrnmi Extension* +
 *Smcdeleg Extension* +
 *Smdbltrp Extension* +
-_Supervisor ISA_ +
+*Supervisor ISA* +
 *Svade Extension* +
 *Svnapot Extension* +
 *Svpbmt Extension* +
@@ -39,7 +39,7 @@ _Supervisor ISA_ +
 *Shlcofideleg Extension* +
 *Svvptc Extension*
 
-|_1.14_ +
+|*1.13* +
 *1.0* +
 *1.0* +
 *1.0* +
@@ -47,7 +47,7 @@ _Supervisor ISA_ +
 *1.0* +
 *1.0* +
 *1.0* +
-_1.14_ +
+*1.13* +
 *1.0* +
 *1.0* +
 *1.0* +
@@ -61,7 +61,7 @@ _1.14_ +
 *1.0* +
 *1.0*
 
-|_Draft_ +
+|*Ratified* +
 *Ratified* +
 *Ratified* +
 *Ratified* +
@@ -69,7 +69,7 @@ _1.14_ +
 *Ratified* +
 *Ratified* +
 *Ratified* +
-_Draft_ +
+*Ratified* +
 *Ratified* +
 *Ratified* +
 *Ratified* +
@@ -83,22 +83,6 @@ _Draft_ +
 *Ratified* +
 *Ratified*
 |===
-
-The following changes have been made since version 1.13 of the Machine and
-Supervisor ISAs, which, while not strictly backwards compatible, are not
-anticipated to cause software portability problems in practice:
-
-* (None yet)
-
-Additionally, the following compatible changes have been
-made to the Machine and Supervisor ISAs since version 1.13:
-
-* Defined the `mstateen0` P1P14 field.
-
-Finally, the following clarifications and document improvements have been made
-since the last document release:
-
-* (None yet)
 
 [.big]*_Preface to Version 20241017_*
 

--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -184,7 +184,7 @@ read-only).
 {bits: 1, name: 'JVT'},
 {bits: 51, name: 'WPRI'},
 {bits: 1, name: 'CTR'},
-{bits: 1, name: 'P1P14'},
+{bits: 1, name: 'SRMCFG'},
 {bits: 1, name: 'P1P13'},
 {bits: 1, name: 'CONTEXT'},
 {bits: 1, name: 'IMSIC'},
@@ -292,7 +292,7 @@ extension.
 The P1P13 bit in `mstateen0` controls access to the `hedelegh` introduced by
 Privileged Specification Version 1.13.
 
-The P1P14 bit in `mstateen0` controls access to the `srmcfg` CSR introduced by
+The SRMCFG bit in `mstateen0` controls access to the `srmcfg` CSR introduced by
 the Ssqosid <<ssqosid>> extension.
 
 === Usage

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -2366,10 +2366,10 @@ modes of software execution on that hart by default, but this behavior may be
 overridden by future extensions.
 
 If extension Smstateen is implemented together with Ssqosid, then Ssqosid also
-requires the P1P14 bit in `mstateen0` to be implemented.
-If P1P14 of `mstateen0` is 0, attempts to access `srmcfg` in privilege modes
+requires the SRMCFG bit in `mstateen0` to be implemented.
+If `mstateen0`.SRMCFG is 0, attempts to access `srmcfg` in privilege modes
 less privileged than M-mode raise an illegal-instruction exception.
-If P1P14 bit of `mstateen0` is 1 or if extension Smstateen is not implemented,
+If `mstateen0`.SRMCFG is 1 or if extension Smstateen is not implemented,
 attempts to access `srmcfg` when `V=1` raise a virtual-instruction exception.
 
 [NOTE]


### PR DESCRIPTION
Since it was ratified as part of Ssqosid, there are actually no priv-1.14 changes in flight, so revert the version number to 1.13.