### PR TITLE
Specify behaviour of explicit minstreth writes

### DIFF
--- a/src/zicsr.adoc
+++ b/src/zicsr.adoc
@@ -162,6 +162,27 @@ In particular, a value
 written to `instret` by one instruction will be the value read by the
 following instruction.
 
+On RV32, 64-bit counters such as `instret` are split over multiple CSRs
+(`instret` and `instreth`). If a CSR access instruction writes to one
+of the CSRs then the other is not updated by any side effects.
+
+----
+li t0, 0xFFFFFFFF
+csrw minstret, t0
+# minstret = 0x????????FFFFFFFF
+csrw minstreth, t0
+# minstret = 0xFFFFFFFFFFFFFFFF (the lower 32 bits did not increment
+# because we explicitly wrote to the upper 32 bits)
+
+nop
+
+# minstret = 0x0000000000000000
+csrr t1, minstret
+# t1 = 0x00000000
+csrr t2, minstreth
+# t2 = 0x00000000
+----
+
 The assembler pseudoinstruction to read a CSR, CSRR _rd, csr_, is
 encoded as CSRRS _rd, csr, x0_. The assembler pseudoinstruction to write
 a CSR, CSRW _csr, rs1_, is encoded as CSRRW _x0, csr, rs1_, while CSRWI


### PR DESCRIPTION
This is the behaviour that is expected by Valtrix SPIKE. However Spike and the Sail model currently implement the alternate behaviour.

Fixes #1255