### PR TITLE
Specify behaviour of explicit minstreth writes

### DIFF
--- a/src/zicsr.adoc
+++ b/src/zicsr.adoc
@@ -162,6 +162,28 @@ In particular, a value
 written to `instret` by one instruction will be the value read by the
 following instruction.
 
+In cases where a value is split over two CSRs - such as `instret` and
+`instreth` on RV32 - the instruction execution side effects still update
+the CSR that was not explicitly written. For `instret` the full 64-bit
+value is incremented and then half of it is overwritten by the
+explicit CSR write.
+
+----
+li t0, 0xFFFFFFFF
+csrw minstret, t0
+# minstret = 0x????????FFFFFFFF
+csrw minstreth, t0
+# minstret = 0xFFFFFFFF00000000 (because the lower 32-bits incremented and overflowed)
+
+nop
+
+# minstret = 0xFFFFFFFF00000001
+csrr t1, minstret
+# t1 = 0x00000001
+csrr t2, minstreth
+# t2 = 0xFFFFFFFF
+----
+
 The assembler pseudoinstruction to read a CSR, CSRR _rd, csr_, is
 encoded as CSRRS _rd, csr, x0_. The assembler pseudoinstruction to write
 a CSR, CSRW _csr, rs1_, is encoded as CSRRW _x0, csr, rs1_, while CSRWI


### PR DESCRIPTION
This is the behaviour that is currently implemented in Spike and Sail. However Valtrix SPIKE checks the alternate behaviour.

Fixes #1255