### PR TITLE
Remove [5:4] after spimm in cm.push/pop wavedrom and assembly syntax explanation.

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -1406,11 +1406,11 @@ Encoding (RV32, RV64):
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  2, name: 0x2,             attr: ['C2'] },
-    { bits:  2, name: 'spimm\[5:4\]',  attr: [] },
-    { bits:  4, name: 'rlist',         attr: [] },
-    { bits:  5, name: 0x18,            attr: [] },
-    { bits:  3, name: 0x5,             attr: ['FUNCT3'] },
+    { bits:  2, name: 0x2,      attr: ['C2'] },
+    { bits:  2, name: 'spimm',  attr: [] },
+    { bits:  4, name: 'rlist',  attr: [] },
+    { bits:  5, name: 0x18,     attr: [] },
+    { bits:  3, name: 0x5,      attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
 
@@ -1439,7 +1439,7 @@ switch (rlist){
   case  6: {reg_list="ra, s0-s1";  xreg_list="x1, x8-x9";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1462,7 +1462,7 @@ switch (rlist){
   case 15: {reg_list="ra, s0-s11"; xreg_list="x1, x8-x9, x18-x27";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1601,11 +1601,11 @@ Encoding (RV32, RV64):
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  2, name: 0x2,             attr: ['C2'] },
-    { bits:  2, name: 'spimm\[5:4\]',  attr: [] },
-    { bits:  4, name: 'rlist',         attr: [] },
-    { bits:  5, name: 0x1a,            attr: [] },
-    { bits:  3, name: 0x5,             attr: ['FUNCT3'] },
+    { bits:  2, name: 0x2,      attr: ['C2'] },
+    { bits:  2, name: 'spimm',  attr: [] },
+    { bits:  4, name: 'rlist',  attr: [] },
+    { bits:  5, name: 0x1a,     attr: [] },
+    { bits:  3, name: 0x5,      attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
 
@@ -1634,7 +1634,7 @@ switch (rlist){
   case  6: {reg_list="ra, s0-s1";  xreg_list="x1, x8-x9";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1657,7 +1657,7 @@ switch (rlist){
   case 15: {reg_list="ra, s0-s11"; xreg_list="x1, x8-x9, x18-x27";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1826,7 +1826,7 @@ switch (rlist){
   case  6: {reg_list="ra, s0-s1";  xreg_list="x1, x8-x9";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1849,7 +1849,7 @@ switch (rlist){
   case 15: {reg_list="ra, s0-s11"; xreg_list="x1, x8-x9, x18-x27";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -1993,11 +1993,11 @@ Encoding (RV32, RV64):
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  2, name: 0x2,             attr: ['C2'] },
-    { bits:  2, name: 'spimm\[5:4\]',  attr: [] },
-    { bits:  4, name: 'rlist',         attr: [] },
-    { bits:  5, name: 0x1e,            attr: [] },
-    { bits:  3, name: 0x5,             attr: ['FUNCT3'] },
+    { bits:  2, name: 0x2,      attr: ['C2'] },
+    { bits:  2, name: 'spimm',  attr: [] },
+    { bits:  4, name: 'rlist',  attr: [] },
+    { bits:  5, name: 0x1e,     attr: [] },
+    { bits:  3, name: 0x5,      attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
 
@@ -2026,7 +2026,7 @@ switch (rlist){
   case  6: {reg_list="ra, s0-s1";  xreg_list="x1, x8-x9";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]
@@ -2049,7 +2049,7 @@ switch (rlist){
   case 15: {reg_list="ra, s0-s11"; xreg_list="x1, x8-x9, x18-x27";}
   default: reserved();
 }
-stack_adj      = stack_adj_base + spimm[5:4] * 16;
+stack_adj      = stack_adj_base + spimm * 16;
 ----
 
 [source,sail]


### PR DESCRIPTION
The text refers to spimm as "the number of additional 16-byte address increments allocated for the stack frame." and "The total stack adjustment represents the total size of the stack frame, which is stack_adj_base added to spimm scaled by 16"

The "Example RV32I PUSH/POP sequences" section shows spimm with values of 0-3.

Based on the text and those examples, I think spimm is a 2-bit value rather than a 6-bit value.