### PR TITLE
Clarify that vaadd intermediate results aren't truncated

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -3096,6 +3096,7 @@ vssub.vx vd, vs2, rs1, vm   # vector-scalar
 
 The averaging add and subtract instructions right shift the result by
 one bit and round off the result according to the setting in `vxrm`.
+Computation is performed in infinite precision before rounding and truncating.
 Both unsigned and signed versions are provided.
 For `vaaddu` and `vaadd` there can be no overflow in the result.
 For `vasub` and `vasubu`, overflow is ignored and the result wraps around.


### PR DESCRIPTION
Resolves #1957 