### PR TITLE
Add missing SSE bit in senvcfg for RV32

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -745,7 +745,7 @@ characteristics of the U-mode execution environment.
   {bits:  1, name: 'FIOM'},
   {bits:  1, name: 'WPRI'},
   {bits:  1, name: 'LPE'},
-  {bits:  1, name: 'WPRI'},
+  {bits:  1, name: 'SSE'},
   {bits:  2, name: 'CBIE'},
   {bits:  1, name: 'CBCFE'},
   {bits:  1, name: 'CBZE'},


### PR DESCRIPTION
closes #1963 