### PR TITLE
Fix a broken extension reference.

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -224,7 +224,7 @@ Please refer to <<b-st-ext.adoc#zbkc>>.
 
 These instructions are useful for implementing SBoxes in constant time, and
 potentially with DPA protections.
-These are separated from the <<b-st-ext.adoc#zbkbc>> because they
+These are separated from the <<b-st-ext.adoc#zbkb>> because they
 have an implementation overhead which cannot be amortised
 across other instructions.
 


### PR DESCRIPTION
'zbkbc' was likely a typo since no such extension exists; from the context, it probably meant 'zbkb'.