### PR TITLE
Three minor documentation tweaks

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -371,11 +371,12 @@ physical memory and some could not, which requires a new restart
 mechanism for partially executed instructions.
 * Unlike the rest of the RVC instructions, there is no IFD equivalent to
 Load Multiple and Store Multiple.
-* Unlike the rest of the RVC instructions, the compiler would have to be
-aware of these instructions to both generate the instructions and to
-allocate registers in an order to maximize the chances of the them being
-saved and stored, since they would be saved and restored in sequential
-order.
+* Unlike the rest of the RVC instructions, the compiler would have to be aware
+of these load-multiple and store-multiple instructions to both allocate
+registers in the expected order and also to schedule the loads and
+stores contiguously and in the proper order, to maximize the chances of them
+being detected and replaced by an assembler or linker with the equivalent
+load-multiple or store-multiple compressed instruction.
 * Simple microarchitectural implementations will constrain how other
 instructions can be scheduled around the load and store multiple
 instructions, leading to a potential performance loss.

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2403,9 +2403,9 @@ also raise an illegal-instruction exception when TSR=1 in `mstatus`, as
 described in <<virt-control>>. An __x__RET instruction
 can be executed in privilege mode _x_ or higher, where executing a
 lower-privilege __x__RET instruction will pop the relevant lower-privilege
-interrupt enable and privilege mode stack. Invoking MRET in a lower privilege
-level than M, or SRET in a lower privilege level than S, will raise an
-illegal-instruction exception.  In addition to manipulating
+interrupt enable and privilege mode stack. Attempting to execute an __x__RET
+instruction in a mode less privileged than _x_ will raise an
+illegal-instruction exception. In addition to manipulating
 the privilege stack as described in <<privstack>>,
 __x__RET sets the `pc` to the value stored in the `__x__epc` register.
 

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2403,7 +2403,9 @@ also raise an illegal-instruction exception when TSR=1 in `mstatus`, as
 described in <<virt-control>>. An __x__RET instruction
 can be executed in privilege mode _x_ or higher, where executing a
 lower-privilege __x__RET instruction will pop the relevant lower-privilege
-interrupt enable and privilege mode stack. In addition to manipulating
+interrupt enable and privilege mode stack. Invoking MRET in a lower privilege
+level than M, or SRET in a lower privilege level than S, will raise an
+illegal-instruction exception.  In addition to manipulating
 the privilege stack as described in <<privstack>>,
 __x__RET sets the `pc` to the value stored in the `__x__epc` register.
 

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -83,8 +83,8 @@ Therefore common ISA strings can be updated as follows to include the relevant Z
 
 MISA.C is set if the following extensions are selected:
 
-* Zca and not F
-* Zca, Zcf and F is specified (RV32 only)
+* Zca and not F (or D)
+* Zca, Zcf and F (but not D) is specified (RV32 only)
 * Zca, Zcf and Zcd if D is specified (RV32 only)
 ** this configuration excludes Zcmp, Zcmt
 * Zca, Zcd if D is specified (RV64 only)

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -83,7 +83,7 @@ Therefore common ISA strings can be updated as follows to include the relevant Z
 
 MISA.C is set if the following extensions are selected:
 
-* Zca and not F (or D)
+* Zca and not F
 * Zca, Zcf and F (but not D) is specified (RV32 only)
 * Zca, Zcf and Zcd if D is specified (RV32 only)
 ** this configuration excludes Zcmp, Zcmt


### PR DESCRIPTION
1. Invoking *ret from a too-low priv level results in illegal exception. This is otherwise not clearly stated.
2. Added clarifications around MISA.C and the D extension.
3. Rewrote a sentence discussing why we don't do load/store multiples in the C extension. See https://github.com/riscv/riscv-isa-manual/issues/1849 -- I think this will resolve that.