### PR TITLE
Fix HRM=>HRW typo for henvcfgh in priv-csrs.adoc

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -420,7 +420,7 @@ Hypervisor guest external interrupt pending.
 |`0x60A` +
 `0x61A`
 |HRW +
-HRM
+HRW
 |`henvcfg` +
 `henvcfgh`
 |Hypervisor environment configuration register. +


### PR DESCRIPTION
Hi, I'm new to RISC-V, and was learning about the architecture by skimming over the instruction set manual.
I noticed what looks like a trivial typo in Table 6 in section 2.2 of Volume II: the henvcfgh CSR is listed with a privilege of of "HRM" which appears to be a typo for "HRW".

