### PR TITLE
Updated JVT and pseudocode 

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1142,7 +1142,9 @@ read-only zeros. Else, `vsip`.SSIP and `vsie`.SSIE are aliases of
 
 The `vstvec` register is a VSXLEN-bit read/write register that is
 VS-mode’s version of supervisor register `stvec`, formatted as shown in
-<<vstvecreg>>. When V=1, `vstvec` substitutes for
+<<vstvecreg>>. Note that, similar to `mtvec` and `stvec`, the
+least-significant two bits are omitted in the field, and will be replaced
+with zeroes when used as an address, thus enforcing 4-byte alignment. When V=1, `vstvec` substitutes for
 the usual `stvec`, so instructions that normally read or modify `stvec`
 actually access `vstvec` instead. When V=0, `vstvec` does not directly
 affect the behavior of the machine.

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1182,9 +1182,11 @@ include::images/bytefield/mtvec.edn[]
 
 The `mtvec` register must always be implemented, but can contain a
 read-only value. If `mtvec` is writable, the set of values the register
-may hold can vary by implementation. The value in the BASE field must
-always be aligned on a 4-byte boundary, and the MODE setting may impose
-additional alignment constraints on the value in the BASE field.
+may hold can vary by implementation. Note that the CSR contains only bits
+XLEN-1 through 2 of the address BASE. When used as an address, the unspecified
+lower 2 bits are filled with zeroes to obtain a full XLEN-bit address that is
+always aligned on a 4-byte boundary. The MODE setting may impose additional
+alignment constraints on the value in the BASE field.
 
 [NOTE]
 ====

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -306,11 +306,10 @@ vector mode (MODE).
 .Supervisor trap vector base address (`stvec`) register.
 include::images/bytefield/stvec.edn[]
 
-The BASE field in `stvec` is a  field that can hold any valid virtual or
-physical address, subject to the following alignment constraints: the
-address must be 4-byte aligned, and MODE settings other than Direct
-might impose additional alignment constraints on the value in the BASE
-field.
+Similar to `mtvec`, the BASE field in `stvec` contains all but the least significant two bits
+(thus enforcing 4-byte alignment) of any valid virtual or
+physical address.  MODE settings other than Direct might impose additional
+alignment constraints on the value in the BASE field.
 
 [[stvec-mode]]
 .Encoding of `stvec` MODE field.

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2400,9 +2400,9 @@ The _jvt_ register is an XLEN-bit *WARL* read/write register that holds the jump
 
 If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. Note that the CSR contains only bits XLEN-1 through 6 of the address. The lower bits _base_[5:0] will be filled with zeroes for jump-table address computations, resulting in a BASE field whose address is always aligned on a 64-byte boundary.
 
-The jump table address derived from _jvt.base_ is a virtual address, whenever virtual memory is enabled.
+_jvt.base_ is a virtual address, whenever virtual memory is enabled.
 
-The memory specified by _jvt.base_ is treated as instruction memory for the purpose of executing table jump instructions, implying execute access permission.
+The memory pointed to by _jvt.base_ is treated as instruction memory for the purpose of executing table jump instructions, implying execute access permission.
 
 [#JVT-config-table]
 ._jvt.mode_ definition

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2398,11 +2398,11 @@ Description:
 
 The _jvt_ register is an XLEN-bit *WARL* read/write register that holds the jump table configuration, consisting of the jump table base address (BASE) and the jump table mode (MODE).
 
-If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. The value in the BASE field must always be aligned on a 64-byte boundary.
+If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. The jump table must always be aligned on a 64-byte boundary. The value in the BASE field will be shifted left 6 bits before use, and thus will always result in a jump table address that is aligned on a 64-byte boundary.
 
-_jvt.base_ is a virtual address, whenever virtual memory is enabled.
+The jump table address derived from _jvt.base_ is a virtual address, whenever virtual memory is enabled.
 
-The memory pointed to by _jvt.base_ is treated as instruction memory for the purpose of executing table jump instructions, implying execute access permission.
+The memory specified by _jvt.base_ is treated as instruction memory for the purpose of executing table jump instructions, implying execute access permission.
 
 [#JVT-config-table]
 ._jvt.mode_ definition
@@ -2497,8 +2497,8 @@ Operation:
 # InstMemory is byte indexed
 
 switch(XLEN) {
-  32:  table_address[XLEN-1:0] = jvt.base + (index<<2);
-  64:  table_address[XLEN-1:0] = jvt.base + (index<<3);
+  32:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<2);
+  64:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<3);
 }
 
 //fetch from the jump table
@@ -2576,8 +2576,8 @@ Operation:
 # InstMemory is byte indexed
 
 switch(XLEN) {
-  32:  table_address[XLEN-1:0] = jvt.base + (index<<2);
-  64:  table_address[XLEN-1:0] = jvt.base + (index<<3);
+  32:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<2);
+  64:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<3);
 }
 
 //fetch from the jump table

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2398,7 +2398,7 @@ Description:
 
 The _jvt_ register is an XLEN-bit *WARL* read/write register that holds the jump table configuration, consisting of the jump table base address (BASE) and the jump table mode (MODE).
 
-If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. The jump table must always be aligned on a 64-byte boundary. The value in the BASE field will be shifted left 6 bits before use, and thus will always result in a jump table address that is aligned on a 64-byte boundary.
+If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. Note that the CSR contains only bits XLEN-1 through 6 of the address. The lower bits _base_[5:0] will be filled with zeroes for jump-table address computations, resulting in a BASE field whose address is always aligned on a 64-byte boundary.
 
 The jump table address derived from _jvt.base_ is a virtual address, whenever virtual memory is enabled.
 
@@ -2497,8 +2497,8 @@ Operation:
 # InstMemory is byte indexed
 
 switch(XLEN) {
-  32:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<2);
-  64:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<3);
+  32:  table_address[XLEN-1:0] = jvt.base + (index<<2);
+  64:  table_address[XLEN-1:0] = jvt.base + (index<<3);
 }
 
 //fetch from the jump table
@@ -2576,8 +2576,8 @@ Operation:
 # InstMemory is byte indexed
 
 switch(XLEN) {
-  32:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<2);
-  64:  table_address[XLEN-1:0] = (jvt.base<<6) + (index<<3);
+  32:  table_address[XLEN-1:0] = jvt.base + (index<<2);
+  64:  table_address[XLEN-1:0] = jvt.base + (index<<3);
 }
 
 //fetch from the jump table

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2398,7 +2398,7 @@ Description:
 
 The _jvt_ register is an XLEN-bit *WARL* read/write register that holds the jump table configuration, consisting of the jump table base address (BASE) and the jump table mode (MODE).
 
-If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. Note that the CSR contains only bits XLEN-1 through 6 of the address. The lower bits _base_[5:0] will be filled with zeroes for jump-table address computations, resulting in a BASE field whose address is always aligned on a 64-byte boundary.
+If <<Zcmt>> is implemented then _jvt_ must also be implemented, but can contain a read-only value. If _jvt_ is writable, the set of values the register may hold can vary by implementation. Note that the CSR contains only bits XLEN-1 through 6 of the address _base_. When computing jump-table accesses, the unspecified lower bits 5:0 of _base_ will be filled with zeroes to obtain a full XLEN-bit jump-table base address _jvt.base_ that is always aligned on a 64-byte boundary.
 
 _jvt.base_ is a virtual address, whenever virtual memory is enabled.
 


### PR DESCRIPTION
The existing document and pseudocode did not mention that the base field is shifted left 6 bits before use.