### PR TITLE
Fix incorrect instruction names

### DIFF
--- a/src/zicsr.adoc
+++ b/src/zicsr.adoc
@@ -168,8 +168,8 @@ a CSR, CSRW _csr, rs1_, is encoded as CSRRW _x0, csr, rs1_, while CSRWI
 _csr, uimm_, is encoded as CSRRWI _x0, csr, uimm_.
 
 Further assembler pseudoinstructions are defined to set and clear bits
-in the CSR when the old value is not required: CSRS/CSRC _csr, rs1_;
-CSRSI/CSRCI _csr, uimm_.
+in the CSR when the old value is not required: CSRS/CSRC _csr, uimm_;
+CSRRSI/CSRRCI _x0, csr, uimm_.
 
 ==== CSR Access Ordering
 


### PR DESCRIPTION
The spec says:
> [...] assembler pseudoinstructions are defined to set and clear bits in the
> CSR when the old value is not required: CSRS/CSRC csr, rs1; CSRSI/CSRCI csr,
> uimm.

Neither CSRSI nor CSRCI are actual instruction names.

Correct these references to CSRRSI and CSRRCI, respetively.