### PR TITLE
Avoid describing fixed-point RDN rounding mode as truncation

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -592,7 +592,7 @@ mode as specified in the following table.
 
 | 0 | 0 | rnu | round-to-nearest-up (add +0.5 LSB)          | `v[d-1]`
 | 0 | 1 | rne | round-to-nearest-even                       | `v[d-1] & (v[d-2:0]{ne}0 \| v[d])`
-| 1 | 0 | rdn | round-down (truncate)                       | `0`
+| 1 | 0 | rdn | round-down                                  | `0`
 | 1 | 1 | rod | round-to-odd (OR bits into LSB, aka "jam")  | `!v[d] & v[d-1:0]{ne}0`
 |===
 


### PR DESCRIPTION
In the fixed-point context, describing RDN as truncation is correct, since the effect of lopping off the LSBs is to round towards -inf for both unsigned and two's complement integers.

Because truncation effects a rounding towards zero in other number formats, including IEEE 754, truncation has become conflated with rounding towards zero.  (The terminology even shows up in the C standard.) This is unfortunate, but it is an avoidable source of confusion.