### PR TITLE
Change reference in rnmi.adoc from MRET to MNRET

### DIFF
--- a/src/rnmi.adoc
+++ b/src/rnmi.adoc
@@ -56,7 +56,7 @@ zero.
 If an implementation allows IALIGN to be either 16 or 32 (by changing
 CSR `misa`, for example), then, whenever IALIGN=32, bit `mnepc[1]` is
 masked on reads so that it appears to be 0. This masking occurs also for
-the implicit read by the MRET instruction. Though masked, `mnepc[1]`
+the implicit read by the MNRET instruction. Though masked, `mnepc[1]`
 remains writable when IALIGN=32.
 
 `mnepc` is a *WARL* register that must be able to hold all valid virtual


### PR DESCRIPTION
mnepc is used by the MNRET instruction, not the MRET instruction.