### PR TITLE
fixed missing frm reg in FCVT.W.D source registers

### DIFF
--- a/src/rvwmo.adoc
+++ b/src/rvwmo.adoc
@@ -778,7 +778,7 @@ register(s) to destination register(s) as specified
 
 |FCLASS.D |_rs1_ |_rd_ | |
 
-|FCVT.W.D |_rs1_,^*^ |_rd_ |NV, NX |^*^if rm=111
+|FCVT.W.D |_rs1_, frm^*^ |_rd_ |NV, NX |^*^if rm=111
 
 |FCVT.WU.D |_rs1_, frm^*^ |_rd_ |NV, NX |^*^if rm=111
 


### PR DESCRIPTION
as mentionned in #2063 