### PR TITLE
Correct the table for RVWMO CSR instruction dependencies

### DIFF
--- a/src/rvwmo.adoc
+++ b/src/rvwmo.adoc
@@ -503,19 +503,23 @@ register(s) to destination register(s) as specified
 
 |CSRRW‡ |_rs1_, _csr_^*^ | _rd_, _csr_ | |^*^unless _rd_=`x0`
 
+5+| ‡ carries a dependency from _rs1_ to _csr_ and from _csr_ to _rd_
+
 |CSRRS‡ |_rs1_, _csr_ |_rd_ ^*^, _csr_ | |^*^unless _rs1_=`x0`
 
 |CSRRC‡ |_rs1_, _csr_  |_rd_ ^*^, _csr_ | |^*^unless _rs1_=`x0`
 
-5+| ‡ carries a dependency from _rs1_ to _csr_ and from _csr_ to _rd_
+5+| ‡ carries a dependency from _csr_ and _rs1_ to _csr_ and from _csr_ to _rd_
 
 |CSRRWI ‡ |_csr_ ^*^ |_rd_, _csr_  | |^*^unless _rd_=_x0_
+
+5+| ‡ carries a dependency from _csr_ to _rd_ and clears the dependencies of _csr_
 
 |CSRRSI ‡ |_csr_ |_rd_, _csr_^*^  | |^*^unless uimm[4:0]=0
 
 |CSRRCI ‡ |_csr_ |_rd_, _csr_^*^  | |^*^unless uimm[4:0]=0
 
-5+| ‡ carries a dependency from _csr_ to _rd_
+5+| ‡ carries a dependency from _csr_ to _rd_ and _csr_
 |===
 
 .RV64I Base Integer Instruction Set


### PR DESCRIPTION
CSR instructions which set/clear bits must still carry the previous dependencies for the target CSR.
Conversely, instructions which update a CSR from an immediate clear dependencies.