### PR TITLE
fix: mstateen*h and hstateen*h access upper half of 64-bit registers

### DIFF
--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -59,9 +59,8 @@ level:
 And if the hypervisor extension is implemented, another set of CSRs is added:
 `hstateen0`, `hstateen1`, `hstateen2`, and `hstateen3`.
 
-For RV32, the registers listed above are 32-bit, and for the machine-level and
-hypervisor CSRs there is a corresponding set of high-half CSRs for the upper 32
-bits of each register:
+For RV32, there are CSR addresses for accessing the upper 32 bits of
+corresponding machine-level and hypervisor CSRs:
 `mstateen0h`, `mstateen1h`, `mstateen2h`, `mstateen3h`,
 `hstateen0h`, `hstateen1h`, `hstateen2h`, and `hstateen3h`.
 


### PR DESCRIPTION
For `mstateen*` and `hstateen*`, the spec states:
> For RV32, the registers listed above are 32-bit, and for the machine-level and
> hypervisor CSRs there is a corresponding set of high-half CSRs for the upper 32
> bits of each register

This is self-contradictory. If "the registers listed above are 32-bit", there are no "upper 32 bits" to access.

From the discussion in issue #1255, there is general agreement that CSRs that are defined as 64-bit and have "upper-half" analogues to be used for RV32 are indeed architecturally 64-bit.

Remove the assertion that the 64-bit registers are 32-bit for RV32.

(Also related to issue #1966.)