### PR TITLE
Use the plural `instructions` when discussing `vsetvli` and `vsetvl` for AVL.

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -1230,24 +1230,24 @@ When _rs1_=`x0` but _rd_≠`x0`, the maximum unsigned integer value (`~0`)
 is used as the AVL, and the resulting VLMAX is written to `vl` and
 also to the `x` register specified by `rd`.
 
-When _rs1_=`x0` and _rd_=`x0`, the instruction operates as if the current
+When _rs1_=`x0` and _rd_=`x0`, the instructions operate as if the current
 vector length in `vl` is used as the AVL, and the resulting value is
 written to `vl`, but not to a destination register.  This form can
 only be used when VLMAX and hence `vl` is not actually changed by the
-new SEW/LMUL ratio.  Use of the instruction with a new SEW/LMUL ratio
+new SEW/LMUL ratio.  Use of the instructions with a new SEW/LMUL ratio
 that would result in a change of VLMAX is reserved.
-Use of the instruction is also reserved if `vill` was 1 beforehand.
+Use of the instructions is also reserved if `vill` was 1 beforehand.
 Implementations may set `vill` in either case.
 
 NOTE: This last form of the instructions allows the `vtype` register to
 be changed while maintaining the current `vl`, provided VLMAX is not
 reduced.  This design was chosen to ensure `vl` would always hold a
 legal value for current `vtype` setting.  The current `vl` value can
-be read from the `vl` CSR.  The `vl` value could be reduced by this
-instruction if the new SEW/LMUL ratio causes VLMAX to shrink, and so
+be read from the `vl` CSR.  The `vl` value could be reduced by these
+instructions if the new SEW/LMUL ratio causes VLMAX to shrink, and so
 this case has been reserved as it is not clear this is a generally
 useful operation, and implementations can otherwise assume `vl` is not
-changed by this instruction to optimize their microarchitecture.
+changed by these instructions to optimize their microarchitecture.
 
 For the `vsetivli` instruction, the AVL is encoded as a 5-bit
 zero-extended immediate (0--31) in the `rs1` field.


### PR DESCRIPTION
The `AVL encoding` subsection refers to the `vsetvli` and `vsetvl` instructions (and mentions both in Table 51).  However,
the paragraph discussing the `rs1=x0 and rd=x0` case refers to `instruction` in the singular, which is confusing. 

The accompanying NOTE similarly twice uses a singular `instruction`, though its first sentence uses a plural.

This fixes the inconsistencies.

