### PR TITLE
Clarify compressed instruction hints

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -543,18 +543,16 @@ include::images/wavedrom/c-integer-const-gen.edn[]
 
 
 C.LI loads the sign-extended 6-bit immediate, _imm_, into register _rd_.
-C.LI expands into `addi rd, x0, imm`. C.LI is valid only when
-_rd_≠`x0`; the code points with _rd_=`x0` encode HINTs.
+C.LI expands into `addi rd, x0, imm`. C.LI with _rd_=`x0` are HINTs.
 
 C.LUI loads the non-zero 6-bit immediate field into bits 17–12 of the
 destination register, clears the bottom 12 bits, and sign-extends bit 17
 into all higher bits of the destination. C.LUI expands into
 `lui rd, imm`. C.LUI is valid only when
-_rd_≠{`x0`,`x2`},
-and when the immediate is not equal to zero. The code points with
-_imm_=0 are reserved; the remaining code points with _rd_=`x0` are
-HINTs; and the remaining code points with _rd_=`x2` correspond to the
-C.ADDI16SP instruction.
+_rd_≠`x2` (code points with _rd_=`x2` correspond to the
+C.ADDI16SP instruction),
+and when the immediate is not equal to zero (code points with
+_imm_=0 are reserved). C.LUI with _rd_=`x0` are HINTs.
 
 ==== Integer Register-Immediate Operations
 
@@ -569,9 +567,8 @@ include::images/wavedrom/c-int-reg-immed.edn[]
 C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in
 register _rd_ then writes the result to _rd_. C.ADDI expands into
 `addi rd, rd, imm`. C.ADDI is valid only when
-_rd_≠`x0` and _imm_≠0. The code
-points with _rd_=`x0` encode the C.NOP instruction; the remaining code
-points with _imm_=0 encode HINTs.
+_rd_≠`x0` (code points with _rd_=`x0` encode the C.NOP instruction).
+C.ADDI with _imm_=0 are HINTs.
 
 C.ADDIW is an RV64C-only instruction that performs the same
 computation but produces a 32-bit result, then sign-extends result to 64
@@ -618,11 +615,10 @@ the value in register _rd_ then writes the result to _rd_. The shift
 amount is encoded in the _shamt_ field.
 C.SLLI expands into `slli rd, rd, shamt[5:0]`.
 
+For all base ISAs, C.SLLI with _shamt_=0 or with _rd_=`x0` are HINTs.
+
 For RV32C, _shamt[5]_ must be zero; the code points with _shamt[5]_=1
-are designated for custom extensions. For RV32C and RV64C, the shift
-amount must be non-zero; the code points with _shamt_=0 are HINTs. For
-all base ISAs, the code points with _rd_=`x0` are HINTs, except those
-with _shamt[5]_=1 in RV32C.
+are designated for custom extensions and are not HINTs.
 
 [[c-srli-srai]]
 
@@ -635,9 +631,10 @@ the value in register _rd′_ then writes the result to
 _rd′_. The shift amount is encoded in the _shamt_ field.
 C.SRLI expands into `srli rd′, rd′, shamt`.
 
+For all base ISAs, C.SRLI with _shamt_=0 are HINTs.
+
 For RV32C, _shamt[5]_ must be zero; the code points with _shamt[5]_=1
-are designated for custom extensions. For RV32C and RV64C, the shift
-amount must be non-zero; the code points with _shamt_=0 are HINTs.
+are designated for custom extensions and are not HINTs.
 
 C.SRAI is defined analogously to C.SRLI, but instead performs an
 arithmetic right shift. C.SRAI expands to
@@ -660,6 +657,16 @@ value in register _rd′_ and the sign-extended 6-bit
 immediate, then writes the result to _rd′_. C.ANDI
 expands to `andi rd′, rd′, imm`.
 
+==== NOP Instruction
+
+[[c-nop-instr]]
+include::images/wavedrom/c-nop-instr.edn[]
+((((compressed. C.NOPINSTR))))
+
+`C.NOP` is a CI-format instruction that does not change any user-visible
+state, except for advancing the `pc` and incrementing any applicable
+performance counters. `C.NOP` expands to `nop`. `C.NOP` with _imm_≠0 are HINTs.
+
 ==== Integer Register-Register Operations
 
 [[c-cr]]
@@ -670,7 +677,8 @@ These instructions use the CR format.
 
 C.MV copies the value in register _rs2_ into register _rd_. C.MV expands
 into `add rd, x0, rs2`. C.MV is valid only when
-_rs2_≠`x0`; the code points with _rs2_=`x0` correspond to the C.JR instruction. The code points with _rs2_≠`x0` and _rd_=`x0` are HINTs.
+_rs2_≠`x0`; the code points with _rs2_=`x0` correspond to the C.JR instruction.
+C.MV with _rd_=`x0` are HINTs.
 
 [NOTE]
 ====
@@ -684,7 +692,8 @@ hardware cost._
 C.ADD adds the values in registers _rd_ and _rs2_ and writes the result
 to register _rd_. C.ADD expands into `add rd, rd, rs2`. C.ADD is only
 valid when _rs2_≠`x0`; the code points with _rs2_=`x0` correspond to the C.JALR
-and C.EBREAK instructions. The code points with _rs2_≠`x0` and _rd_=`x0` are HINTs.
+and C.EBREAK instructions.
+C.ADD with _rd_=`x0` are HINTs.
 
 [[c-ca]]
 include::images/wavedrom/c-int-reg-to-reg-ca-format.edn[]
@@ -752,17 +761,6 @@ extension. Similarly, we reserve instructions with all bits set to 1
 encoding scheme) as illegal to capture another common value seen in
 non-existent memory regions.
 ====
-
-==== NOP Instruction
-
-[[c-nop-instr]]
-include::images/wavedrom/c-nop-instr.edn[]
-((((compressed. C.NOPINSTR))))
-
-`C.NOP` is a CI-format instruction that does not change any user-visible
-state, except for advancing the `pc` and incrementing any applicable
-performance counters. `C.NOP` expands to `nop`. `C.NOP` is valid only when
-_imm_=0; the code points with _imm_≠0 encode HINTs.
 
 ==== Breakpoint Instruction
 
@@ -836,29 +834,27 @@ no standard HINTs will ever be defined in this subspace.
 |===
 |Instruction |Constraints |Code Points |Purpose
 
-|C.NOP |_imm_≠0 |63 .6+.^|_Designated for future standard use_
+|C.NOP | _imm_≠0 |63 .6+.^|_Designated for future standard use_
 
-|C.ADDI | _rd_≠`x0`, _imm_=0 |31
+|C.ADDI | _imm_=0 |31
 
 |C.LI | _rd_=`x0` |64
 
-|C.LUI | _rd_=`x0`, _imm_≠0 |63
+|C.LUI | _rd_=`x0` |63
 
-|C.MV | _rd_=`x0`, _rs2_≠`x0` |31
+|C.MV | _rd_=`x0` |31
 
-|C.ADD | _rd_=`x0`, _rs2_≠`x0`, _rs2_≠`x2-x5` | 27
+|C.ADD | _rd_=`x0` and _rs2_≠`x2-x5` | 27
 
-|C.ADD | _rd_=`x0`, _rs2_≠`x2-x5` |4|(rs2=x2) C.NTL.P1 (rs2=x3) C.NTL.PALL (rs2=x4) C.NTL.S1 (rs2=x5) C.NTL.ALL
+|C.ADD | _rd_=`x0` and _rs2_=`x2-x5` |4|(rs2=x2) C.NTL.P1 (rs2=x3) C.NTL.PALL (rs2=x4) C.NTL.S1 (rs2=x5) C.NTL.ALL
 
-|C.SLLI |_rd_=`x0`, _imm_≠0 |31 (RV32), 63 (RV64)  .5+.^|_Designated for custom use_
+|C.SLLI |_rd_=`x0` and _imm_≠0 |31 (RV32), 63 (RV64)  .5+.^|_Designated for custom use_
 
-|C.SLLI64 | _rd_=`x0` |1
+|C.SLLI | _imm_=0 |32
 
-|C.SLLI64 | _rd_≠`x0`, RV32 and RV64 only |31
+|C.SRLI | _imm_=0 |8
 
-|C.SRLI64 | RV32 and RV64 only |8
-
-|C.SRAI64 | RV32 and RV64 only |8
+|C.SRAI | _imm_=0 |8
 |===
 
 === RVC Instruction Set Listings

--- a/src/images/wavedrom/c-ci.edn
+++ b/src/images/wavedrom/c-ci.edn
@@ -5,7 +5,7 @@
 {reg: [
   {bits: 2, name: 'op', attr: ['2', 'C2']},
   {bits: 5, name: 'shamt[4:0]',    attr: ['5', 'shamt[4:0]']},
-  {bits: 5, name: 'rd/rs1',     attr: ['5', 'dest != 0']},
+  {bits: 5, name: 'rd/rs1',     attr: ['5', 'dest']},
   {bits: 1, name: 'shamt[5]',    attr: ['1', 'shamt[5]']},
   {bits: 3, name: 'funct3',    attr: ['3', 'C.SLLI']},
 ]}

--- a/src/images/wavedrom/c-int-reg-immed.edn
+++ b/src/images/wavedrom/c-int-reg-immed.edn
@@ -4,9 +4,9 @@
 ....
 {reg: [
   {bits: 2, name: 'op',        attr: ['2','C1', 'C1', 'C1']},
-  {bits: 5, name: 'imm[4:]',  attr: ['5','nzimm[4:0]', 'imm[4:0]', 'nzimm[4|6|8:7|5]']},
+  {bits: 5, name: 'imm[4:]',  attr: ['5','imm[4:0]', 'imm[4:0]', 'nzimm[4|6|8:7|5]']},
   {bits: 5, name: 'rd/rs1',    attr: ['5','dest != 0', 'dest != 0', '2']},
-  {bits: 1, name: 'imm[5]',    attr: ['1','nzimm[5]', 'imm[5]', 'nzimm[9]']},
+  {bits: 1, name: 'imm[5]',    attr: ['1','imm[5]', 'imm[5]', 'nzimm[9]']},
   {bits: 3, name: 'funct3',    attr: ['3','C.ADDI', 'C.ADDIW', 'C.ADDI16SP']},
 ], config: {bits: 16}}
 ....

--- a/src/images/wavedrom/c-integer-const-gen.edn
+++ b/src/images/wavedrom/c-integer-const-gen.edn
@@ -5,7 +5,7 @@
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C1', 'C1']},
   {bits: 5, name: 'imm[4:0]',    attr: ['5','imm[4:0]','nzimm[16:12]']},
-  {bits: 5, name: 'rd',     attr: ['5','dest != 0', 'dest != {0, 2}']},
+  {bits: 5, name: 'rd',     attr: ['5','dest', 'dest != 2']},
   {bits: 1, name: 'imm[5]',    attr: ['1','imm[5]', 'nzimm[17]'],},
   {bits: 3, name: 'funct3',    attr: ['3','C.LI', 'C.LUI'],},
 ], config: {bits: 16}}


### PR DESCRIPTION
The text around these was a little confusing so I've changed it to be more consistent and fixed a few minor mistakes.

1. There's a lot of text that's like "C.FOO is only valid when dest != 0. Oh but actually you can also have dest=0, then it's a HINT." I changed those so that C.FOO is valid for all dests, but *also* the instances of C.FOO where dest=0 are HINTs. This is more consistent with the `RVC HINT instructions` table which lists the HINTs as being part of the C.FOO instructions, and also explicitly states that "RVC HINTs are encoded as computational instructions that do not modify the architectural state".

2. Removed a lot of redundant constraints from the `RVC Hint Instructions` table. E.g. there's no need to say `rd != x0` for C.ADDI because that's already a condition for an instruction being C.ADDI at all. So the table now only lists the *additional* constraints that make instructions into HINTs.

3. Move the NOP instruction definition closer to `C.ADDI` where it is referenced (it's basically just a specific `C.ADDI` hint).

4. Remove the `64` suffix and `RV32 and RV64 only` from the hint table. `C.SLLI64` isn't an instruction and RV32 and RV64 are the only options currently.

5. Fix a `≠` that should have been `=` for `C.ADD`.