### PR TITLE
Fix constraint for assigned C.ADD hints

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -849,7 +849,7 @@ no standard HINTs will ever be defined in this subspace.
 
 |C.ADD | _rd_=`x0`, _rs2_≠`x0`, _rs2_≠`x2-x5` | 27
 
-|C.ADD | _rd_=`x0`, _rs2_≠`x2-x5` |4|(rs2=x2) C.NTL.P1 (rs2=x3) C.NTL.PALL (rs2=x4) C.NTL.S1 (rs2=x5) C.NTL.ALL
+|C.ADD | _rd_=`x0`, _rs2_=`x2-x5` |4|(rs2=x2) C.NTL.P1 (rs2=x3) C.NTL.PALL (rs2=x4) C.NTL.S1 (rs2=x5) C.NTL.ALL
 
 |C.SLLI |_rd_=`x0` or _imm_=0 |63 (RV32), 95 (RV64)  .3+.^|_Designated for custom use_
 


### PR DESCRIPTION
The C.ADD hints are split into unassigned ones where rs2≠x2-x5, and assigned ones where rs2=x2-x5, but the constraint was ≠ for both.