### PR TITLE
Remove now-impossible clause from PMP description

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -3221,10 +3221,6 @@ back to NAPOT.
 Software may determine the PMP granularity by writing zero to `pmp0cfg`, then writing all ones to `pmpaddr0`, then reading back `pmpaddr0`. If _G_ is the index of the least-significant bit set, the PMP granularity is 2^G+2^ bytes.
 ====
 
-If the current XLEN is greater than MXLEN, the PMP address registers are
-zero-extended from MXLEN to XLEN bits for the purposes of address
-matching.
-
 ===== Locking and Privilege Mode
 
 The L bit indicates that the PMP entry is locked, i.e., writes to the


### PR DESCRIPTION
XLEN can no longer be greater than MXLEN.

Resolves #2090