### PR TITLE
Improve c.nop hint description

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -762,8 +762,8 @@ include::images/wavedrom/c-nop-instr.edn[]
 
 `C.NOP` is a CI-format instruction that does not change any user-visible
 state, except for advancing the `pc` and incrementing any applicable
-performance counters. `C.NOP` expands to `nop`. `C.NOP` is valid only when
-_imm_=0; the code points with _imm_≠0 encode HINTs.
+performance counters. `C.NOP` expands to `nop`. The `C.NOP` code points
+with _imm_≠0 encode HINTs.
 
 ==== Breakpoint Instruction
 


### PR DESCRIPTION
`c.nop` with a non-zero immediate is valid; it's just a hint. For example, assemblers accept `c.nop 7`.

Follow up to #2088  and #2093.