### PR TITLE
Update smcdeleg.adoc

### DIFF
--- a/src/smcdeleg.adoc
+++ b/src/smcdeleg.adoc
@@ -62,10 +62,11 @@ the table below.
 ^3^ Depends on Sscofpmf support +
 ^4^ Depends on Smcntrpmf support
 
-[NOTE]
-====
-`__hpmevent__i` _represents a subset of the state accessed by the_ `__mhpmevent__i` _register. Likewise, `cyclecfg` and `instretcfg` represent a subset of the state accessed by the `mcyclecfg` and `minstretcfg` registers, respectively. See below for subset details._
-====
+`hpmevent__i__` may represent a subset of the state accessed by the `mhpmevent__i__` register. Specifically, if Sscofpmf is implemented, event selector bit
+62 (MINH) is read-only 0 when accessed through `sireg*`.
+
+Likewise, `cyclecfg` and `instretcfg` may represent a subset of the state accessed by the `mcyclecfg` and `minstretcfg` registers, respectively. If
+Smcntrpmf is implemented, counter configuration register bit 62 (MINH) is read-only 0 when accessed through `sireg*`.
 
 If extension Smstateen is implemented, refer to extensions Smcsrind/Sscsrind (<<indirect-csr>>) for how setting bit 60 of CSR
 `mstateen0` to zero prevents access to registers `siselect`, `sireg*`,
@@ -107,13 +108,6 @@ or `vsireg*`, or attempts from VU-mode to access `siselect` or `sireg*`. Further
 instruction exception.
 * An attempt from VS-mode to access any `sireg*` (really `vsireg*`) raises an illegal-instruction exception if `menvcfg`.CDE = 0, or a virtual
 instruction exception if `menvcfg`.CDE = 1.
-
-If Sscofpmf is implemented, `sireg2` and `sireg5` provide access only to a
-subset of the event selector registers. Specifically, event selector bit
-62 (MINH) is read-only 0 when accessed through `sireg*`. Similarly, if
-Smcntrpmf is implemented, `sireg2` and `sireg5` provide access only to a
-subset of the counter configuration registers. Counter configuration
-register bit 62 (MINH) is read-only 0 when accessed through `sireg*`.
 
 === Supervisor Counter Inhibit (`scountinhibit`) Register
 


### PR DESCRIPTION
Combine non-normative and normative explanations of what event selector / counter configuration state is accessible in S-mode.