### PR TITLE
Fix vector example appendix as separate from previous.

### DIFF
--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -196,11 +196,13 @@ include::rv-32-64g.adoc[]
 include::naming.adoc[]
 include::mm-eplan.adoc[]
 include::mm-formal.adoc[]
+
 //Appendices for Vector
 include::vector-examples.adoc[]
 include::calling-convention.adoc[]
 //include::fraclmul.adoc[]
 //End of Vector appendices
+
 include::index.adoc[]
 // this is generated generated from index markers.
 include::bibliography.adoc[]


### PR DESCRIPTION
Presently, what should be Appendix C is included in Appendix B.

Fix this so have Appendices A, B, C, D.