### PR TITLE
Mark GitHub-generated releases as "Intermediate Releases"

### DIFF
--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.pull_container_image.outcome == 'success'
         run: |
           docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-          /bin/sh -c "make -j$(nproc)"
+          /bin/sh -c "make -j$(nproc) RELEASE_TYPE=intermediate"
 
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,22 @@
 
 DOCS := riscv-privileged riscv-unprivileged
 
-DATE ?= $(shell date +%Y-%m-%d)
+RELEASE_TYPE ?= draft
+
+ifeq ($(RELEASE_TYPE), draft)
+  WATERMARK_OPT := -a draft-watermark
+  RELEASE_DESCRIPTION := DRAFT---NOT AN OFFICIAL RELEASE
+else ifeq ($(RELEASE_TYPE), intermediate)
+  WATERMARK_OPT :=
+  RELEASE_DESCRIPTION := Intermediate Release
+else ifeq ($(RELEASE_TYPE), official)
+  WATERMARK_OPT :=
+  RELEASE_DESCRIPTION := Official Release
+else
+  $(error Unknown build type; use RELEASE_TYPE={draft, intermediate, official})
+endif
+
+DATE ?= $(shell date +%Y%m%d)
 SKIP_DOCKER ?= $(shell if command -v docker >/dev/null 2>&1 ; then echo false; else echo true; fi)
 DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
 ifneq ($(SKIP_DOCKER),true)
@@ -89,6 +104,9 @@ OPTIONS := --trace \
            -a mathematical-format=svg \
            -a pdf-fontsdir=docs-resources/fonts \
            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
+           $(WATERMARK_OPT) \
+           -a revnumber='$(DATE)' \
+           -a revremark='$(RELEASE_DESCRIPTION)' \
            $(XTRA_ADOC_OPTS) \
            -D build \
            --failure-level=ERROR

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -2,8 +2,6 @@
 = The RISC-V Instruction Set Manual: Volume II: Privileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Volume II - Privileged Architecture
-:revnumber: 20250508
-:revremark: This document is in Ratified state.
 //development: assume everything can change
 //stable: assume everything could change
 //frozen: of you implement this version you assume the risk that something might change because of the public review cycle  but we expect little to no change.
@@ -13,7 +11,9 @@ include::../docs-resources/global-config.adoc[]
 :appendix-caption: Appendix
 :imagesdir: ../docs-resources/images
 :title-logo-image: image:risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
-//:page-background-image: image:draft.png[opacity=20%]
+ifdef::draft-watermark[]
+:page-background-image: image:draft.png[opacity=20%]
+endif::[]
 //:title-page-background-image: none
 //:back-cover-image: image:backpage.png[opacity=25%]
 // Settings:

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -2,14 +2,14 @@
 = The RISC-V Instruction Set Manual Volume I: Unprivileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Unprivileged Architecture
-:revnumber: 20250508
-:revremark: This document is in ratified state.
 :colophon:
 :preface-title: Preamble
 :appendix-caption: Appendix
 :imagesdir: ../docs-resources/images
 :title-logo-image: image:risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
-//:page-background-image: image:draft.png[opacity=20%]
+ifdef::draft-watermark[]
+:page-background-image: image:draft.png[opacity=20%]
+endif::[]
 //:title-page-background-image: none
 //:back-cover-image: image:backpage.png[opacity=25%]
 :back-cover-image: image:riscv-horizontal-color.svg[opacity=25%]


### PR DESCRIPTION
We now have three kinds of releases:

- Draft releases, which are the product of generating a copy of the spec from this repo on one's own machine.  These releases will include the DRAFT watermark and a note on the front page that says "DRAFT---NOT AN OFFICIAL RELEASE".

- Intermediate releases, which GitHub builds automatically when PRs are merged into the `main` branch of this repo.  The intent is that the `main` branch contains only ratified material, but since they are auto-generated, they aren't necessarily carefully vetted.  These releases will omit the DRAFT watermark but will include a note on the front page indicating they're "Intermediate" releases.

- Official releases, which are posted on `riscv.org` from time to time.  These omit the DRAFT watermark, obviously, and include a note on the front page indicating they're "Official" releases.
