### PR TITLE
Fix copy/paste error, correcting hideleg to 'interrupt' rather than 'exception'.

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -325,7 +325,7 @@ to a VS-mode guest; their layout is the same as `medeleg` and `mideleg`.
 include::images/bytefield/hedelegreg.edn[]
 
 [[hidelegreg]]
-.Hypervisor exception delegation register (`hideleg`).
+.Hypervisor interrupt delegation register (`hideleg`).
 include::images/bytefield/hidelegreg.edn[]
 
 A synchronous trap that has been delegated to HS-mode (using `medeleg`)


### PR DESCRIPTION
Following both the abbreviation itself, and the naming convention for medeleg/mideleg, hideleg should refer to interrupt delegation, not exception delegation which is already covered by hedeleg.