### PR TITLE
Fix some references to illegal-instruction exceptions that should be reserved

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2098,9 +2098,6 @@ vs4r.v v4, (a1)      # Store v4-v7 to address in a1
 vs8r.v v8, (a1)      # Store v8-v15 to address in a1
 ----
 
-NOTE: Implementations should raise illegal-instruction exceptions on
-`vl<nf>r` instructions for EEW values that are not supported.
-
 NOTE: We have considered adding a whole register mask load instruction
 (`vl1rm.v`) but have decided to omit from initial extension.  The
 primary purpose would be to inform the microarchitecture that the data

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -1409,9 +1409,9 @@ EEW.
 If the vector offset elements are narrower than XLEN, they are
 zero-extended to XLEN before adding to the base effective address.  If
 the vector offset elements are wider than XLEN, the least-significant
-XLEN bits are used in the address calculation.  An implementation must
-raise an illegal-instruction exception if the EEW is not supported for
-offset elements.
+XLEN bits are used in the address calculation.
+If the implementation does not support the EEW of the offset elements,
+the instruction is reserved.
 
 NOTE: A profile may place an upper limit on the maximum supported index
 EEW (e.g., only up to XLEN) smaller than ELEN.
@@ -1514,8 +1514,7 @@ claimed by the standard scalar floating-point loads and stores.
 
 Implementations must provide vector loads and stores with EEWs
 corresponding to all supported SEW settings.  Vector load/store
-encodings for unsupported EEW widths must raise an illegal
-instruction exception.
+encodings for unsupported EEW widths are reserved.
 
 .Width encoding for vector loads and stores.
 [cols="5,1,1,1,1,>3,>3,>3,3"]

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -5208,8 +5208,7 @@ strip-mine iterations in vector-length-agnostic code.
 The element group size is statically encoded in the instruction, often
 implicitly as part of the opcode.
 
-Executing a vector instruction with EGS > VLMAX causes an illegal
-instruction exception to be raised.
+Vector instructions with EGS > VLMAX are reserved.
 
 NOTE: The vector instructions in the base V vector ISA can be viewed
 as all having an element group size of 1 for all operands statically


### PR DESCRIPTION
There are a handful of places in the vector ISA spec where we mandate illegal-instruction exceptions but really should have indicated the behavior is reserved. Implementations that raise illegal-instruction exceptions in these cases remain compatible, of course.