### PR TITLE
Describe mask tail handling consistently

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -1021,7 +1021,7 @@ Other vector registers can be used to hold working mask values, and
 mask vector logical operations are provided to perform predicate
 calculations. [[sec-mask-vector-logical]]
 
-As specified in <<sec-agnostic>>, mask destination values are
+As specified in <<sec-agnostic>>, mask destination tail elements are
 always treated as tail-agnostic, regardless of the setting of `vta`.
 
 [[sec-vector-mask-encoding]]


### PR DESCRIPTION
Make the wording in sec-vec-operands match that of sec-agnostic.

Resolves #2114