### PR TITLE
Improve code highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ OPTIONS := --trace \
 REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-diagram \
             --require=asciidoctor-lists \
-            --require=asciidoctor-mathematical
+            --require=asciidoctor-mathematical \
+            --require=asciidoctor-sail
 
 .PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub submodule-check
 

--- a/src/fraclmul.adoc
+++ b/src/fraclmul.adoc
@@ -5,6 +5,7 @@ compilers can make good use of the fractional LMUL feature.
 
 Consider the following (admittedly contrived) loop written in C:
 
+[source,c]
 ----
 void add_ref(long N,
     signed char *restrict c_c, signed char *restrict c_a, signed char *restrict c_b,

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -33,10 +33,7 @@ endif::[]
 :sectnumlevels: 5
 :toc: left
 :toclevels: 4
-:source-highlighter: pygments
-ifdef::backend-pdf[]
 :source-highlighter: rouge
-endif::[]
 :table-caption: Table
 :figure-caption: Figure
 :xrefstyle: short

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -30,10 +30,7 @@ endif::[]
 :sectnumlevels: 5
 :toc: left
 :toclevels: 5
-:source-highlighter: pygments
-ifdef::backend-pdf[]
 :source-highlighter: rouge
-endif::[]
 :table-caption: Table
 :figure-caption: Figure
 :xrefstyle: short

--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -710,7 +710,8 @@ stack instructions to unwind a shadow stack. This example assumes that the
 `setjmp` function itself does not push on to the shadow stack (being a leaf
 function, it is not required to).
 
-[listing]
+[source,c]
+----
 setjmp() {
     :
     :
@@ -741,7 +742,7 @@ longjmp() {
 back_cfi_not_active:
     :
 }
-====
+----
 
 <<<
 


### PR DESCRIPTION
Always use `rouge` for syntax highlighting and install `asciidoctor-sail` - this means the Sail code gets syntax highlighted.

I also tagged a couple of C snippets so they get highlighted.

Unfortunately rouge does not support highlighting RISC-V assembly (neither does pygments).