### PR TITLE
Simplify make command in CI workflows

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -41,20 +41,10 @@ jobs:
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-    # Pull the latest RISC-V Docs container image
-    # https://github.com/riscv/riscv-docs-base-container-image
-    # https://hub.docker.com/r/riscvintl/riscv-docs-base-container-image
-      - name: Pull Container
-        id: pull_container_image
-        run: docker pull riscvintl/riscv-docs-base-container-image:latest
-
     # Build PDF and HTML files using the container
       - name: Build Files
         id: build_files
-        if: steps.pull_container_image.outcome == 'success'
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-          /bin/sh -c "make -j$(nproc)"
+        run: make -j$(nproc)
 
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -27,17 +27,9 @@ jobs:
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Pull Container
-        id: pull_container_image
-        run: |
-          docker pull riscvintl/riscv-docs-base-container-image:latest
-
       - name: Build Files
         id: build_files
-        if: steps.pull_container_image.outcome == 'success'
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-          /bin/sh -c "make -j$(nproc) RELEASE_TYPE=intermediate"
+        run: make -j$(nproc) RELEASE_TYPE=intermediate
 
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf


### PR DESCRIPTION
`make` already automatically uses Docker and downloads the image. I don't think it is necessary to do it explicitly.