### PR TITLE
Solidify description of how tval is populated on EBREAK

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1989,6 +1989,14 @@ address-misaligned, access-fault, or page-fault exception occurs on an
 instruction fetch, load, or store, then `mtval` will contain the
 faulting virtual address.
 
+On a breakpoint exception raised by an EBREAK or C.EBREAK instruction, `mtval`
+is written with either zero or the virtual address of the instruction.
+
+NOTE: For breakpoint exceptions raised by [C.]EBREAK, the virtual address of
+the instruction is already recorded in `mepc`.
+Recording the same address in `mtval` is redundant; the option is provided for
+backwards compatibility.
+
 When page-based virtual memory is enabled, `mtval` is written with the
 faulting virtual address, even for physical-memory access-fault
 exceptions. This design reduces datapath cost for most implementations,

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -672,6 +672,9 @@ address-misaligned, access-fault, or page-fault exception occurs on an
 instruction fetch, load, or store, then `stval` will contain the
 faulting virtual address.
 
+On a breakpoint exception raised by an EBREAK or C.EBREAK instruction, `stval`
+is written with either zero or the virtual address of the instruction.
+
 [[stvalreg]]
 .Supervisor Trap Value register.
 include::images/bytefield/stvalreg.edn[]


### PR DESCRIPTION
We tried to fix this in #601, but the text doesn't quite cover the intended case, because the breakpoint exception does not occur on a fetch, load, or store: it occurs as a result of executing a non-memory instruction.  Fix by listing this case explicitly.