### PR TITLE
Avoid describing vmv<nr>r.v vd, vd as a NOP

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -3041,7 +3041,7 @@ with an EEW equal to SEW.
 NOTE: Implementations that internally reorganize data according to EEW
 can shuffle the internal representation according to SEW.
 Implementations that do not internally reorganize data can dynamically
-elide this instruction, and treat as a NOP.
+elide this instruction (aside from resetting `vstart` to 0).
 
 NOTE: The `vmv.v.v vd, vd` instruction is not a RISC-V HINT as a
 tail-agnostic setting may cause an architectural state change on some
@@ -4818,9 +4818,10 @@ NOTE: The usual property that no elements are written if `vstart` {ge} `vl`
 does not apply to these instructions.
 Instead, no elements are written if `vstart` {ge} `evl`.
 
-NOTE: If `vd` is equal to `vs2` the instruction is an architectural
-NOP, but is treated as a hint to implementations that rearrange data
-internally that the register group will next be accessed with an EEW
+NOTE: If `vd` is equal to `vs2`, the instruction does not change any
+vector register state.
+Implementations that rearrange data internally can treat this instruction
+as a hint that the register group will next be accessed with an EEW
 equal to SEW.
 
 The instruction is encoded as an OPIVI instruction.  The number of


### PR DESCRIPTION
...because it resets vstart to 0.

Resolves #2135