### PR TITLE
List hardware-error exceptions in relevant tval text

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1985,7 +1985,8 @@ If the hardware platform specifies that no exceptions set `mtval`
 to a nonzero value, then `mtval` is read-only zero.
 
 If `mtval` is written with a nonzero value when a breakpoint,
-address-misaligned, access-fault, or page-fault exception occurs on an
+address-misaligned, access-fault, page-fault, or hardware-error exception
+occurs on an
 instruction fetch, load, or store, then `mtval` will contain the
 faulting virtual address.
 
@@ -2000,12 +2001,13 @@ include::images/bytefield/mtvalreg.edn[]
 
 
 If `mtval` is written with a nonzero value when a misaligned load or
-store causes an access-fault or page-fault exception, then `mtval` will
+store causes an access-fault, page-fault, or hardware-error exception,
+then `mtval` will
 contain the virtual address of the portion of the access that caused the
 fault.
 
 If `mtval` is written with a nonzero value when an instruction
-access-fault or page-fault exception occurs on a hart with
+access-fault, page-fault, or hardware-error exception occurs on a hart with
 variable-length instructions, then `mtval` will contain the virtual
 address of the portion of the instruction that caused the fault, while
 `mepc` will point to the beginning of the instruction.

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -668,7 +668,8 @@ exhibit either behavior, depending on the underlying event that caused the
 exception.
 
 If `stval` is written with a nonzero value when a breakpoint,
-address-misaligned, access-fault, or page-fault exception occurs on an
+address-misaligned, access-fault, page-fault, or hardware-error exception
+occurs on an
 instruction fetch, load, or store, then `stval` will contain the
 faulting virtual address.
 
@@ -677,12 +678,13 @@ faulting virtual address.
 include::images/bytefield/stvalreg.edn[]
 
 If `stval` is written with a nonzero value when a misaligned load or
-store causes an access-fault or page-fault exception, then `stval` will
+store causes an access-fault, page-fault, or hardware-error exception,
+then `stval` will
 contain the virtual address of the portion of the access that caused the
 fault.
 
 If `stval` is written with a nonzero value when an instruction
-access-fault or page-fault exception occurs on a system with
+access-fault, page-fault, or hardware-error exception occurs on a hart with
 variable-length instructions, then `stval` will contain the virtual
 address of the portion of the instruction that caused the fault, while
 `sepc` will point to the beginning of the instruction.


### PR DESCRIPTION
The behavior of a hardware-error exception is already described elsewhere in the text, but for clarity, we should mirror this subset of information in the mtval CSR description.