### PR TITLE
Simplify Makefile and remove recursive Make calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,22 +116,22 @@ REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-mathematical \
             --require=asciidoctor-sail
 
-.PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub submodule-check
+.PHONY: all build clean build-pdf build-html build-epub docker-pull-latest
 
 all: build
 
 # Check if the docs-resources/global-config.adoc file exists. If not, the user forgot to check out submodules.
-submodule-check:
-	if [ ! -e docs-resources/global-config.adoc ]; then \
-	  echo "WARNING: You must clone with --recurse-submodules to automatically populate the submodule 'docs-resources'." 1>&2; \
-	  echo "Checking out submodules for you via 'git submodule update --init --recurse'..."; \
-	  git submodule update --init --recursive; \
-	fi
+ifeq ("$(wildcard docs-resources/global-config.adoc)","")
+  $(warning You must clone with --recurse-submodules to automatically populate the submodule 'docs-resources'.")
+  $(warning Checking out submodules for you via 'git submodule update --init --recurse'...)
+  $(shell git submodule update --init --recursive)
+endif
 
-build-docs: $(DOCS_PDF) $(DOCS_HTML) $(DOCS_EPUB)
 build-pdf: $(DOCS_PDF)
 build-html: $(DOCS_HTML)
 build-epub: $(DOCS_EPUB)
+
+build: build-pdf build-html build-epub
 
 ALL_SRCS := $(shell git ls-files $(SRC_DIR))
 
@@ -149,26 +149,6 @@ $(BUILD_DIR)/%.epub: $(SRC_DIR)/%.adoc $(ALL_SRCS)
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_EPUB) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
-
-build: submodule-check
-	@echo "Checking if Docker is available..."
-	@if command -v docker >/dev/null 2>&1 ; then \
-		echo "Docker is available, building inside Docker container..."; \
-		$(MAKE) build-container; \
-	else \
-		echo "Docker is not available, building without Docker..."; \
-		$(MAKE) build-no-container; \
-	fi
-
-build-container: submodule-check
-	@echo "Starting build inside Docker container..."
-	$(MAKE) SKIP_DOCKER=false build-docs
-	@echo "Build completed successfully inside Docker container."
-
-build-no-container: submodule-check
-	@echo "Starting build..."
-	$(MAKE) SKIP_DOCKER=true build-docs
-	@echo "Build completed successfully."
 
 # Update docker image to latest
 docker-pull-latest:


### PR DESCRIPTION
1. The submodule check is done essentially every time you call Make, and it's very fast so we can just do it directly rather than in a rule.
2. Remove the 3-level recursive `make` to handle Docker, which as far as I can tell was completely unnecessary because it is already handled by the `SKIP_DOCKER` flag on line 40.