### PR TITLE
Fix unterminated example block

### DIFF
--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -743,6 +743,7 @@ back_cfi_not_active:
     :
 }
 ----
+====
 
 <<<
 


### PR DESCRIPTION
This note was missing its closing `====` which causes rendering issues for all content after this point. For some reason Asciidoctor ignored this mistake until we enabled highlighting for the C source in the note.