### PR TITLE
Remove obsolete non-normative text in scalar crypto chapter

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4158,13 +4158,6 @@ See <<crypto_scalar_appx_es_access>>.
 
 The <<zbkb-sc>>, <<zbkc-sc>> and <<zbkx-sc>> extensions are included in their entirety.
 
-.Note to implementers
-[NOTE,caption="SH"]
-====
-Recall that `rev`, `zip` and `unzip` are pseudoinstructions representing
-specific instances of `grevi`, `shfli` and `unshfli` respectively.
-====
-
 [%header,cols="^1,^1,4,8"]
 |===
 |RV32


### PR DESCRIPTION
Resolves #2147