### PR TITLE
Avoid stating that G bit is reserved in PTE of G-stage

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1769,7 +1769,7 @@ load or store, not for the original access type. However, any exception
 is always reported for the original access type (instruction, load, or
 store/AMO).
 
-The G bit in all G-stage PTEs is reserved for future standard use. Until
+The G bit in all G-stage PTEs is currently not used. Until
 its use is defined by a standard extension, it should be cleared by
 software for forward compatibility, and must be ignored by hardware.
 


### PR DESCRIPTION
Avoid stating that the  G bit is reserved in the PTE of the G-stage address translation since the spec requires the G bit to be ignored.  Otherwise, we have a contradiction with an earlier section of the spec which states that a reserved bit in a PTE would lead to a page fault when such bit is set.