### PR TITLE
Clearly specify FENCE.I ordering requirements

### DIFF
--- a/src/zifencei.adoc
+++ b/src/zifencei.adoc
@@ -92,8 +92,8 @@ Initially, flag = 0.
 
 Producer hart:                                  Consumer hart:
 
-la t0, patch_me                                 la t0, flag
-li t1, 0x4585                                   lw a0, (t0)
+la t0, patch_me                                 la t2, flag
+li t1, 0x4585                                   lw a0, (t2)
 sh t1, (t0)   # patch_me := c.li a1, 1          fence.i
 fence w, w    # order flag write              patch_me:
 la t0, flag                                     c.li a1, 0


### PR DESCRIPTION
The ratified FENCE.I definition specifies a sufficient code sequence for multiprocessor instruction-memory modification (on the producer, store to instruction memory, fence, then communicate with the consumer; on the consumer, observe communication, fence.i, then execute the new code).
    
However, the spec does not explain _why_ this sequence suffices.  The explanation is that FENCE.I orders older loads on the same thread before younger instruction fetches.  (Otherwise, nothing would force the consumer's observation of the communication to occur before the next fetch.)
    
Combined with the existing statement in the spec that older stores on the same hart are ordered before younger fetches, the overall implied rule is easy to state: FENCE.I orders all older explicit memory accesses before all younger fetches.
