### PR TITLE
priv-csr:table 8: add missing +

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -938,7 +938,7 @@ MRW +
 `minstreth` +
 `mhpmcounter3h` +
 `mhpmcounter4h` +
-&#8942;
+&#8942; +
 `mhpmcounter31h`
 |Machine cycle counter. +
 Machine instructions-retired counter. +


### PR DESCRIPTION
Resolves Issue #2200 

html previous:
<img width="823" height="214" alt="476818060-7b8d92a2-6a0a-4fa0-bd97-5873b9213305" src="https://github.com/user-attachments/assets/50b80bde-ac6a-4320-a76c-8e26d7e06037" />

html after:
<img width="793" height="160" alt="image" src="https://github.com/user-attachments/assets/2a175be3-3f55-46ab-bbf0-52e08e61d64f" />


The pdf didn't really change, I'm guessing the narrower margins (with line wrapping) lead to `mhpmcounter31h` already ending up on the next line.

pdf previous:
<img width="772" height="120" alt="image" src="https://github.com/user-attachments/assets/3eab9145-ec79-4e97-9721-34acf5c74f97" />

pdf after:
<img width="764" height="153" alt="image" src="https://github.com/user-attachments/assets/655d8d48-47af-4ea3-bccf-c4c3f73a3d71" />
