### PR TITLE
Fix C++ rendering when multiple ++ pairs in same paragraph

### DIFF
--- a/src/mm-eplan.adoc
+++ b/src/mm-eplan.adoc
@@ -776,7 +776,7 @@ not enforced. This facilitates the porting of code written under the TSO
 and/or RCpc memory models. To enforce store-release-to-load-acquire
 ordering, the code must use store-release-RCsc and load-acquire-RCsc
 operations so that PPO rule 7 applies. RCpc alone is
-sufficient for many use cases in C/C++ but is insufficient for many
+sufficient for many use cases in C/C\++ but is insufficient for many
 other use cases in C/C++, Java, and Linux, to name just a few examples;
 see <<memory_porting, Memory Porting>> for details.
 


### PR DESCRIPTION
### Problem
AsciiDoc parser incorrectly handles paragraphs containing multiple `++` sequences (e.g., two instances of "C/C++"). The parser treats these as markup pairs, causing content between them to be stripped during compilation, resulting in "C/C++" being rendered as "C/C" in the HTML output.

### Solution
Escape the first `+` character in the first occurrence of "C/C++" by adding a backslash (`C/C\++`), which breaks the incorrect pairing while maintaining proper rendering of both C++ references.

### Files Modified
- `src/mm-eplan.adoc`: Line 779 - escaped first plus sign in C/C++ reference

### Testing
Verified that both C++ references now render correctly in the compiled HTML output.

---

**Developer Certificate of Origin**
By submitting this pull request, I certify that I have the right to submit it under the open source license indicated in the file, and I agree to the Developer Certificate of Origin as outlined in the contribution guidelines.

Signed-off-by: Sheng Jiang jiangshengdev@outlook.com