### PR TITLE
Update supervisor.adoc

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -362,6 +362,13 @@ An interrupt _i_ will trap to S-mode if both of the following are true:
 `sstatus` register is set, or the current privilege mode has less
 privilege than S-mode; and (b) bit _i_ is set in both `sip` and `sie`.
 
+NOTE
+====
+Trapping to S-mode only occurs if bit _i_ of `mideleg` is set. Otherwise,
+bit _i_ of `sip` and `sie` are read-only zero so condition (b) cannot be
+be satisfied.
+====
+
 These conditions for an interrupt trap to occur must be evaluated in a
 bounded amount of time from when an interrupt becomes, or ceases to be,
 pending in `sip`, and must also be evaluated immediately following the


### PR DESCRIPTION
Nonnormative text clarifying why interrupts to S-mode only occur if mideleg = 1 even though this criteria is not explicit in the rule. See https://github.com/riscv/riscv-isa-manual/issues/1163