### PR TITLE
Zihintntl compressed hints are predicated on Zca, not C

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -272,8 +272,8 @@ instruction. The dynamic code executed between the LR and SC
 instructions can only contain instructions from the base ''I''
 instruction set, excluding loads, stores, backward jumps, taken backward
 branches, JALR, FENCE, and SYSTEM instructions.
-Compressed forms of the aforementioned ''I'' instructions in the Zca and Zcb
-extensions are also permitted.
+Compressed forms of the aforementioned ''I'' instructions in the
+C (hence Zca) and Zcb extensions are also permitted.
 * The code to retry a failing LR/SC sequence can contain backwards jumps
 and/or branches to repeat the LR/SC sequence, but otherwise has the same
 constraint as the code between the LR and SC.

--- a/src/zihintntl.adoc
+++ b/src/zihintntl.adoc
@@ -89,7 +89,7 @@ system should use NTL.P1 to indicate a lack of temporal locality
 exploitable by the L1, or should use NTL.ALL indicate a lack of temporal
 locality exploitable by the L2.
 
-If the Zca extension is provided, compressed variants of these HINTs are
+If the C or Zca extension is provided, compressed variants of these HINTs are
 also provided: C.NTL.P1 is encoded as C.ADD _x0, x2_; C.NTL.PALL is
 encoded as C.ADD _x0, x3_; C.NTL.S1 is encoded as C.ADD _x0, x4_; and
 C.NTL.ALL is encoded as C.ADD _x0, x5_.


### PR DESCRIPTION
This fixes an editing error that arose because the Zc* extensions were merged after Zihintntl, but Zihintntl was not updated accordingly.

Ordinarily, this kind of change would be incompatible, on the basis that we would be shoehorning instructions into Zca after the fact.  But these are HINTs, and so functionally they must be present on all implementations of Zca, regardless of the implementer's intent to implement Zihintntl. Hence, no HW implementation is invalidated by making this change.

Resolves #2212