### PR TITLE
Clarify constrained-unpredictable translation rule wrt VA-width change

### DIFF
--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1155,10 +1155,25 @@ loads or stores to the same address.
 ====
 A consequence of this specification is that an implementation may use
 any translation for an address that was valid at any time since the most
-recent SFENCE.VMA that subsumes that address. In particular, if a leaf
-PTE is modified but a subsuming SFENCE.VMA is not executed, either the
-old translation or the new translation will be used, but the choice is
-unpredictable. The behavior is otherwise well-defined.
+recent SFENCE.VMA that subsumes that address.
+
+For example, if a leaf PTE is modified and the corresponding virtual address
+is accessed without a subsuming SFENCE.VMA having been executed in between,
+then either the new translation or any older translation since the last
+subsuming SFENCE.VMA was executed will be used.
+It is unpredictable which translation will be chosen from that set, and
+subsequent accesses to the same virtual address might use different
+translations from that set.
+But the behavior of such accesses is otherwise well defined.
+
+This property applies even if the virtual-address width for that translation
+differs from the width currently specified by `satp`.MODE.
+For a given virtual address and ASID, any translation since the last subsuming
+SFENCE.VMA might be used, even if that translation used a virtual address of a
+different width.
+Similarly, for a given virtual address, any global translation since the
+last subsuming SFENCE.VMA might be used, regardless of both ASID and
+virtual-address width.
 
 In a conventional TLB design, it is possible for multiple entries to
 match a single address if, for example, a page is upgraded to a


### PR DESCRIPTION
A translation can indeed be satisfied by a cached translation from a different virtual-address width if there has been no intervening SFENCE.VMA