### PR TITLE
Improve description of Zfbfmin extension

### DIFF
--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -309,8 +309,11 @@ of the BF16 format. It enables BF16 as an interchange format as it provides conv
 between BF16 values and FP32 values.
 
 This extension depends upon the single-precision floating-point extension
-`F`, and the `FLH`, `FSH`, `FMV.X.H`, and `FMV.H.X` instructions as
-defined in the `Zfh` extension.
+`F`.
+
+This extension includes six instructions: the `FCVT.BF16.S` and `FCVT.S.BF16`
+instructions, defined below, and the `FLH`, `FSH`, `FMV.X.H`, and `FMV.H.X`
+instructions, defined in <<chap:zfh>>.
 
 [NOTE]
 ====

--- a/src/zfh.adoc
+++ b/src/zfh.adoc
@@ -1,3 +1,4 @@
+[[chap:zfh]]
 == "Zfh" and "Zfhmin" Extensions for Half-Precision Floating-Point, Version 1.0
 
 This chapter describes the Zfh standard extension for 16-bit


### PR DESCRIPTION
Using a single sentence to describe an extension-dependence relationship and an instruction-inclusion relationship is a source of confusion.

See https://github.com/riscv-software-src/riscv-isa-sim/pull/2058