### PR TITLE
Fix Makefile warning message for submodule checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ all: build
 # Check if the docs-resources/global-config.adoc file exists. If not, the user forgot to check out submodules.
 ifeq ("$(wildcard docs-resources/global-config.adoc)","")
   $(warning You must clone with --recurse-submodules to automatically populate the submodule 'docs-resources'.")
-  $(warning Checking out submodules for you via 'git submodule update --init --recurse'...)
+  $(warning Checking out submodules for you via 'git submodule update --init --recursive'...)
   $(shell git submodule update --init --recursive)
 endif
 


### PR DESCRIPTION
The warning uses the `--recurse` flag but the actual command uses the `--recursive` flag.