### PR TITLE
Clarify prohibition on memory access by SS instructions when satp mode is Bare

### DIFF
--- a/src/priv-cfi.adoc
+++ b/src/priv-cfi.adoc
@@ -207,10 +207,9 @@ encoding `R=0`, `W=1`, and `X=0`, is defined to represent an SS page. When
 `henvcfg.SSE=0`, this encoding remains reserved at `VS` and `VU` levels.
 
 If `satp.MODE` (or `vsatp.MODE` when `V=1`) is set to `Bare` and the effective
-privilege mode is below M, shadow stack memory accesses are prohibited, and
-shadow stack instructions will raise a store/AMO access-fault exception. When
-the effective privilege mode is M, any memory access by an `SSAMOSWAP.W/D`
-instruction will result in a store/AMO access-fault exception.
+privilege mode is less than M, shadow stack instructions raise a store/AMO
+access-fault exception. When the effective privilege mode is M, memory access
+by an `SSAMOSWAP.W/D` instruction results in a store/AMO access-fault exception.
 
 Memory mapped as an SS page cannot be written to by instructions other than
 `SSAMOSWAP.W/D`, `SSPUSH`, and `C.SSPUSH`. Attempts will raise a store/AMO


### PR DESCRIPTION
closes #2234 