### PR TITLE
Add Zcb c.mul, c.not, and c.zext to Zkt.

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4105,6 +4105,23 @@ Same criteria as in RVI. Organised by quadrants.
 | &#10003; | &#10003; | c.add
 |===
 
+===== Zcb Extension
+
+These instructions are compressed versions of I and M instructions that are
+included in Zkt.
+
+[%header,cols="^1,^1,4,8"]
+|===
+|RV32
+|RV64
+|Mnemonic
+|Instruction
+
+| &#10003; | &#10003; | c.mul       | <<insns-c_mul>>
+| &#10003; | &#10003; | c.not       | <<insns-c_not>>
+| &#10003; | &#10003; | c.zext.b    | <<insns-c_zext_b>>
+|===
+
 ===== RVK (Scalar Cryptography)
 
 All K-specific instructions are included.


### PR DESCRIPTION
These instructions expand to 32-bit instructions that are part of Zkt. They need to be included in Zkt to make assembler compression valid.

Addresses #2257