### PR TITLE
Remove Changelog from Scalar Cryptography.

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -1,20 +1,6 @@
 [[crypto_scalar_instructions]]
 == Cryptography Extensions: Scalar & Entropy Source Instructions, Version 1.0.1
 
-=== Changelog
-
-[cols="1,5"]
-|===
-| Version | Changes
-
-| `v1.0.1`
-| Fix typos to show that
-  `c.srli`, `c.srai`, and `c.slli` are Zkt instructions in RV64.
-
-| `v1.0.0`
-| Initial Release
-|===
-
 [[crypto_scalar_introduction]]
 === Introduction
 


### PR DESCRIPTION
This pre-dates integration into the ISA manual and doesn't look like a standard practice in the ISA manual.