### PR TITLE
Fixed typo of "architecture class"

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -216,7 +216,7 @@ The Zcmp extension is a set of instructions which may be executed as a series of
 This extension reuses some encodings from _c.fsdsp_.  Therefore it is _incompatible_ with <<Zcd>>,
  which is included when C and D extensions are both present.
 
-NOTE: Zcmp is primarily targeted at embedded class CPUs due to implementation complexity. Additionally, it is not compatible with architecture class profiles.
+NOTE: Zcmp is primarily targeted at embedded class CPUs due to implementation complexity. Additionally, it is not compatible with application class profiles.
 
 The Zcmp extension depends on the <<Zca>> extension.
 


### PR DESCRIPTION
"architecture class" -> "application class" to be consistent with other use of application class in this manual