### PR TITLE
Fixup typo of RL for PPO6 & 7

### DIFF
--- a/src/mm-herd.adoc
+++ b/src/mm-herd.adoc
@@ -50,7 +50,7 @@ let rsw = rf^-1;rf
 (* Acquire, or stronger  *)
 let AQ = Acq|AcqRel
 (* Release or stronger *)
-and RL = RelAcqRel
+let RL = Rel|AcqRel
 (* All RCsc *)
 let RCsc = Acq|Rel|AcqRel
 (* Amo events are both R and W, relation rmw relates paired lr/sc *)


### PR DESCRIPTION
Current riscv AQ & RL (Zalasr) instructions are RCsc. This typo affects PPO6 and PPO7.