### PR TITLE
fix zcmp/zcmt instruction pages formatting

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -332,11 +332,11 @@ c.mul uses the existing CA format.
 [#insns-c_lbu,reftext="Load unsigned byte, 16-bit encoding"]
 ==== c.lbu
 
-Synopsis:
+Synopsis::
 
 Load unsigned byte, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.lbu _rd'_, _uimm_(_rs1'_)
 
@@ -363,7 +363,7 @@ The immediate offset is formed as follows:
   uimm[0]    = encoding[6];
 --
 
-Description:
+Description::
 
 This instruction loads a byte from the memory address formed by adding _rs1'_ to the zero extended immediate _uimm_. The resulting byte is zero extended to XLEN bits and is written to _rd'_.
 
@@ -372,13 +372,13 @@ This instruction loads a byte from the memory address formed by adding _rs1'_ to
 _rd'_ and _rs1'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 //32-bit equivalent:
 //<<insns-lbu>>
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -391,11 +391,11 @@ X(rdc) = EXTZ(mem[X(rs1c)+EXTZ(uimm)][7..0]);
 [#insns-c_lhu,reftext="Load unsigned halfword, 16-bit encoding"]
 ==== c.lhu
 
-Synopsis:
+Synopsis::
 
 Load unsigned halfword, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.lhu _rd'_, _uimm_(_rs1'_)
 
@@ -423,7 +423,7 @@ The immediate offset is formed as follows:
   uimm[0]    = 0;
 ----
 
-Description:
+Description::
 
 This instruction loads a halfword from the memory address formed by adding _rs1'_ to the zero extended immediate _uimm_. The resulting halfword is zero extended to XLEN bits and is written to _rd'_.
 
@@ -432,14 +432,14 @@ This instruction loads a halfword from the memory address formed by adding _rs1'
 _rd'_ and _rs1'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 //32-bit equivalent:
 //
 //<<insns-lhu>>
 
-Operation:
+Operation::
 
 [source,sail]
 --
@@ -452,11 +452,11 @@ X(rdc) = EXTZ(load_mem[X(rs1c)+EXTZ(uimm)][15..0]);
 [#insns-c_lh,reftext="Load signed halfword, 16-bit encoding"]
 ==== c.lh
 
-Synopsis:
+Synopsis::
 
 Load signed halfword, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.lh _rd'_, _uimm_(_rs1'_)
 
@@ -484,7 +484,7 @@ The immediate offset is formed as follows:
   uimm[0]    = 0;
 ----
 
-Description:
+Description::
 
 This instruction loads a halfword from the memory address formed by adding _rs1'_ to the zero extended immediate _uimm_. The resulting halfword is sign extended to XLEN bits and is written to _rd'_.
 
@@ -493,14 +493,14 @@ This instruction loads a halfword from the memory address formed by adding _rs1'
 _rd'_ and _rs1'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 //32-bit equivalent:
 //
 //<<insns-lh>>
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -513,11 +513,11 @@ X(rdc) = EXTS(load_mem[X(rs1c)+EXTZ(uimm)][15..0]);
 [#insns-c_sb,reftext="Store byte, 16-bit encoding"]
 ==== c.sb
 
-Synopsis:
+Synopsis::
 
 Store byte, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.sb _rs2'_, _uimm_(_rs1'_)
 
@@ -544,7 +544,7 @@ The immediate offset is formed as follows:
   uimm[0]    = encoding[6];
 ----
 
-Description:
+Description::
 
 This instruction stores the least significant byte of _rs2'_ to the memory address formed by adding _rs1'_ to the zero extended immediate _uimm_.
 
@@ -553,7 +553,7 @@ This instruction stores the least significant byte of _rs2'_ to the memory addre
 _rs1'_ and _rs2'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 //
@@ -561,7 +561,7 @@ None
 //
 //<<insns-sb>>
 
-Operation:
+Operation::
 
 [source,sail]
 --
@@ -574,11 +574,11 @@ mem[X(rs1c)+EXTZ(uimm)][7..0] = X(rs2c)
 [#insns-c_sh,reftext="Store halfword, 16-bit encoding"]
 ==== c.sh
 
-Synopsis:
+Synopsis::
 
 Store halfword, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.sh _rs2'_, _uimm_(_rs1'_)
 
@@ -606,7 +606,7 @@ The immediate offset is formed as follows:
   uimm[0]    = 0;
 ----
 
-Description:
+Description::
 
 This instruction stores the least significant halfword of _rs2'_ to the memory address formed by adding _rs1'_ to the zero extended immediate _uimm_.
 
@@ -615,7 +615,7 @@ This instruction stores the least significant halfword of _rs2'_ to the memory a
 _rs1'_ and _rs2'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 //
@@ -623,7 +623,7 @@ None
 //
 //<<insns-sh>>
 
-Operation:
+Operation::
 [source,sail]
 ----
 //This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
@@ -635,11 +635,11 @@ mem[X(rs1c)+EXTZ(uimm)][15..0] = X(rs2c)
 [#insns-c_zext_b,reftext="Zero extend byte, 16-bit encoding"]
 ==== c.zext.b
 
-Synopsis:
+Synopsis::
 
 Zero extend byte, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.zext.b _rd'/rs1'_
 
@@ -657,7 +657,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes a single source/destination operand.
 It zero-extends the least-significant byte of the operand to XLEN bits by inserting zeros into all of
@@ -668,7 +668,7 @@ the bits more significant than 7.
 _rd'/rs1'_ is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -684,7 +684,7 @@ andi rd'/rs1', rd'/rs1', 0xff
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -695,11 +695,11 @@ X(rsdc) = EXTZ(X(rsdc)[7..0]);
 [#insns-c_sext_b,reftext="Sign extend byte, 16-bit encoding"]
 ==== c.sext.b
 
-Synopsis:
+Synopsis::
 
 Sign extend byte, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.sext.b _rd'/rs1'_
 
@@ -717,7 +717,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes a single source/destination operand.
 It sign-extends the least-significant byte in the operand to XLEN bits by copying the most-significant bit
@@ -728,7 +728,7 @@ in the byte (i.e., bit 7) to all of the more-significant bits.
 _rd'/rs1'_ is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 Zbb is also required.
 //
@@ -740,7 +740,7 @@ Zbb is also required.
 
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -751,11 +751,11 @@ X(rsdc) = EXTS(X(rsdc)[7..0]);
 [#insns-c_zext_h,reftext="Zero extend halfword, 16-bit encoding"]
 ==== c.zext.h
 
-Synopsis:
+Synopsis::
 
 Zero extend halfword, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.zext.h _rd'/rs1'_
 
@@ -773,7 +773,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes a single source/destination operand.
 It zero-extends the least-significant halfword of the operand to XLEN bits by inserting zeros into all of
@@ -784,7 +784,7 @@ the bits more significant than 15.
 _rd'/rs1'_ is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 Zbb is also required.
 //
@@ -797,7 +797,7 @@ Zbb is also required.
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -808,11 +808,11 @@ X(rsdc) = EXTZ(X(rsdc)[15..0]);
 [#insns-c_sext_h,reftext="Sign extend halfword, 16-bit encoding"]
 ==== c.sext.h
 
-Synopsis:
+Synopsis::
 
 Sign extend halfword, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.sext.h _rd'/rs1'_
 
@@ -830,7 +830,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes a single source/destination operand.
 It sign-extends the least-significant halfword in the operand to XLEN bits by copying the most-significant bit
@@ -841,7 +841,7 @@ in the halfword (i.e., bit 15) to all of the more-significant bits.
 _rd'/rs1'_ is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 Zbb is also required.
 //
@@ -854,7 +854,7 @@ Zbb is also required.
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -865,11 +865,11 @@ X(rsdc) = EXTS(X(rsdc)[15..0]);
 [#insns-c_zext_w,reftext="Zero extend word, 16-bit encoding"]
 ==== c.zext.w
 
-Synopsis:
+Synopsis::
 
 Zero extend word, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.zext.w _rd'/rs1'_
 
@@ -887,7 +887,7 @@ Encoding (RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes a single source/destination operand.
 It zero-extends the least-significant word of the operand to XLEN bits by inserting zeros into all of
@@ -898,7 +898,7 @@ the bits more significant than 31.
 _rd'/rs1'_ is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 Zba is also required.
 
@@ -914,7 +914,7 @@ add.uw rd'/rs1', rd'/rs1', zero
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -925,11 +925,11 @@ X(rsdc) = EXTZ(X(rsdc)[31..0]);
 [#insns-c_not,reftext="Bitwise not, 16-bit encoding"]
 ==== c.not
 
-Synopsis:
+Synopsis::
 
 Bitwise not, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.not _rd'/rs1'_
 
@@ -947,7 +947,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction takes the one's complement of _rd'/rs1'_ and writes the result to the same register.
 
@@ -956,7 +956,7 @@ This instruction takes the one's complement of _rd'/rs1'_ and writes the result 
 rd'/rs1' is from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -972,7 +972,7 @@ xori rd'/rs1', rd'/rs1', -1
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -983,11 +983,11 @@ X(rsdc) = X(rsdc) XOR -1;
 [#insns-c_mul,reftext="Multiply, 16-bit encoding"]
 ==== c.mul
 
-Synopsis:
+Synopsis::
 
 Multiply, 16-bit encoding
 
-Mnemonic:
+Mnemonic::
 
 c.mul _rsd'_, _rs2'_
 
@@ -1005,7 +1005,7 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
-Description:
+Description::
 
 This instruction multiplies XLEN bits of the source operands from _rsd'_ and _rs2'_ and writes the lowest XLEN bits of the result to _rsd'_.
 
@@ -1014,7 +1014,7 @@ This instruction multiplies XLEN bits of the source operands from _rsd'_ and _rs
 _rd'/rs1'_ and _rs2'_ are from the standard 8-register set x8-x15.
 ====
 
-Prerequisites:
+Prerequisites::
 
 M or Zmmul must be configured.
 //
@@ -1027,7 +1027,7 @@ M or Zmmul must be configured.
 The SAIL module variable for _rd'/rs1'_ is called _rsdc_, and for _rs2'_ is called _rs2c_.
 ====
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -1393,11 +1393,11 @@ addi sp, sp, 64;
 [#insns-cm_push,reftext="cm.push"]
 ==== cm.push
 
-Synopsis:
+Synopsis::
 
 Create stack frame: store ra and 0 to 12 saved registers to the stack frame, optionally allocate additional stack space.
 
-Mnemonic:
+Mnemonic::
 
 cm.push _{reg_list}, -stack_adj_
 
@@ -1521,7 +1521,7 @@ switch (rlist) {
 ----
 
 <<<
-Description:
+Description::
 
 This instruction pushes (stores) the registers in _reg_list_ to the memory below the stack pointer,
 and then creates the stack frame by decrementing the stack pointer by _stack_adj_,
@@ -1544,7 +1544,7 @@ _spimm_ is the number of additional 16-byte address increments allocated for the
 The total stack adjustment represents the total size of the stack frame, which is _stack_adj_base_ added to _spimm_ scaled by 16,
 as defined above.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -1552,7 +1552,7 @@ None
 
 No direct equivalent encoding exists
 
-Operation:
+Operation::
 
 The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
@@ -1588,11 +1588,11 @@ sp-=stack_adj;
 [#insns-cm_pop,reftext="cm.pop"]
 ==== cm.pop
 
-Synopsis:
+Synopsis::
 
 Destroy stack frame: load ra and 0 to 12 saved registers from the stack frame, deallocate the stack frame.
 
-Mnemonic:
+Mnemonic::
 
 cm.pop  _{reg_list}, stack_adj_
 
@@ -1717,7 +1717,7 @@ switch (rlist) {
 
 <<<
 
-Description:
+Description::
 
 This instruction pops (loads) the registers in _reg_list_ from stack memory,
 and then adjusts the stack pointer by _stack_adj_.
@@ -1738,7 +1738,7 @@ _spimm_ is the number of additional 16-byte address increments allocated for the
 The total stack adjustment represents the total size of the stack frame, which is _stack_adj_base_ added to _spimm_ scaled by 16,
 as defined above.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -1746,7 +1746,7 @@ None
 
 No direct equivalent encoding exists
 
-Operation:
+Operation::
 
 The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
@@ -1782,11 +1782,11 @@ sp+=stack_adj;
 [#insns-cm_popretz,reftext="cm.popretz"]
 ==== cm.popretz
 
-Synopsis:
+Synopsis::
 
 Destroy stack frame: load ra and 0 to 12 saved registers from the stack frame, deallocate the stack frame, move zero into a0, return to ra.
 
-Mnemonic:
+Mnemonic::
 
 cm.popretz _{reg_list}, stack_adj_
 
@@ -1909,7 +1909,7 @@ switch (rlist) {
 
 <<<
 
-Description:
+Description::
 
 This instruction pops (loads) the registers in _reg_list_ from stack memory, adjusts the stack pointer by _stack_adj_, moves zero into a0 and then returns to _ra_.
 
@@ -1928,7 +1928,7 @@ _spimm_ is the number of additional 16-byte address increments allocated for the
 
 The total stack adjustment represents the total size of the stack frame, which is _stack_adj_base_ added to _spimm_ scaled by 16, as defined above.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -1937,7 +1937,7 @@ None
 No direct equivalent encoding exists
 
 
-Operation:
+Operation::
 
 The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
@@ -1980,11 +1980,11 @@ asm("ret");
 [#insns-cm_popret,reftext="cm.popret"]
 ==== cm.popret
 
-Synopsis:
+Synopsis::
 
 Destroy stack frame: load ra and 0 to 12 saved registers from the stack frame, deallocate the stack frame, return to ra.
 
-Mnemonic:
+Mnemonic::
 
 cm.popret _{reg_list}, stack_adj_
 
@@ -2109,7 +2109,7 @@ switch (rlist) {
 
 <<<
 
-Description:
+Description::
 
 This instruction pops (loads) the registers in _reg_list_ from stack memory, adjusts the stack pointer by _stack_adj_ and then returns to _ra_.
 
@@ -2128,7 +2128,7 @@ _spimm_ is the number of additional 16-byte address increments allocated for the
 
 The total stack adjustment represents the total size of the stack frame, which is _stack_adj_base_ added to _spimm_ scaled by 16, as defined above.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -2136,7 +2136,7 @@ None
 
 No direct equivalent encoding exists
 
-Operation:
+Operation::
 
 The first section of pseudocode may be executed multiple times before the instruction successfully completes.
 
@@ -2174,11 +2174,11 @@ asm("ret");
 [#insns-cm_mvsa01,reftext="Move a0-a1 into two different s0-s7 registers"]
 ==== cm.mvsa01
 
-Synopsis:
+Synopsis::
 
 Move a0-a1 into two registers of s0-s7
 
-Mnemonic:
+Mnemonic::
 
 cm.mvsa01 _r1s'_, _r2s'_
 
@@ -2208,7 +2208,7 @@ Assembly Syntax:
 cm.mvsa01 r1s', r2s'
 ----
 
-Description:
+Description::
 This instruction moves _a0_ into _r1s'_ and _a1_ into _r2s'_.  _r1s'_ and _r2s'_ must be different.
 The execution is atomic, so it is not possible to observe state where only one of _r1s'_ or _r2s'_ has been updated.
 
@@ -2220,7 +2220,7 @@ The mapping between them is specified in the pseudocode below.
 The _s_ register mapping is taken from the UABI, and may not match the currently unratified EABI. _cm.mvsa01.e_ may be included in the future.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -2228,7 +2228,7 @@ None
 
 No direct equivalent encoding exists.
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -2247,11 +2247,11 @@ X[xreg2] = X[11];
 [#insns-cm_mva01s,reftext="Move two s0-s7 registers into a0-a1"]
 ==== cm.mva01s
 
-Synopsis:
+Synopsis::
 
 Move two s0-s7 registers into a0-a1
 
-Mnemonic:
+Mnemonic::
 
 cm.mva01s _r1s'_, _r2s'_
 
@@ -2276,7 +2276,7 @@ Assembly Syntax:
 cm.mva01s r1s', r2s'
 ----
 
-Description:
+Description::
 This instruction moves _r1s'_ into _a0_ and _r2s'_ into _a1_.
 The execution is atomic, so it is not possible to observe state where only one of _a0_ or _a1_ have been updated.
 
@@ -2288,7 +2288,7 @@ The mapping between them is specified in the pseudocode below.
 The _s_ register mapping is taken from the UABI, and may not match the currently unratified EABI. _cm.mva01s.e_ may be included in the future.
 ====
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -2296,7 +2296,7 @@ None
 
 No direct equivalent encoding exists.
 
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -2362,7 +2362,7 @@ If an exception occurs on either instruction fetch, xEPC is set to the PC of the
 [#csrs-jvt,reftext="jvt CSR, table jump base vector and control register"]
 ==== jvt CSR
 
-Synopsis:
+Synopsis::
 
 Table jump base vector and control register
 
@@ -2394,7 +2394,7 @@ Format (RV64):
 ],config:{bits:64}}
 ....
 
-Description:
+Description::
 
 The _jvt_ register is an XLEN-bit *WARL* read/write register that holds the jump table configuration, consisting of the jump table base address (BASE) and the jump table mode (MODE).
 
@@ -2434,11 +2434,11 @@ If the Smstateen extension is implemented, then bit 2 in _mstateen0_, _sstateen0
 [#insns-cm_jt,reftext="Jump via table"]
 ==== cm.jt
 
-Synopsis:
+Synopsis::
 
 jump via table
 
-Mnemonic:
+Mnemonic::
 
 cm.jt _index_
 
@@ -2471,13 +2471,13 @@ Assembly Syntax:
 cm.jt index
 ----
 
-Description:
+Description::
 
 _cm.jt_ reads an entry from the jump vector table in memory and jumps to the address that was read.
 
 For further information see <<insns-tablejump>>.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -2488,7 +2488,7 @@ No direct equivalent encoding exists.
 <<<
 
 [#insns-cm_jt-SAIL,reftext="cm.jt SAIL code"]
-Operation:
+Operation::
 
 [source,sail]
 ----
@@ -2513,11 +2513,11 @@ j target_address[XLEN-1:0]&~0x1;
 [#insns-cm_jalt,reftext="Jump and link via table"]
 ==== cm.jalt
 
-Synopsis:
+Synopsis::
 
 jump via table with optional link
 
-Mnemonic:
+Mnemonic::
 
 cm.jalt _index_
 
@@ -2550,13 +2550,13 @@ Assembly Syntax:
 cm.jalt index
 ----
 
-Description:
+Description::
 
 _cm.jalt_ reads an entry from the jump vector table in memory and jumps to the address that was read, linking to _ra_.
 
 For further information see <<insns-tablejump>>.
 
-Prerequisites:
+Prerequisites::
 
 None
 
@@ -2567,7 +2567,7 @@ No direct equivalent encoding exists.
 <<<
 
 [#insns-cm_jalt-SAIL,reftext="cm.jalt SAIL code"]
-Operation:
+Operation::
 
 [source,sail]
 ----


### PR DESCRIPTION
all the headings had : instead of ::