### PR TITLE
Remove redundant intro in Zicond spec

### DIFF
--- a/src/zicond.adoc
+++ b/src/zicond.adoc
@@ -14,10 +14,6 @@ Yet, low-cost conditional instructions are a desirable feature as they allow the
 
 === Zicond specification
 
-The "Conditional" operations extension provides a simple solution that provides most of the benefit and all of the flexibility one would desire to support conditional arithmetic and conditional-select/move operations, while remaining true to the RISC-V design philosophy.
-The instructions follow the format for R-type instructions with 3 operands (i.e., 2 source operands and 1 destination operand).
-Using these instructions, branchless sequences can be implemented (typically in two-instruction sequences) without the need for instruction fusion, special provisions during the decoding of architectural instructions, or other microarchitectural provisions.
-
 The following instructions comprise the Zicond extension:
 
 [%header,cols="^1,^1,4,8"]


### PR DESCRIPTION
The Zicond `Introduction` section and the first few paragraphs of the `Zicond specification` section were nearly identical. This removes the duplicate text in the `Zicond specification` section.