### PR TITLE
Remove freeze/ratification note from vector spec

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -11,11 +11,7 @@ domains._
 
 === Introduction
 
-This spec includes the complete set of currently frozen vector
-instructions.  Other instructions that have been considered during
-development but are not present in this document are not included in
-the review and ratification process, and may be completely revised or
-abandoned.  <<sec-vector-extensions>> lists the standard
+<<sec-vector-extensions>> lists the standard
 vector extensions and which instructions and element widths are
 supported by each extension.
 


### PR DESCRIPTION
Remove the introductory note about the "currently frozen vector instructions" and the ratification process now that the vector extensions are ratified.