### PR TITLE
Add seemingly obvious statement that fetch precedes execute

### DIFF
--- a/src/zifencei.adoc
+++ b/src/zifencei.adoc
@@ -107,6 +107,9 @@ In a realistic producer-consumer code-generation scheme, the consumer would loop
 until `flag` becomes 1 before executing the FENCE.I instruction.
 ====
 
+An instruction fetch is always ordered before any explicit memory accesses
+that instruction gives rise to.
+
 The unused fields in the FENCE.I instruction, _funct12_, _rs1_, and
 _rd_, are reserved for finer-grain fences in future extensions. For
 forward compatibility, base implementations shall ignore these fields,


### PR DESCRIPTION
@dkruckemyer-ventana and I realized in defining the Ziccid extension that we hadn't written this fact down, probably because it seemed tautological.