### PR TITLE
Progress Axiom: Fixup spin_unlock description

### DIFF
--- a/src/mm-eplan.adoc
+++ b/src/mm-eplan.adoc
@@ -449,7 +449,7 @@ other harts in the system in a finite amount of time, and that loads
 from other harts will eventually be able to read those values (or
 successors thereof). Without this rule, it would be legal, for example,
 for a spinlock to spin infinitely on a value, even with a store from
-another hart waiting to unlock the spinlock.
+another hart unlocking the spinlock.
 
 The progress axiom is intended not to impose any other notion of
 fairness, latency, or quality of service onto the harts in a RISC-V


### PR DESCRIPTION
There is no waiting for a spin_unlock, and the store is committed. The word "waiting" confused the people.