### PR TITLE
RVWMO: Fixup litmus_ppoca sequence description

### DIFF
--- a/src/mm-eplan.adoc
+++ b/src/mm-eplan.adoc
@@ -358,7 +358,7 @@ store buffer (but does not drain to memory)
 * (g) executes speculatively and reads the value 0 from memory
 * (a) executes, enters the first hart's private store buffer, and
 drains to memory
-* (b) executes and retires
+* (b) executes, guarantee the first hart's write order
 * (c) executes, enters the first hart's private store buffer, and
 drains to memory
 * (d) executes and reads the value 1 from memory


### PR DESCRIPTION
The (b) "fence w,w" is not "executes and retires". Correct it with "executes, guarantee the first hart's write order".