### PR TITLE
Fix incorrect source language annotations.

### DIFF
--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -285,7 +285,7 @@ addition are required, leveraging the observation that the sum should be
 less than one of the operands if and only if the other operand is
 negative.
 
-[source,text]
+[source,asm]
 ....
          add t0, t1, t2
          slti t3, t2, 0

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -674,7 +674,7 @@ None
 
 32-bit equivalent:
 
-[source,sail]
+[source,asm]
 ----
 andi rd'/rs1', rd'/rs1', 0xff
 ----
@@ -904,7 +904,7 @@ Zba is also required.
 
 32-bit equivalent:
 
-[source,sail]
+[source,asm]
 ----
 add.uw rd'/rs1', rd'/rs1', zero
 ----
@@ -962,7 +962,7 @@ None
 
 32-bit equivalent:
 
-[source,sail]
+[source,asm]
 ----
 xori rd'/rs1', rd'/rs1', -1
 ----
@@ -1082,7 +1082,7 @@ The function _processMarkers_ in the EMBench benchmark picojpeg in the following
 
 The prologue and epilogue compile with GCC10 to:
 
-[source,SAIL]
+[source,asm]
 ----
 
    0001098a <processMarkers>:
@@ -1123,7 +1123,7 @@ The prologue and epilogue compile with GCC10 to:
 
 with the GCC option _-msave-restore_ the output is the following:
 
-[source,SAIL]
+[source,asm]
 ----
 0001080e <processMarkers>:
    1080e:       73a012ef                jal     t0,11f48 <__riscv_save_12>
@@ -1136,7 +1136,7 @@ with the GCC option _-msave-restore_ the output is the following:
 
 with PUSH/POPRET this reduces to
 
-[source,SAIL]
+[source,asm]
 ----
 0001080e <processMarkers>:
    1080e:       b8fa                    cm.push    {ra,s0-s11},-96
@@ -1210,14 +1210,14 @@ or handles errors responses after completing the PUSH instruction.
 
 For example:
 
-[source,sail]
+[source,asm]
 ----
 cm.push  {ra, s0-s5}, -64
 ----
 
 Appears to software as:
 
-[source,sail]
+[source,asm]
 ----
 # any bytes from sp-1 to sp-28 may be written multiple times before
 # the instruction completes therefore these updates may be visible in
@@ -1259,14 +1259,14 @@ For POPRET once the stack pointer adjustment has been committed the `ret` must e
 <<<
 For example:
 
-[source,sail]
+[source,asm]
 ----
 cm.popretz {ra, s0-s3}, 32;
 ----
 
 Appears to software as:
 
-[source,sail]
+[source,asm]
 ----
 # any or all of these load instructions may execute multiple times
 # therefore these updates may be visible in the interrupt/exception handler
@@ -1308,7 +1308,7 @@ Encoding: _rlist_=7, _spimm_=3
 
 expands to:
 
-[source,sail]
+[source,asm]
 ----
 sw  s2,  -4(sp);
 sw  s1,  -8(sp);
@@ -1323,7 +1323,7 @@ Encoding: _rlist_=15, _spimm_=3
 
 expands to:
 
-[source,sail]
+[source,asm]
 ----
 sw  s11,  -4(sp);
 sw  s10,  -8(sp);
@@ -1349,7 +1349,7 @@ Encoding: _rlist_=4, _spimm_=0
 
 expands to:
 
-[source,sail]
+[source,asm]
 ----
 lw   ra, 12(sp);
 addi sp, sp, 16;
@@ -1361,7 +1361,7 @@ Encoding: _rlist_=8, _spimm_=1
 
 expands to:
 
-[source,sail]
+[source,asm]
 ----
 lw   s3, 44(sp);
 lw   s2, 40(sp);
@@ -1377,7 +1377,7 @@ Encoding: _rlist_=9, _spimm_=2
 
 expands to:
 
-[source,sail]
+[source,asm]
 ----
 lw   s4, 60(sp);
 lw   s3, 56(sp);
@@ -1421,7 +1421,7 @@ _rlist_ values 0 to 3 are reserved for a future EABI variant called _cm.push.e_
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 --
 cm.push {reg_list},  -stack_adj
 cm.push {xreg_list}, -stack_adj
@@ -1616,7 +1616,7 @@ _rlist_ values 0 to 3 are reserved for a future EABI variant called _cm.pop.e_
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 ----
 cm.pop {reg_list},  stack_adj
 cm.pop {xreg_list}, stack_adj
@@ -2203,7 +2203,7 @@ For the encoding to be legal _r1s'_ != _r2s'_.
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 ----
 cm.mvsa01 r1s', r2s'
 ----
@@ -2271,7 +2271,7 @@ Encoding (RV32, RV64):
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 ----
 cm.mva01s r1s', r2s'
 ----
@@ -2466,7 +2466,7 @@ If jvt.mode = 0 (Jump Table Mode) then _cm.jt_ behaves as specified here. If jvt
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 ----
 cm.jt index
 ----
@@ -2545,7 +2545,7 @@ If jvt.mode = 0 (Jump Table Mode) then _cm.jalt_ behaves as specified here. If j
 
 Assembly Syntax:
 
-[source,sail]
+[source,asm]
 ----
 cm.jalt index
 ----


### PR DESCRIPTION
Most were incorrectly marked as `sail`; one marked `text` is better annotated as `asm`.