### PR TITLE
Enable section links

### DIFF
--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -31,6 +31,7 @@ endif::[]
 :listing-caption: Listing
 :sectnums:
 :sectnumlevels: 5
+:sectlinks:
 :toc: left
 :toclevels: 4
 :source-highlighter: rouge

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -28,6 +28,7 @@ endif::[]
 :listing-caption: Listing
 :sectnums:
 :sectnumlevels: 5
+:sectlinks:
 :toc: left
 :toclevels: 5
 :source-highlighter: rouge


### PR DESCRIPTION
This turns the section headings in the generated HTML into links to themselves. It doesn't change the styling at all but it means you can easily right-click->copy-link-address on a heading to get a direct link to it. Previously you could only do that from the TOC which is very long and difficult to navigate.