### PR TITLE
Upgrade GitHub Action to setup-python@v6

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Version v6 provides faster environment setup, improved caching, and full compatibility with the latest Python releases.
Release notes: https://github.com/actions/setup-python/releases/tag/v6.0.0

Change:
uses: actions/setup-python@v5 -> uses: actions/setup-python@v6