### PR TITLE
Making titles consistent

### DIFF
--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -1,4 +1,4 @@
-[[manual:priv,RISC-V ISA Manual: Volume II - Privileged Architecture]]
+[[manual:priv,RISC-V ISA Manual, Volume II: Privileged Architecture]]
 = The RISC-V Instruction Set Manual: Volume II: Privileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Volume II - Privileged Architecture

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -1,4 +1,4 @@
-[[manual:unpriv,RISC-V ISA Manual: Volume I - Unprivileged Architecture]]
+[[manual:unpriv,RISC-V ISA Manual, Volume I: Unprivileged Architecture]]
 = The RISC-V Instruction Set Manual Volume I: Unprivileged Architecture
 include::../docs-resources/global-config.adoc[]
 :description: Unprivileged Architecture


### PR DESCRIPTION
Updating both titles to have a colon between Manual and Volume and a dash between Volume and book name.