### PR TITLE
Add new draft preface to priv spec

### DIFF
--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -1,5 +1,72 @@
 [colophon]
 == Preface
+
+This document describes the RISC-V privileged architecture.
+It contains the following versions of the RISC-V ISA modules,
+all of which have been ratified:
+
+[%autowidth,float="center",align="center",cols="^,<",options="header",]
+|===
+|Module |Version
+|*Machine ISA* +
+*Smstateen Extension* +
+*Smcsrind/Sscsrind Extension* +
+*Smepmp Extension* +
+*Smcntrpmf Extension* +
+*Smrnmi Extension* +
+*Smcdeleg Extension* +
+*Smdbltrp Extension* +
+*Smctr Extension* +
+*Supervisor ISA* +
+*Svade Extension* +
+*Svnapot Extension* +
+*Svpbmt Extension* +
+*Svinval Extension* +
+*Svadu Extension* +
+*Svvptc Extension* +
+*Ssqosid Extension* +
+*Sstc Extension* +
+*Sscofpmf Extension* +
+*Ssdbltrp Extension* +
+*Ssqosid Extension* +
+*Hypervisor ISA* +
+*Shlcofideleg Extension* +
+*Svvptc Extension* +
+*Pointer-Masking Extensions* +
+*Svrsw60t59b Extension*
+
+|*1.13* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.13* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0*
+|===
+
+The following changes have been made since version 20250508:
+
+* Addition of the Svrsw60t59b extension for additional PTE reserved-for-software bits.
+
 // Had to make the above a level 1 heading (two equals signs) to avoid error when building
 // the ISA manual as a book with other "parts". This is opposite to what the adoc says to do
 // but otherwise asciidoctor creates the error message:


### PR DESCRIPTION
We were inadvertently adding new extensions to the 20250508 preface, rather than creating a new preface for this draft version of the document.