### PR TITLE
[#2352] Fixing vsha2c[h|l].vv description

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -3188,7 +3188,7 @@ Description::
 - `SEW`=64: 2 rounds of SHA-512 compression are performed (`zvkhnb`)
 
 Two words of `vs1` are processed with
-the 8 words of current state held in `vd` and `vs1` to perform two
+the 8 words of current state held in `vd` and `vs2` to perform two
 rounds of hash computation producing four words of the
 next state.
 


### PR DESCRIPTION
A typo, pointed out in #2352, made its way into the spec: during the compression operations, the state is read from vd and vs2 (not vs1) and the schedule words are read from vs1.