### PR TITLE
Fix punctuation in RISC-V ISA explanation

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -281,7 +281,7 @@ RV64I. This would also be more consistent with the use of the same LW
 opcode for 32-bit load in both RV32I and RV64I. The very first versions
 of RISC-V ISA did have a variant of this alternate design, but the
 RISC-V design was changed to the current choice in January 2011. Our
-focus was on supporting 32-bit integers in the 64-bit ISA not on
+focus was on supporting 32-bit integers in the 64-bit ISA, not on
 providing compatibility with the 32-bit ISA, and the motivation was to
 remove the asymmetry that arose from having not all opcodes in RV32I
 have a *W suffix (e.g., ADDW, but AND not ANDW). In hindsight, this was


### PR DESCRIPTION
Tiny grammatical detail (added a comma in part of the text I was reading for clarity).