### PR TITLE
Add toggle to enable tag styling

### DIFF
--- a/src/docinfo-header.html
+++ b/src/docinfo-header.html
@@ -1,0 +1,6 @@
+<div class="tag-toggle-container">
+    <button class="tag-toggle-btn" onclick="document.documentElement.classList.toggle('tag-highlight-enabled');">
+        <span id="tag-toggle-label">Highlight Tags</span>
+        <div class="tag-toggle-switch"></div>
+    </button>
+</div>

--- a/src/docinfo.html
+++ b/src/docinfo.html
@@ -1,0 +1,106 @@
+<style>
+/*
+Any ID starting with 'norm:' is a snippet of specification text
+that has been specifically tagged to allow referencing it robustly,
+for use cases such as:
+
+* Linking coverage, tests plans, tests, assertions etc. to parts of
+  the spec that they cover.
+* Detecting when parts of the spec change. You can extract these
+  snippets via Asciidoc's docbook output and parsing the XML.
+* Linking documentation (e.g. the implementation defined parameter list)
+  to the spec.
+
+This adds a toggle button to enable highlighting of the tagged text
+and viewing their tags as tooltips.
+*/
+.tag-highlight-enabled [id^="norm:"] {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-color: green;
+    text-decoration-thickness: 3px;
+    cursor: pointer;
+}
+
+/* Highlight tags when hovered. */
+.tag-highlight-enabled [id^="norm:"]:hover {
+    text-shadow: 0px 0px 10px green;
+}
+
+/* Highlight tags when directly linked to, irrepsective of the highlight toggle. */
+[id^="norm:"]:target {
+    text-shadow: 0px 0px 10px yellow;
+}
+
+/* Tag tooltip on hover. */
+.tag-highlight-enabled [id^="norm:"]:hover::before {
+    content: attr(id);
+    position: absolute;
+    background: #333;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    z-index: 1000;
+    pointer-events: none;
+    margin-top: -2em;
+}
+
+/* Toggle Button Styles */
+.tag-toggle-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+}
+
+.tag-toggle-btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: #fff;
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    transition: all 0.1s ease;
+}
+
+.tag-toggle-btn:hover {
+    border-color: #999;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.tag-toggle-switch {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    background: #ccc;
+    border-radius: 12px;
+    transition: background 0.1s ease;
+}
+
+.tag-toggle-switch::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 0.1s ease;
+}
+
+/* When highlighting is enabled */
+.tag-highlight-enabled .tag-toggle-switch {
+    background: #4CAF50;
+}
+
+.tag-highlight-enabled .tag-toggle-switch::after {
+    transform: translateX(20px);
+}
+</style>


### PR DESCRIPTION
Add a toggle button to the HTML styling output. When enabled this will highlight the `norm:` tags in the document. If you hover them it will show their ID.

Also highlight tags in yellow when directly linked to. This ignores the tag toggle button state.

Fixes #2249