### PR TITLE
Minor typo in rationale.adoc

### DIFF
--- a/src/rationale.adoc
+++ b/src/rationale.adoc
@@ -37,7 +37,7 @@ These instructions can be used as part of a three-instruction sequence to
 synthesize conditional select.
 Several common conditional-execution idioms require only two instructions,
 as would be the case with conditional select or move, including
-conditional addition, subraction, and bitwise AND, OR, and XOR.
+conditional addition, subtraction, and bitwise AND, OR, and XOR.
 
 Two conditional-zero instructions are included: one that writes zero if the
 comparand is zero, and one that does so if the comparand is nonzero.


### PR DESCRIPTION
Changing "subraction" to "subtraction".

I learned a word today "comparand". It is certainly going to go on my list of exotic words between addend and subtrahend.