### PR TITLE
Add Zvbc32e and Zvkgs specifications (into vector crypto chapter)

### DIFF
--- a/normative_rule_defs/vector-crypto.yaml
+++ b/normative_rule_defs/vector-crypto.yaml
@@ -50,6 +50,9 @@ normative_rule_definitions:
   - name: Zvbc_sew64only
     tags: ["norm:Zvbc_sew64only"]
 
+  - name: Zvbc32e_sew8_16_32only
+    tags: ["norm:Zvbc32e_sew8_16_32only"]
+
   - name: Zvkg_egw128b_elem32b
     tags: ["norm:Zvkg_egw128b_elem32b"]
 
@@ -140,11 +143,17 @@ normative_rule_definitions:
   - name: vclmul_sewn64_rsv
     tags: ["norm:vclmul_sewn64_rsv"]
 
+  - name: vclmul_sewn8_16_32_rsv
+    tags: ["norm:vclmul_sewn8_16_32_rsv"]
+
   - name: vclmulh_op
     tags: ["norm:vclmulh_op"]
 
   - name: vclmulh_sewn64_rsv
     tags: ["norm:vclmulh_sewn64_rsv"]
+
+  - name: vclmulh_sewn8_16_32_rsv
+    tags: ["norm:vclmulh_sewn8_16_32_rsv"]
 
   - name: vclz-v_op
     tags: ["norm:vclz-v_op", "norm:vclz-v_op_zeroinput"]

--- a/src/rationale.adoc
+++ b/src/rationale.adoc
@@ -106,22 +106,22 @@ Several limitations arise from this emulation approach:
 The Zabha extension addresses these limitations by adding support for _byte_ and
 _halfword_ atomic memory operations to the RISC-V Unprivileged ISA.
 
-=== "Zvbc32e" Extension for Vector Carry-less Multiplication for `SEW <= 32`
+=== "Zvbc32e" Extension for Vector Carry-less Multiplication for `SEW` {le} 32
 
 
-<<Zvbc>> defines vector carry-less multiplication instructions for SEW=64 only.
-It is not suitable for implementations with small ELEN (32) and incurs some inefficiencies for algorithms where at least one of the multiplication operands is limited to 32 bits (or less).
+<<Zvbc>> defines vector carry-less multiplication instructions for `SEW`=64 only.
+It is not suitable for implementations with small `ELEN` (32) and incurs some inefficiencies for algorithms where at least one of the multiplication operands is limited to 32 bits (or less).
 The list of such algorithms includes the CLM-based folding algorithm used to compute the widespread 32-bit CRCs (e.g. Ethernet CRC)
-With `Zvbc`, only half the 64-bit element multiplication provided is exploited.
+With Zvbc, only half the 64-bit element multiplication provided is exploited.
 This is due to the fact that CRC acceleration based on carry-less multiplication often relies on a product term which is a polynomial modulo the CRC.
 This limits the size of this term to the output size of the CRC.
 
-`Zvbc32e` defines the same vector carry-less multiplication operations as `Zvbc` but on smaller SEW values (32, 16, and 8 bits).
-It can be leveraged by implementations with any ELEN value >= 32.
-For implementations with small ELEN (32), supporting Zvbc32e brings ISA support for vector carry-less multiplication (which was not possible through `Zvbc` alone).
+Zvbc32e defines the same vector carry-less multiplication operations as Zvbc but on smaller SEW values (32, 16, and 8 bits).
+It can be leveraged by implementations with any `ELEN` value {ge} 32.
+For implementations with small `ELEN` (32), supporting Zvbc32e brings ISA support for vector carry-less multiplication (which was not possible through Zvbc alone).
 
-`Zvbc32e` is also useful for implementations with ELEN >= 64, as it allows more efficient implementations of algorithms relying on 32-bit (or less) carry-less multiplications.
-Selecting only `Zvbc32e` allows implementations to save area while providing identical performance on those algorithms.
+Zvbc32e is also useful for implementations with `ELEN` {ge} 64, as it allows more efficient implementations of algorithms relying on 32-bit (or less) carry-less multiplications.
+Selecting only Zvbc32e allows implementations to save area while providing identical performance on those algorithms.
 
 For all implementations, `Zvbc32e` allows better implementations (less instructions and more targeted use of hardware resources) of algorithms relying on 8-bit and 16-bit carry-less multiplications (e.g. erasure coding).
 

--- a/src/rationale.adoc
+++ b/src/rationale.adoc
@@ -110,17 +110,17 @@ _halfword_ atomic memory operations to the RISC-V Unprivileged ISA.
 
 
 <<Zvbc>> defines vector carry-less multiplication instructions for SEW=64 only.
-It is not suitable for implementations with small ELEN (32) and incur some inefficiencies for algorithms were at least one of the multiplication operands is limited to 32 bits (or less).
+It is not suitable for implementations with small ELEN (32) and incurs some inefficiencies for algorithms where at least one of the multiplication operands is limited to 32 bits (or less).
 The list of such algorithms includes the CLM-based folding algorithm used to compute the widespread 32-bit CRCs (e.g. Ethernet CRC)
 With `Zvbc`, only half the 64-bit element multiplication provided is exploited.
 This is due to the fact that CRC acceleration based on carry-less multiplication often relies on a product term which is a polynomial modulo the CRC.
 This limits the size of this term to the output size of the CRC.
 
-Zvbc32e's defines the same vector carry-less multiplication operations as Zvbc but on smaller SEW values (32, 16, and 8 bits).
+`Zvbc32e` defines the same vector carry-less multiplication operations as `Zvbc` but on smaller SEW values (32, 16, and 8 bits).
 It can be leveraged by implementations with any ELEN value >= 32.
-For implementations with small ELEN (32), supporting Zvbc32e brings ISA support for vector carry-less multiplication (which was not possible through Zvbc alone).
+For implementations with small ELEN (32), supporting Zvbc32e brings ISA support for vector carry-less multiplication (which was not possible through `Zvbc` alone).
 
-Zvbc32e is also useful for implementations with ELEN >= 64, as it allows more efficient implementations of algorithms relying on 32-bit (or less) carry-less multiplications.
+`Zvbc32e` is also useful for implementations with ELEN >= 64, as it allows more efficient implementations of algorithms relying on 32-bit (or less) carry-less multiplications.
 Selecting only `Zvbc32e` allows implementations to save area while providing identical performance on those algorithms.
 
 For all implementations, `Zvbc32e` allows better implementations (less instructions and more targeted use of hardware resources) of algorithms relying on 8-bit and 16-bit carry-less multiplications (e.g. erasure coding).

--- a/src/rationale.adoc
+++ b/src/rationale.adoc
@@ -105,3 +105,22 @@ Several limitations arise from this emulation approach:
 
 The Zabha extension addresses these limitations by adding support for _byte_ and
 _halfword_ atomic memory operations to the RISC-V Unprivileged ISA.
+
+=== "Zvbc32e" Extension for Vector Carry-less Multiplication for `SEW <= 32`
+
+
+<<Zvbc>> defines vector carry-less multiplication instructions for SEW=64 only.
+It is not suitable for implementations with small ELEN (32) and incur some inefficiencies for algorithms were at least one of the multiplication operands is limited to 32 bits (or less).
+The list of such algorithms includes the CLM-based folding algorithm used to compute the widespread 32-bit CRCs (e.g. Ethernet CRC)
+With `Zvbc`, only half the 64-bit element multiplication provided is exploited.
+This is due to the fact that CRC acceleration based on carry-less multiplication often relies on a product term which is a polynomial modulo the CRC.
+This limits the size of this term to the output size of the CRC.
+
+Zvbc32e's defines the same vector carry-less multiplication operations as Zvbc but on smaller SEW values (32, 16, and 8 bits).
+It can be leveraged by implementations with any ELEN value >= 32.
+For implementations with small ELEN (32), supporting Zvbc32e brings ISA support for vector carry-less multiplication (which was not possible through Zvbc alone).
+
+Zvbc32e is also useful for implementations with ELEN >= 64, as it allows more efficient implementations of algorithms relying on 32-bit (or less) carry-less multiplications.
+Selecting only `Zvbc32e` allows implementations to save area while providing identical performance on those algorithms.
+
+For all implementations, `Zvbc32e` allows better implementations (less instructions and more targeted use of hardware resources) of algorithms relying on 8-bit and 16-bit carry-less multiplications (e.g. erasure coding).

--- a/src/rationale.adoc
+++ b/src/rationale.adoc
@@ -124,3 +124,14 @@ Zvbc32e is also useful for implementations with ELEN >= 64, as it allows more ef
 Selecting only `Zvbc32e` allows implementations to save area while providing identical performance on those algorithms.
 
 For all implementations, `Zvbc32e` allows better implementations (less instructions and more targeted use of hardware resources) of algorithms relying on 8-bit and 16-bit carry-less multiplications (e.g. erasure coding).
+
+
+=== "Zvkgs"  Extension for Vector-Scalar GCM/GHASH
+
+One of the key use cases for the vector instructions `vghsh.vv` and `vgmul.vv` defined in <<Zvkg>> is to speed-up the Galois Counter Mode (GCM) cipher mode for a single encryption/decryption stream by computing the GHASH algorithm for multiple blocks of the same message in parallel (using the same symmetric key).
+The parallel processing accumulates and multiplies multiple blocks of the message by the same power of `H` (`H` is the encryption of `0` by the cipher key).
+The power being equal to the number of blocks processed in parallel.
+The processing completes by reducing the parallel accumulators into a single output tag.
+With `Zvkg` only, a full vector register was required to hold the multiple copies of the power of H.
+`Zvkgs` reduces the size of the vector register group needed for powers of H: it just needs to contain a 128-bit wide element group, freeing some vector registers (The exact number of freed registers depends on VLEN and LMUL).
+This exploits the same scalar element group broadcast mechanism used in other instructions defined in the vector crypto extensions (e.g. `vaesem.vs` from <<Zvkned>>).

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -492,7 +492,7 @@ Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 
 
 
 All _cryptography-specific_ instructions defined in this Vector Crypto specification (i.e., those
-in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>, <<zvkb>>, <<zvbc>> or <<zvbc,Zvbc32e>>) shall
+in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvkg,Zvkgs>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>, <<zvkb>>, <<zvbc>> or <<zvbc,Zvbc32e>>) shall
 be executed with data-independent execution latency as defined in the
 <<#crypto_scalar_instructions,RISC-V Scalar Cryptography Extensions specification>>.
 [#norm:veccrypto_indepZkt]#It is important to note that the Vector Crypto instructions are independent of the
@@ -601,10 +601,14 @@ in the Zvbb extension: vbrev.v, vclz.v, vctz.v, vcpop.v, and vwsll.[vv,vx,vi].
 <<<
 
 [[zvkg,Zvkg]]
-==== `Zvkg` - Vector GCM/GMAC
+==== `Zvkg` and `Zvkgs` - Vector GCM/GMAC
 
 Instructions to enable the efficient implementation of GHASH~H~ which is used in Galois/Counter Mode (GCM) and
 Galois Message Authentication Code (GMAC).
+
+Zvkg defines the vector-vector (.vv) versions of the instructions.
+Zvkgs defines the vector-scalar (.vs) versions of the instructions.
+Zvkgs depends on Zvkg.
 
 [#norm:Zvkg_egw128b_elem32b]#All of these instructions work on 128-bit element groups comprised of four 32-bit elements.#
 
@@ -636,8 +640,8 @@ therefore must be a multiple of `EGS=4`.# +
 |EGW
 |Mnemonic
 |Instruction
-| 32 | 128 | vghsh.vv | <<insns-vghsh>>
-| 32 | 128 | vgmul.vv | <<insns-vgmul>>
+| 32 | 128 | vghsh.[vv,vs] | <<insns-vghsh>>
+| 32 | 128 | vgmul.[vv,vs] | <<insns-vgmul>>
 
 |===
 
@@ -881,7 +885,7 @@ This extension is shorthand for the following set of other extensions:
 
 [NOTE]
 ====
-While Zvkg and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
+While Zvkg, Zvkgs and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
 ====
 
 <<<
@@ -956,7 +960,7 @@ This extension is shorthand for the following set of other extensions:
 
 [NOTE]
 ====
-While Zvkg and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
+While Zvkg, Zvkgs and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
 ====
 
 <<<
@@ -2560,15 +2564,16 @@ Included in::
 <<<
 
 [[insns-vghsh, Vector GHASH Add-Multiply]]
-==== vghsh.vv
+==== vghsh.[vv,vs]
 
 Synopsis::
 Vector Add-Multiply over GHASH Galois-Field
 
 Mnemonic::
-vghsh.vv vd, vs2, vs1
+vghsh.vv vd, vs2, vs1 +
+vghsh.vs vd, vs2, vs1
 
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -2581,8 +2586,26 @@ Encoding::
 {bits: 6, name: '101100'},
 ]}
 ....
+
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg:[
+{bits: 7, name: 'OP-VE'},
+{bits: 5, name: 'vd'},
+{bits: 3, name: 'OPMVV'},
+{bits: 5, name: 'vs1'},
+{bits: 5, name: 'vs2'},
+{bits: 1, name: '1'},
+{bits: 6, name: '100011'},
+]}
+....
+
+
+
 Reserved Encodings::
 * [#norm:vghsh-vv_sewn32_rsv]#`SEW` is any value other than 32#
+* [#norm:vghsh-vs_vdovlpvs2_rsv]#Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group#
 
 Arguments::
 
@@ -2605,7 +2628,12 @@ Arguments::
 Description::
 A single "iteration" of the GHASH~H~ algorithm is performed.
 
-[#norm:vghsh-vv_op]#This instruction treats all of the inputs and outputs as 128-bit polynomials and
+[#norm:vghsh-vv_op]#The previous partial hashes are read as 4-element groups from `vd`,
+the cipher texts are read as 4-element groups from `vs1`
+ and the hash subkey is read either as 4-element groups from `vs2` (`vghsh.vv`) or from the scalar 4-element group in `vs2` (`vghsh.vs`).
+The resulting partial hashes are written as 4-element groups into `vd`.
+
+This instruction treats all of the inputs and outputs as 128-bit polynomials and
 performs operations over GF[2].
 It produces the next partial hash (Y~i+1~) by adding the current partial
 hash (Y~i~) to the cipher text block (X~i~) and then multiplying (over GF(2^128^))
@@ -2635,12 +2663,6 @@ with the NIST specification. These reversals are inexpensive to implement as the
 swap bit positions and therefore do not require any logic.
 ====
 
-[NOTE]
-====
-Since the same hash subkey `H` will typically be used repeatedly on a given message,
-a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
-====
 
 Operation::
 [source,pseudocode]
@@ -2656,9 +2678,10 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
   eg_start = (vstart/EGS)
 
   foreach (i from eg_start to eg_len-1) {
+    let hindex = if suffix == "vv" then i else 0;
     let Y = get_velem(vd,EGW=128,i);  // current partial-hash
     let X = get_velem(vs1,EGW=128,i);  // block cipher output
-    let H = brev8(get_velem(vs2,EGW=128,i)); // Hash subkey
+    let H = brev8(get_velem(vs2,EGW=128,hindex)); // Hash subkey
 
     let Z : bits(128) = 0;
 
@@ -2682,21 +2705,25 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
 }
 --
 
-Included in::
+`vghsh.vv` is included in::
 <<zvkg>>, <<zvkng>>, <<zvksg>>
+
+`vghsh.vs` is included in::
+<<zvkg,Zvkgs>>
 
 <<<
 
 [[insns-vgmul, Vector GHASH Multiply]]
-==== vgmul.vv
+==== vgmul.[vv,vs]
 
 Synopsis::
 Vector Multiply over GHASH Galois-Field
 
 Mnemonic::
-vgmul.vv vd, vs2
+vgmul.vv vd, vs2 +
+vgmul.vs vd, vs2
 
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -2709,8 +2736,24 @@ Encoding::
 {bits: 6, name: '101000'},
 ]}
 ....
+
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg:[
+{bits: 7, name: 'OP-VE'},
+{bits: 5, name: 'vd'},
+{bits: 3, name: 'OPMVV'},
+{bits: 5, name: '10001'},
+{bits: 5, name: 'vs2'},
+{bits: 1, name: '1'},
+{bits: 6, name: '101001'},
+]}
+....
+
 Reserved Encodings::
 * [#norm:vgmul-vv_sewn32_rsv]#`SEW` is any value other than 32#
+* [#norm:vgmul-vs_vdovlpvs2_rsv]#Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group#
 
 Arguments::
 
@@ -2732,7 +2775,11 @@ Arguments::
 Description::
 A GHASH~H~ multiply is performed.
 
-[#norm:vgmul-vv_op]#This instruction treats all of the inputs and outputs as 128-bit polynomials and
+[#norm:vgmul-vv_op]#The multipliers are read as 4-element groups from `vd`,
+ the multiplicand subkey is read either as 4-element groups from `vs2` (`vgmul.vv`) or from the scalar element group in `vs2` (`vgmul.vs`).
+The resulting products are written as 4-element groups into `vd`.
+
+This instruction treats all of the inputs and outputs as 128-bit polynomials and
 performs operations over GF[2].
 It produces the product over GF(2^128^) of the two 128-bit inputs.#
 
@@ -2756,20 +2803,14 @@ with the NIST specification. These reversals are inexpensive to implement as the
 swap bit positions and therefore do not require any logic.
 ====
 
-[NOTE]
-====
-Since the same multiplicand will typically be used repeatedly on a given message,
-a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
-====
 
 [NOTE]
 ====
-This instruction is identical to `vghsh.vv` with vs1=0.
+This instruction is identical to `vghsh.vv` (respectively `vghsh.vs`) with vs1=0.
 This instruction is often used in GHASH code. In some cases it is followed
 by an XOR to perform a multiply-add. Implementations may choose to fuse these
 two instructions to improve performance on GHASH code that
-doesn't use the add-multiply form of the `vghsh.vv` instruction.
+doesn't use the add-multiply form of the `vghsh.[vv,vs]` instruction.
 ====
 
 
@@ -2787,8 +2828,9 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
   eg_start = (vstart/EGS)
 
   foreach (i from eg_start to eg_len-1) {
+    let hindex = if suffix == "vv" then i else 0;
     let Y = brev8(get_velem(vd,EGW=128,i));  // Multiplier
-    let H = brev8(get_velem(vs2,EGW=128,i)); // Multiplicand
+    let H = brev8(get_velem(vs2,EGW=128,hindex)); // Multiplicand
     let Z : bits(128) = 0;
 
     for (int bit = 0; bit < 128; bit++) {
@@ -2810,8 +2852,11 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
 }
 --
 
-Included in::
+`vgmul.vv` included in::
 <<zvkg>>, <<zvkng>>, <<zvksg>>
+
+`vgmul.vs` included in::
+<<zvkg, Zvkgs>>
 
 <<<
 
@@ -4403,7 +4448,7 @@ Crypto Vector instructions except Zvbb and Zvbc
 |100000||||| 100000 |V| | vsm3me      | 100000 | | |
 | 100001 | | | |            | 100001 |V| | vsm4k.vi    | 100001 | | |
 | 100010 | | | |            | 100010 |V| | vaeskf1.vi  | 100010 | | |
-| 100011 | | | |            | 100011 | | |             | 100011 | | |
+| 100011 | | | |            | 100011 | | | vghsh.vs    | 100011 | | |
 | 100100 | | | |            | 100100 | | |             | 100100 | | |
 | 100101 | | | |            | 100101 | | |             | 100101 | | |
 | 100110 | | | |            | 100110 | | |             | 100110 | | |
@@ -4413,7 +4458,7 @@ Crypto Vector instructions except Zvbb and Zvbc
 | 101001 | | | |            | 101001 |V| | *VAES.vs*   | 101001 | | |
 | 101010 | | | |            | 101010 |V| | vaeskf2.vi  | 101010 | | |
 | 101011 | | | |            | 101011 |V| | vsm3c.vi    | 101011 | | |
-| 101100 | | | |            | 101100 |V| | vghsh      | 101100 | | |
+| 101100 | | | |            | 101100 |V| | vghsh.vv   | 101100 | | |
 | 101101 | | | |            | 101101 |V| | vsha2ms     | 101101 | | |
 | 101110 | | | |            | 101110 |V| | vsha2ch     | 101110 | | |
 | 101111 | | | |            | 101111 |V| | vsha2cl     | 101111 | | |

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -542,7 +542,7 @@ This extension is a superset of the <<Zvkb>> extension.
 <<<
 
 [[zvbc,Zvbc]]
-==== `Zvbc` and `Zvbc32e` - Vector Carryless Multiplication
+==== `Zvbc` and `Zvbc32e` - Vector Carry-less Multiplication
 
 General purpose carry-less multiplication instructions which are commonly used in cryptography
 and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
@@ -2247,11 +2247,11 @@ significant `SEW` bits of the carry-less product.#
 
 [NOTE]
 ====
-The carryless multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
-We do not make these instructions exclusive as the carryless multiply is readily derived from the
+The carry-less multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
+We do not make these instructions exclusive as the carry-less multiply is readily derived from the
 instructions in the `zvkg` extension and can have utility in other areas.
 
-Zvbc32e allows Zve32x implementations to support vector carryless multiplication.
+Zvbc32e allows Zve32x implementations to support vector carry-less multiplication.
 ====
 
 Operation::

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -303,13 +303,14 @@ all other `SEW` values are _reserved_.#
 | Instructions
 | Required SEW
 
-| vaes*          | 32
-| Zvknha: vsha2* | 32
-| Zvknhb: vsha2* | 32 or 64
-| vclmul[h]      | 64
-| vg*            | 32
-| vsm3*          | 32
-| vsm4*          | 32
+| vaes*               | 32
+| Zvknha: vsha2*      | 32
+| Zvknhb: vsha2*      | 32 or 64
+| vclmul[h] (Zvbc)    | 64
+| vclmul[h] (Zvbc32e) | 8, 16, 32
+| vg*                 | 32
+| vsm3*               | 32
+| vsm4*               | 32
 
 
 |===
@@ -491,14 +492,14 @@ Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 
 
 
 All _cryptography-specific_ instructions defined in this Vector Crypto specification (i.e., those
-in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>,<<zvkb>>, or <<zvbc>>) shall
+in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>, <<zvkb>>, <<zvbc>> or <<zvbc,Zvbc32e>>) shall
 be executed with data-independent execution latency as defined in the
 <<#crypto_scalar_instructions,RISC-V Scalar Cryptography Extensions specification>>.
 [#norm:veccrypto_indepZkt]#It is important to note that the Vector Crypto instructions are independent of the
 implementation of the `Zkt` extension and do not require that `Zkt` is implemented.#
 
 This specification includes a <<Zvkt>> extension that, when implemented, requires certain vector instructions
-(including <<zvbb>>, <<zvkb>>, and <<zvbc>>) to be executed with data-independent execution latency.
+(including <<zvbb>>, <<zvkb>>, <<zvbc,Zvbc>> and <<zvbc,Zvbc32e>>) to be executed with data-independent execution latency.
 
 Detection of individual cryptography extensions uses the
 unified software-based RISC-V discovery method.
@@ -541,12 +542,16 @@ This extension is a superset of the <<Zvkb>> extension.
 <<<
 
 [[zvbc,Zvbc]]
-==== `Zvbc` - Vector Carry-less Multiplication
+==== `Zvbc` and `Zvbc32e` - Vector Carryless Multiplication
 
 General purpose carry-less multiplication instructions which are commonly used in cryptography
 and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
 
-[#norm:Zvbc_sew64only]#These instructions are only defined for `SEW`=64.#
+[#norm:Zvbc_sew64only]#These instructions are defined for `SEW`=64. (Zvbc)#
+[#norm:Zvbc32e_sew32168only]#These instructions are defined for `SEW`=8, 16, 32. (Zvbc32e)#
+
+Note:: Zvbc and Zvbc32e can be implemented independently.
+
 
 [%autowidth]
 [%header,cols="^2,4"]
@@ -1057,7 +1062,7 @@ All <<Zvkb>> instructions are also covered by DIEL as they are a
 proper subset of <<Zvbb>>
 ====
 
-===== All <<Zvbc>> instructions
+===== All <<Zvbc>> and Zvbc32e instructions
 - vclmul[h].v[vx]
 
 ===== add/sub
@@ -2214,7 +2219,9 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vclmul_sewn64_rsv]#`SEW` is any value other than 64#
+* [#norm:vclmul_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc) #
+* `SEW` is any value other than 8, 16 or 32 (Zvbc32e)
+
 
 Arguments::
 
@@ -2231,22 +2238,20 @@ Arguments::
 |===
 
 Description::
-Produces the low half of 128-bit carry-less product.
+Produces the low half of `2*SEW`-bit carry-less product.
 
-[#norm:vclmul_op]#Each 64-bit element in the `vs2` vector register is carry-less multiplied by
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
+[#norm:vclmul_op]#Each `SEW`-bit element in the `vs2` vector register is carry-less multiplied by
+either each `SEW`-bit element in `vs1` (vector-vector), or the `SEW`-bit value
 from integer register `rs1` (vector-scalar). The result is the least
-significant 64 bits of the carry-less product.#
+significant `SEW` bits of the carry-less product.#
 
 [NOTE]
 ====
-The 64-bit carry-less multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
-We do not make these instructions exclusive as the 64-bit carry-less multiply is readily derived from the
+The carryless multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
+We do not make these instructions exclusive as the carryless multiply is readily derived from the
 instructions in the `zvkg` extension and can have utility in other areas.
-Likewise, we treat other SEW values as reserved so as not to preclude
-future extensions from using this opcode with different element widths.
-For example, a future extension might define an `SEW`=32 version of this instruction to enable `Zve32*` implementations to have
-vector carry-less multiplication instructions.
+
+Zvbc32e allows Zve32x implementations to support vector carryless multiplication.
 ====
 
 Operation::
@@ -2257,10 +2262,10 @@ Operation::
 function clause execute (VCLMUL(vs2, vs1, vd, suffix)) = {
 
   foreach (i from vstart to vl-1) {
-    let op1 : bits (64) = if suffix =="vv" then get_velem(vs1,i)
+    let op1 : bits (SEW) = if suffix == "vv" then get_velem(vs1, i)
                           else zext_or_truncate_to_sew(X(vs1));
-    let op2 : bits (64) = get_velem(vs2,i);
-    let product : bits (64) = clmul(op1,op2,SEW);
+    let op2 : bits (SEW) = get_velem(vs2, i);
+    let product : bits (SEW) = clmul(op1, op2, SEW);
     set_velem(vd, i, product);
   }
   RETIRE_SUCCESS
@@ -2273,10 +2278,12 @@ function clmul(x, y, width) = {
   }
   result
 }
+
+
 --
 
 Included in::
-<<zvbc>>, <<zvknc>>, <<zvksc>>
+<<zvbc>>, <<zvbc,Zvbc32e>>, <<zvknc>>, <<zvksc>>
 
 <<<
 
@@ -2318,7 +2325,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vclmulh_sewn64_rsv]#`SEW` is any value other than 64#
+* [#norm:vclmulh_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc)#
+* `SEW` is any value other than 8, 16 or 32 (Zvbc32e)
 
 Arguments::
 
@@ -2335,12 +2343,12 @@ Arguments::
 |===
 
 Description::
-Produces the high half of 128-bit carry-less product.
+Produces the high half of `2*SEW`-bit carry-less product.
 
-[#norm:vclmulh_op]#Each 64-bit element in the `vs2` vector register is carry-less multiplied by
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
+[#norm:vclmulh_op]#Each `SEW`-bit element in the `vs2` vector register is carry-less multiplied by
+either each `SEW`-bit element in `vs1` (vector-vector), or the `SEW`-bit value
 from integer register `rs1` (vector-scalar). The result is the most
-significant 64 bits of the carry-less product.#
+significant `SEW` bits of the carry-less product.#
 
 // This instruction must always be implemented such that its execution latency does not depend
 // on the data being operated upon.
@@ -2349,12 +2357,11 @@ Operation::
 [source,sail]
 --
 function clause execute (VCLMULH(vs2, vs1, vd, suffix)) = {
-
   foreach (i from vstart to vl-1) {
-    let op1 : bits (64) = if suffix =="vv" then get_velem(vs1,i)
+    let op1 : bits (SEW) = if suffix == "vv" then get_velem(vs1,i)
                           else zext_or_truncate_to_sew(X(vs1));
-    let op2 : bits (64) = get_velem(vs2, i);
-    let product : bits (64) = clmulh(op1, op2, SEW);
+    let op2 : bits (SEW) = get_velem(vs2, i);
+    let product : bits (SEW) = clmulh(op1, op2, SEW);
     set_velem(vd, i, product);
   }
   RETIRE_SUCCESS
@@ -2367,11 +2374,10 @@ function clmulh(x, y, width) = {
   }
   result
 }
-
 --
 
 Included in::
-<<zvbc>>, <<zvknc>>, <<zvksc>>
+<<zvbc>>, <<zvbc,Zvbc32e>>, <<zvknc>>, <<zvksc>>
 
 <<<
 

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -548,7 +548,7 @@ General purpose carry-less multiplication instructions which are commonly used i
 and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
 
 [#norm:Zvbc_sew64only]#These instructions are defined for `SEW`=64. (Zvbc)#
-[#norm:Zvbc32e_sew32168only]#These instructions are defined for `SEW`=8, 16, 32. (Zvbc32e)#
+[#norm:Zvbc32e_sew8_16_32only]#These instructions are defined for `SEW`=8, 16, 32. (Zvbc32e)#
 
 Note:: `Zvbc` and `Zvbc32e` can be implemented independently.
 
@@ -2224,7 +2224,7 @@ Encoding (Vector-Scalar)::
 ....
 Reserved Encodings::
 * [#norm:vclmul_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc) #
-* `SEW` is any value other than 8, 16, or 32 (Zvbc32e)
+* [#norm:vclmul_sewn8_16_32_rsv]#`SEW` is any value other than 8, 16, or 32 (Zvbc32e)
 
 
 Arguments::
@@ -2330,7 +2330,7 @@ Encoding (Vector-Scalar)::
 ....
 Reserved Encodings::
 * [#norm:vclmulh_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc)#
-* `SEW` is any value other than 8, 16, or 32 (Zvbc32e)
+* [#norm:vclmulh_sewn8_16_32_rsv]#`SEW` is any value other than 8, 16, or 32 (Zvbc32e)
 
 Arguments::
 

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -492,14 +492,14 @@ Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 
 
 
 All _cryptography-specific_ instructions defined in this Vector Crypto specification (i.e., those
-in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvkg,Zvkgs>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>, <<zvkb>>, <<zvbc>> or <<zvbc,Zvbc32e>>) shall
+in <<zvkned>>, <<zvknh,Zvknh[ab]>>, <<Zvkg>>, <<Zvkg,Zvkgs>>, <<Zvksed>> and <<zvksh>> but _not_ <<zvbb>>, <<zvkb>>, <<zvbc>>, or <<zvbc,Zvbc32e>>) shall
 be executed with data-independent execution latency as defined in the
 <<#crypto_scalar_instructions,RISC-V Scalar Cryptography Extensions specification>>.
 [#norm:veccrypto_indepZkt]#It is important to note that the Vector Crypto instructions are independent of the
 implementation of the `Zkt` extension and do not require that `Zkt` is implemented.#
 
 This specification includes a <<Zvkt>> extension that, when implemented, requires certain vector instructions
-(including <<zvbb>>, <<zvkb>>, <<zvbc,Zvbc>> and <<zvbc,Zvbc32e>>) to be executed with data-independent execution latency.
+(including <<zvbb>>, <<zvkb>>, <<zvbc,Zvbc>>, and <<zvbc,Zvbc32e>>) to be executed with data-independent execution latency.
 
 Detection of individual cryptography extensions uses the
 unified software-based RISC-V discovery method.
@@ -550,7 +550,7 @@ and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
 [#norm:Zvbc_sew64only]#These instructions are defined for `SEW`=64. (Zvbc)#
 [#norm:Zvbc32e_sew32168only]#These instructions are defined for `SEW`=8, 16, 32. (Zvbc32e)#
 
-Note:: Zvbc and Zvbc32e can be implemented independently.
+Note:: `Zvbc` and `Zvbc32e` can be implemented independently.
 
 
 [%autowidth]
@@ -606,9 +606,9 @@ in the Zvbb extension: vbrev.v, vclz.v, vctz.v, vcpop.v, and vwsll.[vv,vx,vi].
 Instructions to enable the efficient implementation of GHASH~H~ which is used in Galois/Counter Mode (GCM) and
 Galois Message Authentication Code (GMAC).
 
-Zvkg defines the vector-vector (.vv) versions of the instructions.
-Zvkgs defines the vector-scalar (.vs) versions of the instructions.
-Zvkgs depends on Zvkg.
+`Zvkg` defines the vector-vector (.vv) versions of the instructions.
+`Zvkgs` defines the vector-scalar (.vs) versions of the instructions.
+`Zvkgs` depends on `Zvkg`.
 
 [#norm:Zvkg_egw128b_elem32b]#All of these instructions work on 128-bit element groups comprised of four 32-bit elements.#
 
@@ -885,7 +885,7 @@ This extension is shorthand for the following set of other extensions:
 
 [NOTE]
 ====
-While Zvkg, Zvkgs and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
+While Zvkg, Zvkgs, and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
 ====
 
 <<<
@@ -960,7 +960,7 @@ This extension is shorthand for the following set of other extensions:
 
 [NOTE]
 ====
-While Zvkg, Zvkgs and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
+While Zvkg, Zvkgs, and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
 ====
 
 <<<
@@ -2224,7 +2224,7 @@ Encoding (Vector-Scalar)::
 ....
 Reserved Encodings::
 * [#norm:vclmul_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc) #
-* `SEW` is any value other than 8, 16 or 32 (Zvbc32e)
+* `SEW` is any value other than 8, 16, or 32 (Zvbc32e)
 
 
 Arguments::
@@ -2330,7 +2330,7 @@ Encoding (Vector-Scalar)::
 ....
 Reserved Encodings::
 * [#norm:vclmulh_sewn64_rsv]#`SEW` is any value other than 64 (Zvbc)#
-* `SEW` is any value other than 8, 16 or 32 (Zvbc32e)
+* `SEW` is any value other than 8, 16, or 32 (Zvbc32e)
 
 Arguments::
 


### PR DESCRIPTION
Following the ARC review on https://github.com/riscv/riscv-isa-manual/pull/1306, I am opening this pull-request to integrate the specifications following the ARC recommendations.

Eventually this PR will represent the frozen specifications for both Zvbc32e and Zvkgs.

### RVIA tracking

This pull requests draft the changes associated with two fast track extensions for vector crypto.

Fast track is tracked in https://riscv.atlassian.net/browse/RVS-1915

### New features:
- Zvbc32e: Extending vclmul[h].v[vh] instruction to support SEW=32-bit, 16-bit and 8-bit values. Zvbc32e is available standalone (ELEN >= 32) or in addition to Zvbc (ELEN >= 64). no new encoding
- Zvkgs: Adding .vs variants to vghsh and vgmul; should depend on Zvkg; new encodings


## Related changes:

- [x] `spike-isa-sim` modifications
    - [x] add support for `Zvbc32e` and `Zvkgs`: https://github.com/riscv-software-src/riscv-isa-sim/pull/1748
- [x] encoding proposal in riscv-opcodes repo: https://github.com/riscv/riscv-opcodes/pull/270
- [ ] adapt vector crypto code samples for `Zvbce32` https://github.com/riscv/riscv-crypto/blob/main/doc/vector/code-samples/zvbc-test.c
- [ ] adapt vector crypto code samples for `Zvkgs` https://github.com/riscv/riscv-crypto/blob/main/doc/vector/code-samples/zvkg-test.c
- [x] Sail models
  - [x] `Zvkgs`: https://github.com/riscv/sail-riscv/pull/1017
  - [x] `Zvbc32e`: https://github.com/riscv/sail-riscv/pull/931
- [ ] Compiler support
  - [x] LLVM: https://github.com/llvm/llvm-project/pull/128243
  - [ ] GCC: TBD  
- [ ] **rvv-intrinsics** support: https://github.com/riscv-non-isa/rvv-intrinsic-doc/pull/420

### History 


During the specification process for vector crypto 1.0.0 a few items had to be discarded because they appeared too late in the process. This fast track extension tries to address some of them.

The official demand that will be discussed in the Task Group and submitted to the Unpriv Committee is being drafter here: https://docs.google.com/document/d/1zpYhnZi2NxhjfcBGvPOy0oDhx6lTXchscG17Qcl6wv8/edit?usp=sharing


This pull request follows a previous PR against **riscv-isa-manual**, https://github.com/riscv/riscv-isa-manual/pull/1306, which itself was the follow-up to a pull request started on the **riscv-crypto** repo: https://github.com/riscv/riscv-crypto/pull/362.