### PR TITLE
Clarify synchronization requirements when changing xenvcfg.ADUE

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -1845,21 +1845,21 @@ address-translation cache entries that have cached PMP settings
 corresponding to the final translated supervisor physical address. An
 HFENCE.VVMA instruction is not required.
 
-Similarly, if the setting of the PBMTE bit in `menvcfg` is changed, an
+Similarly, if the setting of the PBMTE or ADUE bits in `menvcfg` are changed, an
 HFENCE.GVMA instruction with _rs1_=`x0` and _rs2_=`x0` suffices to synchronize
 with respect to the altered interpretation of G-stage and VS-stage PTEs' PBMT
-fields.
+and A/D bit fields, respectively.
 
-By contrast, if the PBMTE bit in `henvcfg` is changed, executing an
+By contrast, if the PBMTE or ADUE bits in `henvcfg` are changed, executing an
 HFENCE.VVMA with _rs1_=`x0` and _rs2_=`x0` suffices to synchronize with
-respect to the altered interpretation of VS-stage PTEs' PBMT fields for the
-currently active VMID.
+respect to the altered interpretation of VS-stage PTEs' PBMT and A/D bit fields
+for the currently active VMID.
 
 NOTE: No mechanism is provided to atomically change `vsatp` and `hgatp`
 together.  Hence, to prevent speculative execution causing one guest's
 VS-stage translations to be cached under another guest's VMID, world-switch
 code should zero `vsatp`, then swap `hgatp`, then finally write the new
-`vsatp` value.  Similarly, if `henvcfg`.PBMTE need be world-switched, it
+`vsatp` value.  Similarly, if `henvcfg`.PBMTE/ADUE need be world-switched, they
 should be switched after zeroing `vsatp` but before writing the new `vsatp`
 value, obviating the need to execute an HFENCE.VVMA instruction.
 

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2203,6 +2203,12 @@ If Svadu is not implemented, ADUE is read-only zero.
 Furthermore, for implementations with the hypervisor extension, `henvcfg`.ADUE
 is read-only zero if `menvcfg`.ADUE is zero.
 
+After changing `menvcfg`.ADUE, executing an SFENCE.VMA instruction with
+_rs1_=`x0` and _rs2_=`x0` suffices to synchronize address-translation caches
+with respect to the altered interpretation of page-table entries' A/D bits.
+See <<hyp-mm-fences>> for additional synchronization requirements when the
+hypervisor extension is implemented.
+
 NOTE: The Svade extension requires page-fault exceptions be raised when PTE
 A/D bits need be set, hence Svade is implemented when ADUE=0.
 

--- a/src/priv-preface.adoc
+++ b/src/priv-preface.adoc
@@ -347,7 +347,7 @@ implemented.
   extension.
 * Allocated interrupt 13 for Sscofpmf LCOFI interrupt.
 * Defined hardware-error and software-check exception codes.
-* Specified synchronization requirements when changing the PBMTE fields
+* Specified synchronization requirements when changing the PBMTE and ADUE fields
 in `menvcfg` and `henvcfg`.
 * Exposed count-overflow interrupts to VS-mode via the Shlcofideleg extension.
 * Relaxed behavior of some HINTs when MXLEN > XLEN.


### PR DESCRIPTION
The ADUE bits in the menvcfg and henvcfg CSRs likely won't change once translation is set up and enabled.  So, we shouldn't need to add hardware to synchronize (invalidate) TLBs when changing them, but can instead require software to do the synchronization and invalidation.  The PBMTE bits are a similar and already specified example.

For comparison, other architectures also require software TLB invalidation when changing these bits.  In their parlance, these are "permitted to be cached in a TLB".