### PR TITLE
Replace all latexmath calls with built-in AsciiDoc substitutes

### DIFF
--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -219,10 +219,10 @@ as well as in the `frm` CSR
 [cols = "1,1,1"]
 |===
 |Rounding Mode | Mnemonic | Meaning
-|000 | RNE | Round to Nearest, ties to Even
-|001 | RTZ | Round towards Zero
-|010 | RDN | Round Down (towards −∞)
-|011 | RUP | Round Up (towards +∞)
+| 000 | RNE | Round to Nearest, ties to Even
+| 001 | RTZ | Round towards Zero
+| 010 | RDN | Round Down (towards −{inf})
+| 011 | RUP | Round Up (towards +{inf})
 |100 | RMM | Round to Nearest, ties to Max Magnitude
 |===
 

--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -361,9 +361,9 @@ instructions, which had suggested the incorrect sign of a zero result.
 * Instructions `FMV.S.X` and `FMV.X.S` were renamed to `FMV.W.X` and `FMV.X.W`
 respectively to be more consistent with their semantics, which did not
 change. The old names will continue to be supported in the tools.
-* Specified behavior of narrower (latexmath:[$<$]FLEN) floating-point
+* Specified behavior of narrower (<FLEN) floating-point
 values held in wider `f` registers using NaN-boxing model.
-* Defined the exception behavior of FMA(latexmath:[$\infty$], 0, qNaN).
+* Defined the exception behavior of FMA({inf}, 0, qNaN).
 * Added note indicating that the `P` extension might be reworked into an
 integer packed-SIMD proposal for fixed-point operations using the
 integer registers.
@@ -385,7 +385,7 @@ software conventions.
 
 * Numerous additions and improvements to the commentary sections.
 * Separate version numbers for each chapter.
-* Modification to long instruction encodings latexmath:[$>$]64 bits to
+* Modification to long instruction encodings >64 bits to
 avoid moving the _rd_ specifier in very long instruction formats.
 * CSR instructions are now described in the base integer format where
 the counter registers are introduced, as opposed to only being
@@ -456,7 +456,7 @@ added.
 64-bits wide, with separate read access to the upper and lower 32 bits.
 * Canonical `NOP` and `MV` encodings have been defined.
 * Standard instruction-length encodings have been defined for 48-bit,
-64-bit, and latexmath:[$>$]64-bit instructions.
+64-bit, and >64-bit instructions.
 * Description of a 128-bit address space variant, `RV128`, has been added.
 * Major opcodes in the 32-bit base instruction format have been
 allocated for user-defined custom extensions.

--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -127,8 +127,8 @@ particular, with regard to decoding legal vs. reserved encodings).
 |Rounding Mode |Mnemonic |Meaning
 |000 |RNE |Round to Nearest, ties to Even
 |001 |RTZ |Round towards Zero
-|010 |RDN |Round Down (towards latexmath:[$-\infty$])
-|011 |RUP |Round Up (towards latexmath:[$+\infty$])
+|010 |RDN |Round Down (towards −{inf})
+|011 |RUP |Round Up (towards +{inf})
 |100 |RMM |Round to Nearest, ties to Max Magnitude
 |101 | |_Reserved for future use._
 |110 | |_Reserved for future use._
@@ -270,8 +270,8 @@ rounding mode using the _rm_ field with the encoding shown in
 <<rm>>.
 
 Floating-point minimum-number and maximum-number instructions FMIN.S and FMAX.S write, respectively, the smaller or larger of _rs1_ and _rs2_ to _rd_. For the purposes of these instructions only, the value
-latexmath:[$-0.0$] is considered to be less than the value
-latexmath:[$+0.0$]. If both inputs are NaNs, the result is the canonical NaN. If only one operand is a NaN, the result is the non-NaN operand.
+−0.0 is considered to be less than the value
++0.0. If both inputs are NaNs, the result is the canonical NaN. If only one operand is a NaN, the result is the non-NaN operand.
 Signaling NaN inputs set the invalid operation exception flag, even when the result is not NaN.
 
 [NOTE]
@@ -293,14 +293,14 @@ instruction format. R4-type instructions specify three source registers (_rs1_, 
 
 FMADD.S multiplies the values in _rs1_ and _rs2_, adds the value in
 _rs3_, and writes the final result to _rd_. FMADD.S computes
-_(rs1latexmath:[$\times$]rs2)latexmath:[$\+$]rs3_.
+_(rs1×rs2)+rs3_.
 
 FMSUB.S multiplies the values in _rs1_ and _rs2_, subtracts the value in _rs3_, and writes the final result to _rd_. FMSUB.S computes
-_(rs1latexmath:[$\times$]rs2)latexmath:[$\-$]rs3_.
+_(rs1×rs2)−rs3_.
 
-FNMSUB.S multiplies the values in _rs1_ and _rs2_, negates the product, adds the value in _rs3_, and writes the final result to _rd_. FNMSUB.S computes _-(rs1latexmath:[$\times$]rs2)latexmath:[$\+$]rs3_.
+FNMSUB.S multiplies the values in _rs1_ and _rs2_, negates the product, adds the value in _rs3_, and writes the final result to _rd_. FNMSUB.S computes _−(rs1×rs2)+rs3_.
 
-FNMADD.S multiplies the values in _rs1_ and _rs2_, negates the product, subtracts the value in _rs3_, and writes the final result to _rd_. FNMADD.S computes _-(rs1latexmath:[$\times$]rs2)latexmath:[$\-$]rs3_.
+FNMADD.S multiplies the values in _rs1_ and _rs2_, negates the product, subtracts the value in _rs3_, and writes the final result to _rd_. FNMADD.S computes _−(rs1×rs2)−rs3_.
 
 [NOTE]
 ====
@@ -331,12 +331,12 @@ would require additional move instructions in some common sequences. The current
 ====
 
 The fused multiply-add instructions must set the invalid operation
-exception flag when the multiplicands are latexmath:[$\infty$] and zero, even when the addend is a quiet NaN.
+exception flag when the multiplicands are {inf} and zero, even when the addend is a quiet NaN.
 
 [NOTE]
 ====
 The IEEE 754-2008 standard permits, but does not require, raising the
-invalid exception for the operation latexmath:[$\infty\times 0\ +$]qNaN.
+invalid exception for the operation {inf}×0 + qNaN.
 ====
 
 === Single-Precision Floating-Point Conversion and Move Instructions
@@ -349,7 +349,7 @@ register _rd_. FCVT.S.W or FCVT.S.L converts a 32-bit or 64-bit signed
 integer, respectively, in integer register _rs1_ into a floating-point
 number in floating-point register _rd_. FCVT.WU.S, FCVT.LU.S, FCVT.S.WU,
 and FCVT.S.LU variants convert to or from unsigned integer values. For
-XLENlatexmath:[$>32$], FCVT.W[U].S sign-extends the 32-bit result to the
+XLEN>32, FCVT.W[U].S sign-extends the 32-bit result to the
 destination register width. FCVT.L[U].S and FCVT.S.L[U] are RV64-only
 instructions. If the rounded result is not representable in the
 destination format, it is clipped to the nearest value and the invalid
@@ -367,23 +367,23 @@ FCVT.S.W _rd_, `x0`, which will never set any exception flags.
 [%autowidth,float="center",align="center",cols="<,>,>,>,>",options="header",]
 |===
 | |FCVT.W.S |FCVT.WU.S |FCVT.L.S |FCVT.LU.S
-|Minimum valid input (after rounding) |latexmath:[$-2^{31}$] |0
-|latexmath:[$-2^{63}$] |0
+|Minimum valid input (after rounding) |−2^31^ |0
+|−2^63^ |0
 
-|Maximum valid input (after rounding) |latexmath:[$2^{31}-1$]
-|latexmath:[$2^{32}-1$] |latexmath:[$2^{63}-1$] |latexmath:[$2^{64}-1$]
+|Maximum valid input (after rounding) |2^31^−1
+|2^32^−1 |2^63^−1 |2^64^−1
 
-|Output for out-of-range negative input |latexmath:[$-2^{31}$] |0
-|latexmath:[$-2^{63}$] |0
+|Output for out-of-range negative input |−2^31^ |0
+|−2^63^ |0
 
-|Output for latexmath:[$-\infty$] |latexmath:[$-2^{31}$] |0
-|latexmath:[$-2^{63}$] |0
+|Output for -{inf} |−2^31^ |0
+|−2^63^ |0
 
-|Output for out-of-range positive input |latexmath:[$2^{31}-1$]
-|latexmath:[$2^{32}-1$] |latexmath:[$2^{63}-1$] |latexmath:[$2^{64}-1$]
+|Output for out-of-range positive input |2^31^−1
+|2^32^−1 |2^63^−1 |2^64^−1
 
-|Output for latexmath:[$+\infty$] or NaN |latexmath:[$2^{31}-1$]
-|latexmath:[$2^{32}-1$] |latexmath:[$2^{63}-1$] |latexmath:[$2^{64}-1$]
+|Output for +{inf} or NaN |2^31^−1
+|2^32^−1 |2^63^−1 |2^64^−1
 |===
 
 All floating-point conversion instructions set the Inexact exception
@@ -444,10 +444,8 @@ representing integer values in the floating-point registers by defining conversi
 
 Floating-point compare instructions (FEQ.S, FLT.S, FLE.S) perform the
 specified comparison between floating-point registers
-(latexmath:[$\mbox{\em rs1}
-= \mbox{\em rs2}$], latexmath:[$\mbox{\em rs1} < \mbox{\em rs2}$],
-latexmath:[$\mbox{\em rs1} \leq
-\mbox{\em rs2}$]) writing 1 to the integer register _rd_ if the
+(_rs1_ = _rs2_, _rs1_ < _rs2_,
+_rs1_ {le} _rs2_) writing 1 to the integer register _rd_ if the
 condition holds, and 0 otherwise.
 
 FLT.S and FLE.S perform what the IEEE 754-2008 standard refers to as
@@ -461,9 +459,9 @@ include::images/wavedrom/spfloat-comp.edn[]
 
 [NOTE]
 ====
-The F extension provides a latexmath:[$\leq$] comparison, whereas the
-base ISAs provide a latexmath:[$\geq$] branch comparison. Because
-latexmath:[$\leq$] can be synthesized from latexmath:[$\geq$] and
+The F extension provides a {le} comparison, whereas the
+base ISAs provide a {ge} branch comparison. Because
+{le} can be synthesized from {ge} and
 vice-versa, there is no performance implication to this inconsistency,
 but it is nevertheless an unfortunate incongruity in the ISA.
 ====
@@ -488,14 +486,14 @@ include::images/wavedrom/spfloat-classify.edn[]
 [%autowidth,float="center",align="center",cols="^,<",options="header",]
 |===
 |_rd_ bit |Meaning
-|0 |_rs1_ is latexmath:[$-\infty$].
+|0 |_rs1_ is −{inf}.
 |1 |_rs1_ is a negative normal number.
 |2 |_rs1_ is a negative subnormal number.
-|3 |_rs1_ is latexmath:[$-0$].
-|4 |_rs1_ is latexmath:[$+0$].
+|3 |_rs1_ is −0.
+|4 |_rs1_ is +0.
 |5 |_rs1_ is a positive subnormal number.
 |6 |_rs1_ is a positive normal number.
-|7 |_rs1_ is latexmath:[$+\infty$].
+|7 |_rs1_ is +{inf}.
 |8 |_rs1_ is a signaling NaN.
 |9 |_rs1_ is a quiet NaN.
 |===

--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -729,7 +729,7 @@ counters to the guest virtual machine.
 .Hypervisor counter-enable register (`hcounteren`).
 include::images/bytefield/hcounterenreg.edn[]
 
-When the CY, TM, IR, or HPM_n_ bit in the `hcounteren` register is
+When the CY, TM, IR, or HPM__n__ bit in the `hcounteren` register is
 clear, attempts to read the `cycle`, `time`, `instret`, or
 `hpmcounter` _n_ register while V=1 will cause a virtual-instruction
 exception if the same bit in `mcounteren` is 1. When one of these bits

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -355,13 +355,13 @@ regardless of any subsequent extensions.
 
 
 A RISC-V hart has a single byte-addressable address space of
-latexmath:[$2^{\text{XLEN}}$] bytes for all memory accesses. A _word_ of
+2^XLEN^ bytes for all memory accesses. A _word_ of
 memory is defined as 32{nbsp}bits (4{nbsp}bytes). Correspondingly, a _halfword_ is 16{nbsp}bits (2{nbsp}bytes), a
 _doubleword_ is 64{nbsp}bits (8{nbsp}bytes), and a _quadword_ is 128{nbsp}bits (16{nbsp}bytes). The memory address space is
-circular, so that the byte at address latexmath:[$2^{\text{XLEN}}-1$] is
+circular, so that the byte at address 2^XLEN^−1 is
 adjacent to the byte at address zero. Accordingly, memory address
 computations done by the hardware ignore overflow and instead wrap
-around modulo latexmath:[$2^{\text{XLEN}}$].
+around modulo 2^XLEN^.
 
 The execution environment determines the mapping of hardware resources
 into a hart's address space. Different address ranges of a hart's

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -66,8 +66,7 @@ the sign of a nonzero result equals the sign of the dividend.#
 [NOTE]
 ====
 For both signed and unsigned division, except in the case of overflow, it holds
-that
-latexmath:[$\textrm{dividend} = \textrm{divisor} \times \textrm{quotient} + \textrm{remainder}$].
+that dividend = divisor {times} quotient + remainder.
 ====
 
 If both the quotient and remainder are required from the same division,
@@ -89,7 +88,7 @@ The semantics for division by zero and division overflow are summarized
 in <<divby0>>. [#norm:div_by_zero]#The quotient of division by zero has all bits
 set#, and [#norm:rem_by_zero]#the remainder of division by zero equals the dividend.#
 [#norm:signed_div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
-by latexmath:[$-1$]. The quotient of a signed division with overflow is
+by −1. The quotient of a signed division with overflow is
 equal to the dividend, and the remainder is zero.# Unsigned division
 overflow cannot occur.
 
@@ -100,17 +99,17 @@ overflow cannot occur.
 |Condition |Dividend |Divisor |DIVU[W] |REMU[W] |DIV[W] |REM[W]
 
 |Division by zero +
-Overflow (signed only) |latexmath:[$x$] +
-latexmath:[$-2^{L-1}$] |0 +
-latexmath:[$-1$] |latexmath:[$2^{L}-1$] +
- - |latexmath:[$x$] +
- - |latexmath:[$-1$] +
- latexmath:[$-2^{L-1}$] +
-  |latexmath:[$x$] +
+Overflow (signed only) |_x_ +
+-2^L-1^ |0 +
+−1 |2^L^-1 +
+ - |_x_ +
+ - |−1 +
+ -2^L-1^ +
+  |_x_ +
   0
 |===
 
-//|Overflow (signed only) |latexmath:[$-2^{L-1}$] |latexmath:[$-1$] |– |– |latexmath:[$-2^{L-1}$] |0
+//|Overflow (signed only) |−2^L−1^ |−1 |– |– |−2^L−1^ |0
 //|===
 
 [NOTE]

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -456,7 +456,7 @@ S-mode respectively. When executing an __x__RET instruction, supposing
 __x__PP holds the value _y_, __x__IE is set to __x__PIE; the privilege mode is
 changed to _y_; __x__PIE is set to 1; and __x__PP is set to the
 least-privileged supported mode (U if U-mode is implemented, else M). If
-__y__&#8800;M, __x__RET also sets MPRV=0.
+__y__{ne}M, __x__RET also sets MPRV=0.
 
 [NOTE]
 ====
@@ -1626,7 +1626,7 @@ of this register.
 
 When the CY, IR, or HPM__n__ bit in the `mcountinhibit` register is clear,
 the `mcycle`, `minstret`, or `mhpmcountern` register increments as usual.
-When the CY, IR, or HPM_n_ bit is set, the corresponding counter does
+When the CY, IR, or HPM__n__ bit is set, the corresponding counter does
 not increment.
 
 The `mcycle` CSR may be shared between harts on the same core, in which
@@ -2101,7 +2101,7 @@ include::images/bytefield/mconfigptrreg.edn[]
 
 The pointer alignment in bits must be no smaller than MXLEN:
 i.e., if MXLEN is
-latexmath:[$8\times n$], then `mconfigptr`[latexmath:[$\log_2n$]-1:0]
+8{times}__n__, then `mconfigptr`[log~2n~-1:0]
 must be zero.
 
 The `mconfigptr` register must be implemented, but it may be zero to indicate the
@@ -3225,20 +3225,19 @@ If  `pmpaddr~i-1~&#8805;``pmpaddr~i~``` and `pmpcfg~i~.A`=TOR, then PMP entry _i
 
 Although the PMP mechanism supports regions as small as four bytes,
 platforms may specify coarser PMP regions. In general, the PMP grain is
-latexmath:[$2^{G+2}$] bytes and must be the same across all PMP regions.
-When latexmath:[$G \geq 1$], the NA4 mode is not selectable. When
-latexmath:[$G \geq 2$] and latexmath:[${\tt pmpcfg}_i$].A[1] is set,
-i.e. the mode is NAPOT, then bits latexmath:[${\tt pmpaddr}_i$][G-2:0]
-read as all ones. When latexmath:[$G \geq 1$] and
-latexmath:[${\tt pmpcfg}_i$].A[1] is clear, i.e. the mode is OFF or TOR,
-then bits latexmath:[${\tt pmpaddr}_i$][G-1:0] read as all zeros. Bits
-latexmath:[${\tt
-pmpaddr}_i$][G-1:0] do not affect the TOR address-matching logic.
-Although changing latexmath:[${\tt pmpcfg}_i$].A[1] affects the value
-read from latexmath:[${\tt pmpaddr}_i$], it does not affect the
+2^G+2^ bytes and must be the same across all PMP regions.
+When G {ge} 1, the NA4 mode is not selectable. When
+G {ge} 2 and pmpcfg~i~.A[1] is set,
+i.e. the mode is NAPOT, then bits pmpaddr~i~[G-2:0]
+read as all ones. When G {ge} 1 and
+pmpcfg~i~.A[1] is clear, i.e. the mode is OFF or TOR,
+then bits pmpaddr~i~[G-1:0] read as all zeros. Bits
+pmpaddr~i~[G-1:0] do not affect the TOR address-matching logic.
+Although changing pmpcfg~i~.A[1] affects the value
+read from pmpaddr~i~, it does not affect the
 underlying value stored in that register—in particular,
-latexmath:[${\tt pmpaddr}_i$][G-1] retains its original value when
-latexmath:[${\tt pmpcfg}_i$].A is changed from NAPOT to TOR/OFF then
+pmpaddr~i~[G-1] retains its original value when
+pmpcfg~i~.A is changed from NAPOT to TOR/OFF then
 back to NAPOT.
 
 [NOTE]

--- a/src/mm-formal.adoc
+++ b/src/mm-formal.adoc
@@ -473,16 +473,6 @@ Model states: A model state consists of a shared memory and a tuple of hart stat
 +--------------------------+
 ....
 
-//[cols="^,^,^",]
-//|===
-//|Hart 0 |*…* |Hart latexmath:[$n$]
-//
-//|latexmath:[$\big\uparrow$] latexmath:[$\big\downarrow$] |
-//|latexmath:[$\big\uparrow$] latexmath:[$\big\downarrow$]
-//
-//2+|Shared Memory
-//|===
-
 The shared memory state records all the memory store operations that
 have propagated so far, in the order they propagated (this can be made
 more efficient, but for simplicity of the presentation we keep it this
@@ -620,10 +610,10 @@ Transitions specific to fence instructions:
 [circle]
 * <<commit_fence, Commit fence>>
 
-The transitions labeled latexmath:[$\circ$] can always be taken eagerly,
+The transitions labeled {circ} can always be taken eagerly,
 as soon as their precondition is satisfied, without excluding other
-behavior; the latexmath:[$\bullet$] cannot. Although <<fetch, Fetch instruction>> is marked with a
-latexmath:[$\bullet$], it can be taken eagerly as long as it is not
+behavior; the {bullet} cannot. Although <<fetch, Fetch instruction>> is marked with a
+{bullet}, it can be taken eagerly as long as it is not
 taken infinitely many times.
 
 An instance of a non-AMO load instruction, after being fetched, will
@@ -802,25 +792,25 @@ are finished. Similarly, it is said to have a _fully determined memory
 footprint_ if the load (and `sc`) instructions feeding its memory
 operation address register are finished. Formally, we first define the
 notion of _fully determined register write_: a register write
-latexmath:[$w$] from _reg_writes_ of instruction instance
-latexmath:[$i$] is said to be _fully determined_ if one of the following
+_w_ from _reg_writes_ of instruction instance
+_i_ is said to be _fully determined_ if one of the following
 conditions hold:
 
-. latexmath:[$i$] is finished; or
-. the value written by latexmath:[$w$] is not affected by a memory
-operation that latexmath:[$i$] has made (i.e. a value loaded from memory
+. _i_ is finished; or
+. the value written by _w_ is not affected by a memory
+operation that _i_ has made (i.e. a value loaded from memory
 or the result of `sc`), and, for every register read that
-latexmath:[$i$] has made, that affects latexmath:[$w$], the register
-write from which latexmath:[$i$] read is fully determined (or
-latexmath:[$i$] read from the initial register state).
+_i_ has made, that affects _w_, the register
+write from which _i_ read is fully determined (or
+_i_ read from the initial register state).
 
-Now, an instruction instance latexmath:[$i$] is said to have _fully
-determined data_ if for every register read latexmath:[$r$] from
-_reg_reads_, the register writes that latexmath:[$r$] reads from are
-fully determined. An instruction instance latexmath:[$i$] is said to
+Now, an instruction instance _i_ is said to have _fully
+determined data_ if for every register read _r_ from
+_reg_reads_, the register writes that _r_ reads from are
+fully determined. An instruction instance _i_ is said to
 have a _fully determined memory footprint_ if for every register read
-latexmath:[$r$] from _reg_reads_ that feeds into latexmath:[$i$]’s
-memory operation address, the register writes that latexmath:[$r$] reads
+_r_ from _reg_reads_ that feeds into _i_’s
+memory operation address, the register writes that _r_ reads
 from are fully determined.
 [NOTE]
 ====
@@ -882,29 +872,29 @@ generate the new system state.
 ===== Fetch instruction
 
 A possible program-order-successor of instruction instance
-latexmath:[$i$] can be fetched from address _loc_ if:
+_i_ can be fetched from address _loc_ if:
 
 . it has not already been fetched, i.e., none of the immediate
-successors of latexmath:[$i$] in the hart’s _instruction_tree_ are from
+successors of _i_ in the hart’s _instruction_tree_ are from
 _loc_; and
-. if latexmath:[$i$]’s pseudocode has already written an address to
+. if _i_’s pseudocode has already written an address to
 _pc_, then _loc_ must be that address, otherwise _loc_ is:
 * for a conditional branch, the successor address or the branch target
 address;
 * for a (direct) jump and link instruction (`jal`), the target address;
 * for an indirect jump instruction (`jalr`), any address; and
-* for any other instruction, latexmath:[$i.\textit{program\_loc}+4$].
+* for any other instruction, _i.program_loc_+4.
 
 Action: construct a freshly initialized instruction instance
-latexmath:[$i'$] for the instruction in the program memory at _loc_,
+_i'_ for the instruction in the program memory at _loc_,
 with state Plain(_isa_state_), computed from the instruction pseudocode,
 including the static information available from the pseudocode such as
 its _instruction_kind_, _src_regs_, and _dst_regs_, and add
-latexmath:[$i'$] to the hart’s _instruction_tree_ as a successor of
-latexmath:[$i$].
+_i'_ to the hart’s _instruction_tree_ as a successor of
+_i_.
 
 The possible next fetch addresses (_loc_) are available immediately
-after fetching latexmath:[$i$] and the model does not need to wait for
+after fetching _i_ and the model does not need to wait for
 the pseudocode to write to _pc_; this allows out-of-order execution, and
 speculation past conditional branches and jumps. For most instructions
 these addresses are easily obtained from the instruction pseudocode. The
@@ -926,18 +916,18 @@ addresses are detected.
 [[initiate_load]]
 ===== Initiate memory load operations
 
-An instruction instance latexmath:[$i$] in state Plain(Load_mem(_kind_,
+An instruction instance _i_ in state Plain(Load_mem(_kind_,
 _address_, _size_, _load_continuation_)) can always initiate the
 corresponding memory load operations. Action:
 
-. Construct the appropriate memory load operations latexmath:[$mlos$]:
-* if _address_ is aligned to _size_ then latexmath:[$mlos$] is a single
+. Construct the appropriate memory load operations _mlos_:
+* if _address_ is aligned to _size_ then _mlos_ is a single
 memory load operation of _size_ bytes from _address_;
-* otherwise, latexmath:[$mlos$] is a set of _size_ memory load
+* otherwise, _mlos_ is a set of _size_ memory load
 operations, each of one byte, from the addresses
-latexmath:[$\textit{address}\ldots\textit{address}+\textit{size}-1$].
-. set _mem_loads_ of latexmath:[$i$] to latexmath:[$mlos$]; and
-. update the state of latexmath:[$i$] to
+_address_..._address_+_size_−1.
+. set _mem_loads_ of _i_ to _mlos_; and
+. update the state of _i_ to
 Pending_mem_loads(_load_continuation_).
 [NOTE]
 ====
@@ -949,80 +939,80 @@ others.
 [[sat_by_forwarding]]
 ===== Satisfy memory load operation by forwarding from unpropagated stores
 
-For a non-AMO load instruction instance latexmath:[$i$] in state
+For a non-AMO load instruction instance _i_ in state
 Pending_mem_loads(_load_continuation_), and a memory load operation
-latexmath:[$mlo$] in latexmath:[$i.\textit{mem\_loads}$] that has
+_mlo_ in _i.mem_loads_ that has
 unsatisfied slices, the memory load operation can be partially or
 entirely satisfied by forwarding from unpropagated memory store
 operations by store instruction instances that are program-order-before
-latexmath:[$i$] if:
+_i_ if:
 
 . all program-order-previous `fence` instructions with `.sr` and `.pw`
 set are finished;
-. for every program-order-previous `fence` instruction, latexmath:[$f$],
-with `.sr` and `.pr` set, and `.pw` not set, if latexmath:[$f$] is not
+. for every program-order-previous `fence` instruction, _f_,
+with `.sr` and `.pr` set, and `.pw` not set, if _f_ is not
 finished then all load instructions that are program-order-before
-latexmath:[$f$] are entirely satisfied;
+_f_ are entirely satisfied;
 . for every program-order-previous `fence.tso` instruction,
-latexmath:[$f$], that is not finished, all load instructions that are
-program-order-before latexmath:[$f$] are entirely satisfied;
-. if latexmath:[$i$] is a load-acquire-RCsc, all program-order-previous
+_f_, that is not finished, all load instructions that are
+program-order-before _f_ are entirely satisfied;
+. if _i_ is a load-acquire-RCsc, all program-order-previous
 store-releases-RCsc are finished;
-. if latexmath:[$i$] is a load-acquire-release, all
+. if _i_ is a load-acquire-release, all
 program-order-previous instructions are finished;
 . all non-finished program-order-previous load-acquire instructions are
 entirely satisfied; and
 . all program-order-previous store-acquire-release instructions are
 finished;
 
-Let latexmath:[$msoss$] be the set of all unpropagated memory store
+Let _msoss_ be the set of all unpropagated memory store
 operation slices from non-`sc` store instruction instances that are
-program-order-before latexmath:[$i$] and have already calculated the
+program-order-before _i_ and have already calculated the
 value to be stored, that overlap with the unsatisfied slices of
-latexmath:[$mlo$], and which are not superseded by intervening store
+_mlo_, and which are not superseded by intervening store
 operations or store operations that are read from by an intervening
 load. The last condition requires, for each memory store operation slice
-latexmath:[$msos$] in latexmath:[$msoss$] from instruction
-latexmath:[$i'$]:
+_msos_ in _msoss_ from instruction
+_i'_:
 
-* that there is no store instruction program-order-between latexmath:[$i$]
-and latexmath:[$i'$] with a memory store operation overlapping
-latexmath:[$msos$]; and
-* that there is no load instruction program-order-between latexmath:[$i$]
-and latexmath:[$i'$] that was satisfied from an overlapping memory store
+* that there is no store instruction program-order-between _i_
+and _i'_ with a memory store operation overlapping
+_msos_; and
+* that there is no load instruction program-order-between _i_
+and _i'_ that was satisfied from an overlapping memory store
 operation slice from a different hart.
 
 Action:
 
-. update latexmath:[$i.\textit{mem\_loads}$] to indicate that
-latexmath:[$mlo$] was satisfied by latexmath:[$msoss$]; and
+. update _i.mem_loads_ to indicate that
+_mlo_ was satisfied by _msoss_; and
 . restart any speculative instructions which have violated coherence as
 a result of this, i.e., for every non-finished instruction
-latexmath:[$i'$] that is a program-order-successor of latexmath:[$i$],
-and every memory load operation latexmath:[$mlo'$] of latexmath:[$i'$]
-that was satisfied from latexmath:[$msoss'$], if there exists a memory
-store operation slice latexmath:[$msos'$] in latexmath:[$msoss'$], and
+_i'_ that is a program-order-successor of _i_,
+and every memory load operation _mlo'_ of _i'_
+that was satisfied from _msoss'_, if there exists a memory
+store operation slice _msos'_ in _msoss'_, and
 an overlapping memory store operation slice from a different memory
-store operation in latexmath:[$msoss$], and latexmath:[$msos'$] is not
+store operation in _msoss_, and _msos'_ is not
 from an instruction that is a program-order-successor of
-latexmath:[$i$], restart latexmath:[$i'$] and its _restart-dependents_.
+_i_, restart _i'_ and its _restart-dependents_.
 
-Where, the _restart-dependents_ of instruction latexmath:[$j$] are:
+Where, the _restart-dependents_ of instruction _j_ are:
 
-* program-order-successors of latexmath:[$j$] that have data-flow
-dependency on a register write of latexmath:[$j$];
-* program-order-successors of latexmath:[$j$] that have a memory load
-operation that reads from a memory store operation of latexmath:[$j$]
+* program-order-successors of _j_ that have data-flow
+dependency on a register write of _j_;
+* program-order-successors of _j_ that have a memory load
+operation that reads from a memory store operation of _j_
 (by forwarding);
-* if latexmath:[$j$] is a load-acquire, all the program-order-successors
-of latexmath:[$j$];
-* if latexmath:[$j$] is a load, for every `fence`, latexmath:[$f$], with
+* if _j_ is a load-acquire, all the program-order-successors
+of _j_;
+* if _j_ is a load, for every `fence`, _f_, with
 `.sr` and `.pr` set, and `.pw` not set, that is a
-program-order-successor of latexmath:[$j$], all the load instructions
-that are program-order-successors of latexmath:[$f$];
-* if latexmath:[$j$] is a load, for every `fence.tso`, latexmath:[$f$],
-that is a program-order-successor of latexmath:[$j$], all the load
-instructions that are program-order-successors of latexmath:[$f$]; and
+program-order-successor of _j_, all the load instructions
+that are program-order-successors of _f_;
+* if _j_ is a load, for every `fence.tso`, _f_,
+that is a program-order-successor of _j_, all the load
+instructions that are program-order-successors of _f_; and
 * (recursively) all the restart-dependents of all the instruction
 instances above.
 [NOTE]
@@ -1031,14 +1021,14 @@ Forwarding memory store operations to a memory load might satisfy only
 some slices of the load, leaving other slices unsatisfied.
 
 A program-order-previous store operation that was not available when
-taking the transition above might make latexmath:[$msoss$] provisionally
+taking the transition above might make _msoss_ provisionally
 unsound (violating coherence) when it becomes available. That store will
 prevent the load from being finished (see <<finish, Finish instruction>>), and will cause it to
 restart when that store operation is propagated (see <<prop_store, Propagate store operation>>).
 
 A consequence of the transition condition above is that
 store-release-RCsc memory store operations cannot be forwarded to
-load-acquire-RCsc instructions: latexmath:[$msoss$] does not include
+load-acquire-RCsc instructions: _msoss_ does not include
 memory store operations from finished stores (as those must be
 propagated memory store operations), and the condition above requires
 all program-order-previous store-releases-RCsc to be finished when the
@@ -1047,13 +1037,13 @@ load is acquire-RCsc.
 [[sat_from_mem]]
 ===== Satisfy memory load operation from memory
 
-For an instruction instance latexmath:[$i$] of a non-AMO load
+For an instruction instance _i_ of a non-AMO load
 instruction or an AMO instruction in the context of the <<do_amo, Satisfy, commit and propagate operations of an AMO>> transition,
-any memory load operation latexmath:[$mlo$] in
-latexmath:[$i.\textit{mem\_loads}$] that has unsatisfied slices, can be
+any memory load operation _mlo_ in
+_i.mem_loads_ that has unsatisfied slices, can be
 satisfied from memory if all the conditions of <sat_by_forwarding, Satisfy memory load operation by forwarding from unpropagated stores>> are satisfied. Action:
-let latexmath:[$msoss$] be the memory store operation slices from memory
-covering the unsatisfied slices of latexmath:[$mlo$], and apply the
+let _msoss_ be the memory store operation slices from memory
+covering the unsatisfied slices of _mlo_, and apply the
 action of <<do_amo, Satisfy memory operation by forwarding from unpropagates stores>>.
 [NOTE]
 ====
@@ -1065,47 +1055,47 @@ unsatisfied slices of the memory load operation.
 [[complete_loads]]
 ===== Complete load operations
 
-A load instruction instance latexmath:[$i$] in state
+A load instruction instance _i_ in state
 Pending_mem_loads(_load_continuation_) can be completed (not to be
 confused with finished) if all the memory load operations
-latexmath:[$i.\textit{mem\_loads}$] are entirely satisfied (i.e. there
-are no unsatisfied slices). Action: update the state of latexmath:[$i$]
+_i.mem_loads_ are entirely satisfied (i.e. there
+are no unsatisfied slices). Action: update the state of _i_
 to Plain(_load_continuation(mem_value)_), where _mem_value_ is assembled
 from all the memory store operation slices that satisfied
-latexmath:[$i.\textit{mem\_loads}$].
+_i.mem_loads_.
 
 [[early_sc_fail]]
 ===== Early `sc` fail
 
-An `sc` instruction instance latexmath:[$i$] in state
+An `sc` instruction instance _i_ in state
 Plain(Early_sc_fail(_res_continuation_)) can always be made to fail.
-Action: update the state of latexmath:[$i$] to
+Action: update the state of _i_ to
 Plain(_res_continuation(false)_).
 
 [[paired_sc]]
 ===== Paired `sc`
 
-An `sc` instruction instance latexmath:[$i$] in state
+An `sc` instruction instance _i_ in state
 Plain(Early_sc_fail(_res_continuation_)) can continue its (potentially
-successful) execution if latexmath:[$i$] is paired with an `lr`. Action:
-update the state of latexmath:[$i$] to Plain(_res_continuation(true)_).
+successful) execution if _i_ is paired with an `lr`. Action:
+update the state of _i_ to Plain(_res_continuation(true)_).
 
 [[initiate_store_footprint]]
 ===== Initiate memory store operation footprints
 
-An instruction instance latexmath:[$i$] in state Plain(Store_ea(_kind_,
+An instruction instance _i_ in state Plain(Store_ea(_kind_,
 _address_, _size_, _next_state_)) can always announce its pending memory
 store operation footprint. Action:
 
-. construct the appropriate memory store operations latexmath:[$msos$]
+. construct the appropriate memory store operations _msos_
 (without the store value):
-* if _address_ is aligned to _size_ then latexmath:[$msos$] is a single
+* if _address_ is aligned to _size_ then _msos_ is a single
 memory store operation of _size_ bytes to _address_;
-* otherwise, latexmath:[$msos$] is a set of _size_ memory store
+* otherwise, _msos_ is a set of _size_ memory store
 operations, each of one-byte size, to the addresses
-latexmath:[$\textit{address}\ldots\textit{address}+\textit{size}-1$].
-. set latexmath:[$i.\textit{mem\_stores}$] to latexmath:[$msos$]; and
-. update the state of latexmath:[$i$] to Plain(_next_state_).
+_address_..._address_+_size_−1.
+. set _i.mem_stores_ to _msos_; and
+. update the state of _i_ to Plain(_next_state_).
 [NOTE]
 ====
 Note that after taking the transition above the memory store operations
@@ -1119,25 +1109,25 @@ becomes available).
 [[instantiate_store_value]]
 ===== Instantiate memory store operation values
 
-An instruction instance latexmath:[$i$] in state
+An instruction instance _i_ in state
 Plain(Store_memv(_mem_value_, _store_continuation_)) can always
 instantiate the values of the memory store operations
-latexmath:[$i.\textit{mem\_stores}$]. Action:
+_i.mem_stores_. Action:
 
 . split _mem_value_ between the memory store operations
-latexmath:[$i.\textit{mem\_stores}$]; and
-. update the state of latexmath:[$i$] to
+_i.mem_stores_; and
+. update the state of _i_ to
 Pending_mem_stores(_store_continuation_).
 
 [[commit_stores]]
 ===== Commit store instruction
 
-An uncommitted instruction instance latexmath:[$i$] of a non-`sc` store
+An uncommitted instruction instance _i_ of a non-`sc` store
 instruction or an `sc` instruction in the context of the <<commit_sc, Commit and propagate store operation of an `sc`>>
 transition, in state Pending_mem_stores(_store_continuation_), can be
 committed (not to be confused with propagated) if:
 
-. latexmath:[$i$] has fully determined data;
+. _i_ has fully determined data;
 . all program-order-previous conditional branch and indirect jump
 instructions are finished;
 . all program-order-previous `fence` instructions with `.sw` set are
@@ -1146,7 +1136,7 @@ finished;
 . all program-order-previous load-acquire instructions are finished;
 . all program-order-previous store-acquire-release instructions are
 finished;
-. if latexmath:[$i$] is a store-release, all program-order-previous
+. if _i_ is a store-release, all program-order-previous
 instructions are finished;
 . all program-order-previous memory access instructions have a fully
 determined memory footprint;
@@ -1173,70 +1163,70 @@ making that condition simpler.
 [[prop_store]]
 ===== Propagate store operation
 
-For a committed instruction instance latexmath:[$i$] in state
+For a committed instruction instance _i_ in state
 Pending_mem_stores(_store_continuation_), and an unpropagated memory
-store operation latexmath:[$mso$] in
-latexmath:[$i.\textit{mem\_stores}$], latexmath:[$mso$] can be
+store operation _mso_ in
+_i.mem_stores_, _mso_ can be
 propagated if:
 
 . all memory store operations of program-order-previous store
-instructions that overlap with latexmath:[$mso$] have already
+instructions that overlap with _mso_ have already
 propagated;
 . all memory load operations of program-order-previous load instructions
-that overlap with latexmath:[$mso$] have already been satisfied, and
+that overlap with _mso_ have already been satisfied, and
 (the load instructions) are _non-restartable_ (see definition below);
 and
 . all memory load operations that were satisfied by forwarding
-latexmath:[$mso$] are entirely satisfied.
+_mso_ are entirely satisfied.
 
-Where a non-finished instruction instance latexmath:[$j$] is
+Where a non-finished instruction instance _j_ is
 _non-restartable_ if:
 
-. there does not exist a store instruction latexmath:[$s$] and an
-unpropagated memory store operation latexmath:[$mso$] of latexmath:[$s$]
+. there does not exist a store instruction _s_ and an
+unpropagated memory store operation _mso_ of _s_
 such that applying the action of the <<prop_store, Propagate store operation>> transition to
-latexmath:[$mso$] will result in the restart of latexmath:[$j$]; and
-. there does not exist a non-finished load instruction latexmath:[$l$]
-and a memory load operation latexmath:[$mlo$] of latexmath:[$l$] such
+_mso_ will result in the restart of _j_; and
+. there does not exist a non-finished load instruction _l_
+and a memory load operation _mlo_ of _l_ such
 that applying the action of the <<sat_by_forwarding, Satisfy memory load operation by forwarding from unpropagated stores>>/<<sat_from_mem, Satisfy memory load operation from memory>> transition (even if
-latexmath:[$mlo$] is already satisfied) to latexmath:[$mlo$] will result
-in the restart of latexmath:[$j$].
+_mlo_ is already satisfied) to _mlo_ will result
+in the restart of _j_.
 
 Action:
 
-. update the shared memory state with latexmath:[$mso$];
-. update latexmath:[$i.\textit{mem\_stores}$] to indicate that
-latexmath:[$mso$] was propagated; and
+. update the shared memory state with _mso_;
+. update _i.mem_stores_ to indicate that
+_mso_ was propagated; and
 . restart any speculative instructions which have violated coherence as
 a result of this, i.e., for every non-finished instruction
-latexmath:[$i'$] program-order-after latexmath:[$i$] and every memory
-load operation latexmath:[$mlo'$] of latexmath:[$i'$] that was satisfied
-from latexmath:[$msoss'$], if there exists a memory store operation
-slice latexmath:[$msos'$] in latexmath:[$msoss'$] that overlaps with
-latexmath:[$mso$] and is not from latexmath:[$mso$], and
-latexmath:[$msos'$] is not from a program-order-successor of
-latexmath:[$i$], restart latexmath:[$i'$] and its _restart-dependents_
+_i'_ program-order-after _i_ and every memory
+load operation _mlo'_ of _i'_ that was satisfied
+from _msoss'_, if there exists a memory store operation
+slice _msos'_ in _msoss'_ that overlaps with
+_mso_ and is not from _mso_, and
+_msos'_ is not from a program-order-successor of
+_i_, restart _i'_ and its _restart-dependents_
 (see <<sat_by_forwarding, Satisfy memory load operation by forwarding from unpropagated stores>>).
 
 [[commit_sc]]
 ===== Commit and propagate store operation of an `sc`
 
-An uncommitted `sc` instruction instance latexmath:[$i$], from hart
-latexmath:[$h$], in state Pending_mem_stores(_store_continuation_), with
-a paired `lr` latexmath:[$i'$] that has been satisfied by some store
-slices latexmath:[$msoss$], can be committed and propagated at the same
+An uncommitted `sc` instruction instance _i_, from hart
+_h_, in state Pending_mem_stores(_store_continuation_), with
+a paired `lr` _i'_ that has been satisfied by some store
+slices _msoss_, can be committed and propagated at the same
 time if:
 
-. latexmath:[$i'$] is finished;
+. _i'_ is finished;
 . every memory store operation that has been forwarded to
-latexmath:[$i'$] is propagated;
+_i'_ is propagated;
 . the conditions of <<commit_stores, Commit store instruction>> is satisfied;
 . the conditions of <<prop_store, Propagate store instruction>> is satisfied (notice that an `sc` instruction can
 only have one memory store operation); and
-. for every store slice latexmath:[$msos$] from latexmath:[$msoss$],
-latexmath:[$msos$] has not been overwritten, in the shared memory, by a
-store that is from a hart that is not latexmath:[$h$], at any point
-since latexmath:[$msos$] was propagated to memory.
+. for every store slice _msos_ from _msoss_,
+_msos_ has not been overwritten, in the shared memory, by a
+store that is from a hart that is not _h_, at any point
+since _msos_ was propagated to memory.
 
 Action:
 
@@ -1246,12 +1236,12 @@ Action:
 [[late_sc_fail]]
 ===== Late `sc` fail
 
-An `sc` instruction instance latexmath:[$i$] in state
+An `sc` instruction instance _i_ in state
 Pending_mem_stores(_store_continuation_), that has not propagated its
 memory store operation, can always be made to fail. Action:
 
-. clear latexmath:[$i.\textit{mem\_stores}$]; and
-. update the state of latexmath:[$i$] to
+. clear _i.mem_stores_; and
+. update the state of _i_ to
 Plain(_store_continuation(false)_).
 [NOTE]
 ====
@@ -1263,17 +1253,17 @@ should fail one should use the <<early_sc_fail, Early sc fail>> transition inste
 [[complete_stores]]
 ===== Complete store operations
 
-A store instruction instance latexmath:[$i$] in state
+A store instruction instance _i_ in state
 Pending_mem_stores(_store_continuation_), for which all the memory store
-operations in latexmath:[$i.\textit{mem\_stores}$] have been propagated,
+operations in _i.mem_stores_ have been propagated,
 can always be completed (not to be confused with finished). Action:
-update the state of latexmath:[$i$] to
+update the state of _i_ to
 Plain(_store_continuation(true)_).
 
 [[do_amo]]
 ===== Satisfy, commit and propagate operations of an AMO
 
-An AMO instruction instance latexmath:[$i$] in state
+An AMO instruction instance _i_ in state
 Pending_mem_loads(_load_continuation_) can perform its memory access if
 it is possible to perform the following sequence of transitions with no
 intervening transitions:
@@ -1287,7 +1277,7 @@ intervening transitions:
 . <<complete_stores, Complete store operations>>
 
 and in addition, the condition of <<finish, Finish instruction>>, with the exception of not requiring
-latexmath:[$i$] to be in state Plain(Done), holds after those
+_i_ to be in state Plain(Done), holds after those
 transitions. Action: perform the above sequence of transitions (this
 does not include <<finish, Finish instruction>>), one after the other, with no intervening
 transitions.
@@ -1310,25 +1300,25 @@ propagated and therefore cannot be forwarded.
 [[commit_fence]]
 ===== Commit fence
 
-A fence instruction instance latexmath:[$i$] in state
+A fence instruction instance _i_ in state
 Plain(Fence(_kind_, _next_state_)) can be committed if:
 
-. if latexmath:[$i$] is a normal fence and it has `.pr` set, all
+. if _i_ is a normal fence and it has `.pr` set, all
 program-order-previous load instructions are finished;
-. if latexmath:[$i$] is a normal fence and it has `.pw` set, all
+. if _i_ is a normal fence and it has `.pw` set, all
 program-order-previous store instructions are finished; and
-. if latexmath:[$i$] is a `fence.tso`, all program-order-previous load
+. if _i_ is a `fence.tso`, all program-order-previous load
 and store instructions are finished.
 
 Action:
 
-. record that latexmath:[$i$] is committed; and
-. update the state of latexmath:[$i$] to Plain(_next_state_).
+. record that _i_ is committed; and
+. update the state of _i_ to Plain(_next_state_).
 
 [[reg_read]]
 ===== Register read
 
-An instruction instance latexmath:[$i$] in state
+An instruction instance _i_ in state
 Plain(Read_reg(_reg_name_, _read_cont_)) can do a register read of
 _reg_name_ if every instruction instance that it needs to read from has
 already performed the expected _reg_name_ register write.
@@ -1339,78 +1329,78 @@ can write to that bit, if any. If there is no such instruction, the
 source is the initial register value from _initial_register_state_. Let
 _reg_value_ be the value assembled from _read_sources_. Action:
 
-. add _reg_name_ to latexmath:[$i.\textit{reg\_reads}$] with
+. add _reg_name_ to _i.reg_reads_ with
 _read_sources_ and _reg_value_; and
-. update the state of latexmath:[$i$] to Plain(_read_cont(reg_value)_).
+. update the state of _i_ to Plain(_read_cont(reg_value)_).
 
 [[reg_write]]
 ===== Register write
 
-An instruction instance latexmath:[$i$] in state
+An instruction instance _i_ in state
 Plain(Write_reg(_reg_name_, _reg_value_, _next_state_)) can always do a
 _reg_name_ register write. Action:
 
-. add _reg_name_ to latexmath:[$i.\textit{reg\_writes}$] with
+. add _reg_name_ to _i.reg_writes_ with
 latexmath:[$deps$] and _reg_value_; and
-. update the state of latexmath:[$i$] to Plain(_next_state_).
+. update the state of _i_ to Plain(_next_state_).
 
 where latexmath:[$deps$] is a pair of the set of all _read_sources_ from
-latexmath:[$i.\textit{reg\_reads}$], and a flag that is true iff
-latexmath:[$i$] is a load instruction instance that has already been
+_i.reg_reads_, and a flag that is true iff
+_i_ is a load instruction instance that has already been
 entirely satisfied.
 
 [[sail_interp]]
 ===== Pseudocode internal step
 
-An instruction instance latexmath:[$i$] in state
+An instruction instance _i_ in state
 Plain(Internal(_next_state_)) can always do that pseudocode-internal
-step. Action: update the state of latexmath:[$i$] to
+step. Action: update the state of _i_ to
 Plain(_next_state_).
 
 [[finish]]
 ===== Finish instruction
 
-A non-finished instruction instance latexmath:[$i$] in state Plain(Done)
+A non-finished instruction instance _i_ in state Plain(Done)
 can be finished if:
 
-. if latexmath:[$i$] is a load instruction:
+. if _i_ is a load instruction:
 .. all program-order-previous load-acquire instructions are finished;
 .. all program-order-previous `fence` instructions with `.sr` set are
 finished;
 .. for every program-order-previous `fence.tso` instruction,
-latexmath:[$f$], that is not finished, all load instructions that are
-program-order-before latexmath:[$f$] are finished; and
+_f_, that is not finished, all load instructions that are
+program-order-before _f_ are finished; and
 .. it is guaranteed that the values read by the memory load operations
-of latexmath:[$i$] will not cause coherence violations, i.e., for any
-program-order-previous instruction instance latexmath:[$i'$], let
-latexmath:[$\textit{cfp}$] be the combined footprint of propagated
+of _i_ will not cause coherence violations, i.e., for any
+program-order-previous instruction instance _i'_, let
+_cfp_ be the combined footprint of propagated
 memory store operations from store instructions program-order-between
-latexmath:[$i$] and latexmath:[$i'$], and _fixed memory store
-operations_ that were forwarded to latexmath:[$i$] from store
-instructions program-order-between latexmath:[$i$] and latexmath:[$i'$]
-including latexmath:[$i'$], and let
-latexmath:[$\overline{\textit{cfp}}$] be the complement of
-latexmath:[$\textit{cfp}$] in the memory footprint of latexmath:[$i$].
-If latexmath:[$\overline{\textit{cfp}}$] is not empty:
-... latexmath:[$i'$] has a fully determined memory footprint;
-... latexmath:[$i'$] has no unpropagated memory store operations that
-overlap with latexmath:[$\overline{\textit{cfp}}$]; and
-... if latexmath:[$i'$] is a load with a memory footprint that overlaps
-with latexmath:[$\overline{\textit{cfp}}$], then all the memory load
-operations of latexmath:[$i'$] that overlap with
-latexmath:[$\overline{\textit{cfp}}$] are satisfied and latexmath:[$i'$]
+_i_ and _i'_, and _fixed memory store
+operations_ that were forwarded to _i_ from store
+instructions program-order-between _i_ and _i'_
+including _i'_, and let
+_/cfp_ be the complement of
+_cfp_ in the memory footprint of _i_.
+If _/cfp_ is not empty:
+... _i'_ has a fully determined memory footprint;
+... _i'_ has no unpropagated memory store operations that
+overlap with _/cfp_; and
+... if _i'_ is a load with a memory footprint that overlaps
+with _/cfp_, then all the memory load
+operations of _i'_ that overlap with
+_/cfp_ are satisfied and _i'_
 is _non-restartable_ (see the <<prop_store, Propagate store operation>> transition for how to determined if an
 instruction is non-restartable).
 +
 Here, a memory store operation is called fixed if the store instruction
 has fully determined data.
-. latexmath:[$i$] has a fully determined data; and
-. if latexmath:[$i$] is not a fence, all program-order-previous
+. _i_ has a fully determined data; and
+. if _i_ is not a fence, all program-order-previous
 conditional branch and indirect jump instructions are finished.
 
 Action:
 
-. if latexmath:[$i$] is a conditional branch or indirect jump
+. if _i_ is a conditional branch or indirect jump
 instruction, discard any untaken paths of execution, i.e., remove all
 instruction instances that are not reachable by the branch/jump taken in
 _instruction_tree_; and

--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -52,6 +52,9 @@ endif::[]
 :ne: &#8800;
 :approx: &#8776;
 :inf: &#8734;
+:circ: &#x25CB;
+:bullet: &#x2219;
+:times: &#x00D7;
 :imagesdir: images
 
 _Contributors to all versions of the spec in alphabetical order (please contact editors to suggest corrections):

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -49,6 +49,9 @@ endif::[]
 :ne: &#8800;
 :approx: &#8776;
 :inf: &#8734;
+:circ: &#x2218;
+:bullet: &#x2219;
+:times: &#x00D7;
 :csrname: envcfg
 :imagesdir: images
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -1030,21 +1030,21 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 |===
 |Instruction |Constraints |Code Points |Purpose
 
-|LUI |_rd_=`x0` |latexmath:[$2^{20}$] .8+<.^m|_Designated for future standard use_
+|LUI |_rd_=`x0` |2^20^ .8+<.^m|_Designated for future standard use_
 
-|AUIPC |_rd_=`x0` |latexmath:[$2^{20}$]
+|AUIPC |_rd_=`x0` |2^20^
 
-|ADDI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _imm_&#8800;0 |latexmath:[$2^{17}-1$]
+|ADDI |_rd_=`x0`, and either _rs1_{ne}``x0`` or _imm_{ne}0 |2^17^−1
 
-|ANDI |_rd_=`x0` |latexmath:[$2^{17}$]
+|ANDI |_rd_=`x0` |2^17^
 
-|ORI |_rd_=`x0` |latexmath:[$2^{17}$]
+|ORI |_rd_=`x0` |2^17^
 
-|XORI |_rd_=`x0` |latexmath:[$2^{17}$]
+|XORI |_rd_=`x0` |2^17^
 
-|ADD |_rd_=`x0`, _rs1_&#8800;``x0`` |latexmath:[$2^{10}-32$]
+|ADD |_rd_=`x0`, _rs1_{ne}``x0`` |2^10^−32
 
-|ADD |_rd_=`x0`, _rs1_=`x0`, _rs2_&#8800;``x2-x5`` | 28
+|ADD |_rd_=`x0`, _rs1_=`x0`, _rs2_{ne}``x2-x5`` | 28
 
 |ADD |_rd_=`x0`, _rs1_=`x0`, _rs2_=`x2-x5` |4|(_rs2_=`x2`) NTL.P1 +
 (_rs2_=`x3`) NTL.PALL +
@@ -1055,45 +1055,45 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 
 |SRAI |_rd_=`x0`, _rs1_=`x0`, _shamt_=7 |1|Semihosting exit marker
 
-|SUB |_rd_=`x0` |latexmath:[$2^{10}$] .11+<.^m|_Designated for future standard use_
+|SUB |_rd_=`x0` |2^10^ .11+<.^m|_Designated for future standard use_
 
-|AND |_rd_=`x0` |latexmath:[$2^{10}$]
+|AND |_rd_=`x0` |2^10^
 
-|OR |_rd_=`x0` |latexmath:[$2^{10}$]
+|OR |_rd_=`x0` |2^10^
 
-|XOR |_rd_=`x0` |latexmath:[$2^{10}$]
+|XOR |_rd_=`x0` |2^10^
 
-|SLL |_rd_=`x0` |latexmath:[$2^{10}$]
+|SLL |_rd_=`x0` |2^10^
 
-|SRL |_rd_=`x0` |latexmath:[$2^{10}$]
+|SRL |_rd_=`x0` |2^10^
 
-|SRA |_rd_=`x0` |latexmath:[$2^{10}$]
+|SRA |_rd_=`x0` |2^10^
 
-|FENCE|_rd_=`x0`, _rs1_&#8800;``x0``, _fm_=0, and either _pred_=0 or _succ_=0| latexmath:[$2^{10}-63$]
+|FENCE|_rd_=`x0`, _rs1_{ne}``x0``, _fm_=0, and either _pred_=0 or _succ_=0| 2^10^−63
 
-|FENCE|_rd_&#8800;``x0``, _rs1_=`x0`, _fm_=0, and either _pred_=0 or _succ_=0| latexmath:[$2^{10}-63$]
+|FENCE|_rd_{ne}``x0``, _rs1_=`x0`, _fm_=0, and either _pred_=0 or _succ_=0| 2^10^−63
 
-|FENCE |_rd_=_rs1_=`x0`, _fm_=0, _pred_=0, _succ_&#8800;0 |15
+|FENCE |_rd_=_rs1_=`x0`, _fm_=0, _pred_=0, _succ_{ne}0 |15
 
-|FENCE |_rd_=_rs1_=`x0`, _fm_=0, _pred_&#8800;W, _succ_=0 |15
+|FENCE |_rd_=_rs1_=`x0`, _fm_=0, _pred_{ne}W, _succ_=0 |15
 
 |FENCE |_rd_=_rs1_=`x0`, _fm_=0, _pred_=W, _succ_=0 |1 |PAUSE
 
 4+|
 
-|SLTI |_rd_=`x0` |latexmath:[$2^{17}$] .7+<.^m|_Designated for custom use_
+|SLTI |_rd_=`x0` |2^17^ .7+<.^m|_Designated for custom use_
 
-|SLTIU|_rd_=`x0` |latexmath:[$2^{17}$]
+|SLTIU|_rd_=`x0` |2^17^
 
-|SLLI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;31 |latexmath:[$2^{10}-1$]
+|SLLI |_rd_=`x0`, and either _rs1_{ne}``x0`` or _shamt_{ne}31 |2^10^−1
 
-|SRLI |_rd_=`x0` |latexmath:[$2^{10}$]
+|SRLI |_rd_=`x0` |2^10^
 
-|SRAI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;7 |latexmath:[$2^{10}-1$]
+|SRAI |_rd_=`x0`, and either _rs1_{ne}``x0`` or _shamt_{ne}7 |2^10^−1
 
-|SLT |_rd_=`x0` |latexmath:[$2^{10}$]
+|SLT |_rd_=`x0` |2^10^
 
-|SLTU |_rd_=`x0` |latexmath:[$2^{10}$]
+|SLTU |_rd_=`x0` |2^10^
 |===
 
 NOTE: `slli x0, x0, 0x1f` and `srai x0, x0, 7` were previously designated as

--- a/src/rv64.adoc
+++ b/src/rv64.adoc
@@ -73,11 +73,11 @@ include::images/wavedrom/rv64i-slliw.edn[]
 [#norm:slliw_srliw_sraiw_op]#SLLIW, SRLIW, and SRAIW are RV64I-only instructions that are analogously
 defined but operate on 32-bit values and sign-extend their 32-bit
 results to 64 bits.# [#norm:slliw_srliw_sraiw_imm5_rsv]#SLLIW, SRLIW, and SRAIW encodings with
-_imm[5] &#8800; 0_ are reserved.#
+_imm[5] {ne} 0_ are reserved.#
 
 [NOTE]
 ====
-Previously, SLLIW, SRLIW, and SRAIW with _imm[5] &#8800; 0_
+Previously, SLLIW, SRLIW, and SRAIW with _imm[5] {ne} 0_
 were defined to cause illegal-instruction exceptions, whereas now they
 are marked as reserved. This is a backwards-compatible change.
 ====
@@ -102,7 +102,7 @@ address of the AUIPC instruction, then places the result in register _rd_.#
 ====
 Note that the set of address offsets that can be formed by pairing LUI
 with LD, AUIPC with JALR, etc. in RV64I is
-[latexmath:[${-}2^{31}{-}2^{11}$], latexmath:[$2^{31}{-}2^{11}{-}1$]].
+[−2^31^−2^11^, 2^31^−2^11^−1].
 ====
 
 ==== Integer Register-Register Operations
@@ -171,23 +171,23 @@ defined in this subspace.
 [float="center",align="center",cols="<,<,^,<", options="header", grid="all"]
 |===
 |Instruction |Constraints |Code Points |Purpose
-|LUI |_rd_=_x0_ |latexmath:[$2^{20}$] .9+.^|_Designated for future standard use_
+|LUI |_rd_=_x0_ |2^20^ .9+.^|_Designated for future standard use_
 
-|AUIPC |_rd_=_x0_ |latexmath:[$2^{20}$]
+|AUIPC |_rd_=_x0_ |2^20^
 
-|ADDI |_rd_=_x0_, and either _rs1_≠_x0_ or _imm_≠0  |latexmath:[$2^{17}-1$]
+|ADDI |_rd_=_x0_, and either _rs1_≠_x0_ or _imm_≠0  |2^17^−1
 
-|ANDI |_rd_=_x0_ |latexmath:[$2^{17}$]
+|ANDI |_rd_=_x0_ |2^17^
 
-|ORI |_rd_=_x0_ |latexmath:[$2^{17}$]
+|ORI |_rd_=_x0_ |2^17^
 
-|XORI |_rd_=_x0_ |latexmath:[$2^{17}$]
+|XORI |_rd_=_x0_ |2^17^
 
-|ADDIW |_rd_=_x0_ |latexmath:[$2^{17}$]
+|ADDIW |_rd_=_x0_ |2^17^
 
-|ADD |_rd_=_x0_, _rs1_≠_x0_ |latexmath:[$2^{10}-32$]
+|ADD |_rd_=_x0_, _rs1_≠_x0_ |2^10^−32
 
-|ADD |_rd_=_x0_, _rs1_=_x0_, _rs2_≠_x2_-_x5_| 28
+|ADD |_rd_=_x0_, _rs1_=_x0_, _rs2_≠_x2_-_x5_ | 28
 
 |ADD |_rd_=_x0_, _rs1_=_x0_, _rs2_=_x2_-_x5_| 4 | (_rs2_=_x2_) NTL.P1 +
  (_rs2_=_x3_) NTL.PALL +
@@ -198,33 +198,33 @@ defined in this subspace.
 
 |SRAI |_rd_=`x0`, _rs1_=`x0`, _shamt_=7 |1|Semihosting exit marker
 
-|SUB |_rd_=_x0_ |latexmath:[$2^{10}$] .16+.^| _Designated for future standard use_
+|SUB |_rd_=_x0_ |2^10^ .16+.^| _Designated for future standard use_
 
-|AND |_rd_=_x0_ |latexmath:[$2^{10}$]
+|AND |_rd_=_x0_ |2^10^
 
-|OR |_rd_=_x0_ |latexmath:[$2^{10}$]
+|OR |_rd_=_x0_ |2^10^
 
-|XOR |_rd_=_x0_ |latexmath:[$2^{10}$]
+|XOR |_rd_=_x0_ |2^10^
 
-|SLL |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SLL |_rd_=_x0_ |2^10^
 
-|SRL |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRL |_rd_=_x0_ |2^10^
 
-|SRA |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRA |_rd_=_x0_ |2^10^
 
-|ADDW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|ADDW |_rd_=_x0_ |2^10^
 
-|SUBW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SUBW |_rd_=_x0_ |2^10^
 
-|SLLW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SLLW |_rd_=_x0_ |2^10^
 
-|SRLW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRLW |_rd_=_x0_ |2^10^
 
-|SRAW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRAW |_rd_=_x0_ |2^10^
 
-|FENCE |_rd_=_x0_, _rs1_≠_x0_,_fm_=0, and either _pred_=0 or _succ_=0 |latexmath:[$2^{10}-63$]
+|FENCE |_rd_=_x0_, _rs1_≠_x0_,_fm_=0, and either _pred_=0 or _succ_=0 |2^10^−63
 
-|FENCE |_rd_≠_x0_, _rs1_=_x0_, _fm_=0, and either _pred_=0 or _succ_=0  |latexmath:[$2^{10}-63$]
+|FENCE |_rd_≠_x0_, _rs1_=_x0_, _fm_=0, and either _pred_=0 or _succ_=0  |2^10^−63
 
 |FENCE |_rd_=_rs1_=_x0_, _fm_=0, _pred_=0, _succ_≠0 |15
 
@@ -232,25 +232,25 @@ defined in this subspace.
 
 |FENCE |_rd_=_rs1_=_x0_, _fm_=0, _pred_=W, _succ_=0 |1 | PAUSE
 
-|SLTI |_rd_=_x0_ |latexmath:[$2^{17}$] .10+.^|_Designated for custom use_
+|SLTI |_rd_=_x0_ |2^17^ .10+.^|_Designated for custom use_
 
-|SLTIU |_rd_=_x0_ |latexmath:[$2^{17}$]
+|SLTIU |_rd_=_x0_ |2^17^
 
-|SLLI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;31 |latexmath:[$2^{11}-1$]
+|SLLI |_rd_=`x0`, and either _rs1_{ne}``x0`` or _shamt_{ne}31 |2^11^−1
 
-|SRLI |_rd_=`x0` |latexmath:[$2^{11}$]
+|SRLI |_rd_=`x0` |2^11^
 
-|SRAI |_rd_=`x0`, and either _rs1_&#8800;``x0`` or _shamt_&#8800;7 |latexmath:[$2^{11}-1$]
+|SRAI |_rd_=`x0`, and either _rs1_{ne}``x0`` or _shamt_{ne}7 |2^11^−1
 
-|SLLIW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SLLIW |_rd_=_x0_ |2^10^
 
-|SRLIW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRLIW |_rd_=_x0_ |2^10^
 
-|SRAIW |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SRAIW |_rd_=_x0_ |2^10^
 
-|SLT |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SLT |_rd_=_x0_ |2^10^
 
-|SLTU |_rd_=_x0_ |latexmath:[$2^{10}$]
+|SLTU |_rd_=_x0_ |2^10^
 |===
 
 NOTE: `slli x0, x0, 0x1f` and `srai x0, x0, 7` were previously designated as

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -144,9 +144,9 @@ mode must ignore source register operand bits above the configured XLEN,
 and must sign-extend results to fill the widest supported XLEN in the
 destination register.
 
-If UXLEN latexmath:[$<$] SXLEN, user-mode instruction-fetch addresses
+If UXLEN < SXLEN, user-mode instruction-fetch addresses
 and load and store effective addresses are taken modulo
-latexmath:[$2^{\text{UXLEN}}$]. For example, when UXLEN=32 and SXLEN=64,
+2^UXLEN^. For example, when UXLEN=32 and SXLEN=64,
 user-mode memory accesses reference the lowest 4 GiB of the address space.
 
 Some HINT instructions are encoded as integer computational instructions that
@@ -721,7 +721,7 @@ possible invalid addresses. Prior to writing `stval`, implementations
 may convert an invalid address into some other invalid address that
 `stval` is capable of holding. If the feature to return the faulting
 instruction bits is implemented, `stval` must also be able to hold all
-values less than latexmath:[$2^N$], where latexmath:[$N$] is the smaller
+values less than 2^_N_^, where _N_ is the smaller
 of SXLEN and ILEN.
 
 [[sec:senvcfg]]
@@ -941,7 +941,7 @@ ASID bits, termed _ASIDLEN_, may be determined by writing one to every
 bit position in the ASID field, then reading back the value in `satp` to
 see which bit positions in the ASID field hold a one. The
 least-significant bits of ASID are implemented first: that is, if
-ASIDLEN latexmath:[$>$] 0, ASID[ASIDLEN-1:0] is writable. The maximal
+ASIDLEN > 0, ASID[ASIDLEN-1:0] is writable. The maximal
 value of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for Sv39, Sv48,
 and Sv57.
 
@@ -1093,20 +1093,20 @@ The behavior of SFENCE.VMA depends on _rs1_ and _rs2_ as follows:
 made to any level of the page tables, for all address spaces. The fence
 also invalidates all address-translation cache entries, for all address
 spaces.
-* If __rs1__=`x0` and __rs2__&#8800;``x0``, the fence orders all
+* If __rs1__=`x0` and __rs2__{ne}``x0``, the fence orders all
 reads and writes made to any level of the page tables, but only for the
 address space identified by integer register _rs2_. Accesses to _global_
 mappings (see <<translation>>) are not ordered. The
 fence also invalidates all address-translation cache entries matching
 the address space identified by integer register _rs2_, except for
 entries containing global mappings.
-* If __rs1__&#8800;``x0`` and __rs2__=`x0`, the fence orders only
+* If __rs1__{ne}``x0`` and __rs2__=`x0`, the fence orders only
 reads and writes made to leaf page table entries corresponding to the
 virtual address in __rs1__, for all address spaces. The fence also
 invalidates all address-translation cache entries that contain leaf page
 table entries corresponding to the virtual address in _rs1_, for all
 address spaces.
-* If __rs1__&#8800;``x0`` and __rs2__&#8800;``x0``, the
+* If __rs1__{ne}``x0`` and __rs2__{ne}``x0``, the
 fence orders only reads and writes made to leaf page table entries
 corresponding to the virtual address in _rs1_, for the address space
 identified by integer register _rs2_. Accesses to global mappings are
@@ -1130,7 +1130,7 @@ choice not to raise an exception when an invalid virtual address is held
 in _rs1_ facilitates this type of simplification.
 ====
 
-When __rs2__&#8800;``x0``, bits SXLEN-1:ASIDMAX of the value held
+When __rs2__{ne}``x0``, bits SXLEN-1:ASIDMAX of the value held
 in _rs2_ are reserved for future standard use. Until their use is
 defined by a standard extension, they should be zeroed by software and
 ignored by current implementations. Furthermore, if
@@ -1428,7 +1428,7 @@ either mapping being used.
 Global mappings need not be stored redundantly in address-translation
 caches for multiple ASIDs. Additionally, they need not be flushed from
 local address-translation caches when an SFENCE.VMA instruction is
-executed with __rs2__&#8800;``x0``.
+executed with __rs2__{ne}``x0``.
 ====
 
 The RSW field is reserved for use by supervisor software; the

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -322,7 +322,7 @@ Scalar element group operands do not need to be aligned to LMUL for any implemen
 ====
 
 In the case of the `.vs` instructions defined in this specification, `vs2` holds a 128-bit scalar element group.
-For implementations with `VLEN` ≥ 128, `vs2` refers to a single register. Thus, the `vd` register group must not
+For implementations with `VLEN` {ge} 128, `vs2` refers to a single register. Thus, the `vd` register group must not
 overlap the `vs2` register.
 However, in implementations where `VLEN` < 128, `vs2` refers to a register group comprised of the number
 of registers needed to hold the 128-bit scalar element group. In this case, the `vd` register group must not
@@ -413,7 +413,7 @@ The following contains some guidelines that enable the portability of vector-cry
 to implementations with different values for `VLEN`
 
 Application Processors::
-Application processors are expected to follow the V-extension and will therefore have `VLEN` ≥ 128.
+Application processors are expected to follow the V-extension and will therefore have `VLEN` {ge} 128.
 
 
 
@@ -424,15 +424,15 @@ for these instructions to support implementations with `VLEN`=128.
 
 However, the SHA-512 and SM3 instructions have an `EGW`=256. Implementations with `VLEN` = 128, require that
 `LMUL` is doubled for these instructions in order to create 256-bit elements across a pair of registers.
-Code written with this doubling of `LMUL` will not affect the results returned by implementations with `VLEN` ≥ 256
+Code written with this doubling of `LMUL` will not affect the results returned by implementations with `VLEN` {ge} 256
 because `vl` controls how many element groups are processed. Therefore, we recommend that libraries that implement
 SHA-512 and SM3 employ this doubling of `LMUL` to ensure that the software can run on all implementation
-with `VLEN` ≥ 128.
+with `VLEN` {ge} 128.
 
-While the doubling of `LMUL` for these instructions is _safe_ for implementations with `VLEN` ≥ 256, it may be less
+While the doubling of `LMUL` for these instructions is _safe_ for implementations with `VLEN` {ge} 256, it may be less
 optimal as it will result in unnecessary register pressure and might exact a performance penalty in
 some microarchitectures. Therefore, we suggest that in addition to providing portable code for SHA-512 and SM3,
-libraries should also include more optimal code for these instructions when `VLEN` ≥ 256.
+libraries should also include more optimal code for these instructions when `VLEN` {ge} 256.
 // ====
 
 [%autowidth]
@@ -450,8 +450,8 @@ libraries should also include more optimal code for these instructions when `VLE
 // [NOTE]
 // ====
 // We recommend that all library code for application processors be written so that it can be run on any
-// implementation with `VLEN` ≥ 128. Such libraries are also encouraged to have versions of code for
-// SHA-512 and SM3 optimized for implementations with `VLEN` ≥ 256.
+// implementation with `VLEN` {ge} 128. Such libraries are also encouraged to have versions of code for
+// SHA-512 and SM3 optimized for implementations with `VLEN` {ge} 256.
 // ====
 
 Embedded Processors::
@@ -730,8 +730,8 @@ To help avoid side-channel timing attacks, these instructions shall be implement
 
 // [NOTE]
 // ====
-// It is recommended that implementations have VLEN≥128 for these instructions.
-// // Furthermore, for the best performance in SHA512, it is recommended that implementations have VLEN≥256.
+// It is recommended that implementations have VLEN{ge}128 for these instructions.
+// // Furthermore, for the best performance in SHA512, it is recommended that implementations have VLEN{ge}256.
 // When VLEN<EGW, an appropriate LMUL needs to be used by software so that elements from the
 // specified register groups can be combined to form the full element group.
 // ====
@@ -823,7 +823,7 @@ eight 32-bit elements.
 Implementations with VLEN < 256 require LMUL>1 to combine 32-bit elements from register groups
 to provide all eight elements of the element group.
 
-// The instructions will be most efficient on implementations where `VLEN`≥256.
+// The instructions will be most efficient on implementations where `VLEN`{ge}256.
 // They will also provide substantial benefit on implementations where
 // `VLEN`=128, but will require an `LMUL`>1 in order to combine elements
 // within a register group to form the full element group.
@@ -3776,7 +3776,7 @@ specification without requiring that software perform these swaps.
 
 // NOTE
 // ====
-// For the best performance, it is recommended that implementations have VLEN≥256.
+// For the best performance, it is recommended that implementations have VLEN{ge}256.
 // When VLEN<EGW, an appropriate LMUL needs to be used by software so that elements from the
 // specified register groups can be combined to form the full element group.
 // ====

--- a/src/zfa.adoc
+++ b/src/zfa.adoc
@@ -23,14 +23,14 @@ like FMV.W.X, but with _rs2_=1.
 [%autowidth,float="center",align="center",cols=">,>,^,^,^",options="header",]
 |===
 |_rs1_ |Value |Sign |Exponent |Significand
-|0 |latexmath:[$-1.0$] |`1` |`01111111` |`000...000`
+|0 |−1.0 |`1` |`01111111` |`000...000`
 |1 |_Minimum positive normal_ |`0` |`00000001` |`000...000`
-|2 |latexmath:[$1.0 \times 2^{-16}$] |`0` |`01101111` |`000...000`
-|3 |latexmath:[$1.0 \times 2^{-15}$] |`0` |`01110000` |`000...000`
-|4 |latexmath:[$1.0 \times 2^{-8}$] |`0` |`01110111` |`000...000`
-|5 |latexmath:[$1.0 \times 2^{-7}$] |`0` |`01111000` |`000...000`
-|6 |0.0625 (latexmath:[$2^{-4}$]) |`0` |`01111011` |`000...000`
-|7 |0.125 (latexmath:[$2^{-3}$]) |`0` |`01111100` |`000...000`
+|2 |1.0 × 2^−16^ |`0` |`01101111` |`000...000`
+|3 |1.0 × 2^−15^ |`0` |`01110000` |`000...000`
+|4 |1.0 × 2^−8^ |`0` |`01110111` |`000...000`
+|5 |1.0 × 2^−7^ |`0` |`01111000` |`000...000`
+|6 |0.0625 (2^−4^) |`0` |`01111011` |`000...000`
+|7 |0.125 (2^−3^) |`0` |`01111100` |`000...000`
 |8 |0.25 |`0` |`01111101` |`000...000`
 |9 |0.3125 |`0` |`01111101` |`010...000`
 |10 |0.375 |`0` |`01111101` |`100...000`
@@ -49,11 +49,11 @@ like FMV.W.X, but with _rs2_=1.
 |23 |4 |`0` |`10000001` |`000...000`
 |24 |8 |`0` |`10000010` |`000...000`
 |25 |16 |`0` |`10000011` |`000...000`
-|26 |128 (latexmath:[$2^7$]) |`0` |`10000110` |`000...000`
-|27 |256 (latexmath:[$2^8$]) |`0` |`10000111` |`000...000`
-|28 |latexmath:[$2^{15}$] |`0` |`10001110` |`000...000`
-|29 |latexmath:[$2^{16}$] |`0` |`10001111` |`000...000`
-|30 |latexmath:[$+\infty$] |`0` |`11111111` |`000...000`
+|26 |128 (2^7^) |`0` |`10000110` |`000...000`
+|27 |256 (2^8^) |`0` |`10000111` |`000...000`
+|28 |2^15^ |`0` |`10001110` |`000...000`
+|29 |2^16^ |`0` |`10001111` |`000...000`
+|30 |+{inf} |`0` |`11111111` |`000...000`
 |31 |_Canonical NaN_ |`0` |`11111111` |`100...000`
 |===
 
@@ -90,13 +90,13 @@ If the Zfh or Zvfh extension is implemented, FLI.H performs the
 analogous operation, but loads a half-precision floating-point value
 into register _rd_. Note that entry 1 (corresponding to the minimum
 positive normal value) has a numerically different value for
-half-precision. Furthermore, since latexmath:[$2^{16}$] is not
+half-precision. Furthermore, since 2^16^ is not
 representable in half-precision floating-point, entry 29 in the table
 instead loads positive infinity—i.e., it is redundant with entry 30.
 FLI.H is encoded like FLI.S, but with _fmt_=H.
 [NOTE]
 ====
-Additionally, since latexmath:[$2^{-16}$] and latexmath:[$2^{-15}$] are subnormal in half-precision, entry 1 is numerically greater than entries 2 and 3 for FLI.H.
+Additionally, since 2^−16^ and 2^−15^ are subnormal in half-precision, entry 1 is numerically greater than entries 2 and 3 for FLI.H.
 ====
 The FLI._fmt_ instructions never set any floating-point exception flags.
 
@@ -161,7 +161,7 @@ The FCVTMOD.W.D instruction is defined similarly to the FCVT.W.D
 instruction, with the following differences. FCVTMOD.W.D always rounds
 towards zero. Bits 31:0 are taken from the rounded, unbounded two's
 complement result, then sign-extended to XLEN bits and written to
-integer register _rd_. latexmath:[$\pm\infty$] and NaN are converted to
+integer register _rd_. ±{inf} and NaN are converted to
 zero.
 
 Floating-point exception flags are raised the same as they would be for
@@ -178,7 +178,7 @@ specified, i.e., `fcvtmod.w.d rd, rs1, rtz`.
 The FCVTMOD.W.D instruction was added principally to accelerate the
 processing of JavaScript Numbers. Numbers are double-precision
 values, but some operators implicitly truncate them to signed integers
-mod latexmath:[$2^{32}$].
+mod 2^32^.
 ====
 === Move Instructions
 

--- a/src/zfh.adoc
+++ b/src/zfh.adoc
@@ -19,9 +19,9 @@ intermediate precision. Although this extension provides explicit
 conversion instructions that suffice to implement that pattern, future
 extensions might further accelerate such computation with additional
 instructions that implicitly widen their operands—e.g.,
-halflatexmath:[$\times$]halflatexmath:[$+$]singlelatexmath:[$\rightarrow$]single—or
+half{times}half+single->single—or
 implicitly narrow their results—e.g.,
-halflatexmath:[$+$]singlelatexmath:[$\rightarrow$]half.
+half+single->half.
 ====
 === Half-Precision Load and Store Instructions
 

--- a/src/zfinx.adoc
+++ b/src/zfinx.adoc
@@ -43,11 +43,11 @@ The Zfinx extension depends on the "Zicsr" extension for control and status regi
 
 === Processing of Narrower Values
 
-Floating-point operands of width _w_ latexmath:[$<$] XLEN bits occupy
+Floating-point operands of width _w_ < XLEN bits occupy
 bits _w_-1:0 of an `x` register. Floating-point operations on _w_-bit
 operands ignore operand bits XLEN-1: _w_.
 
-Floating-point operations that produce _w_ latexmath:[$<$] XLEN-bit
+Floating-point operations that produce _w_ < XLEN-bit
 results fill bits XLEN-1: _w_ with copies of bit _w_-1 (the sign bit).
 
 [NOTE]

--- a/src/zicsr.adoc
+++ b/src/zicsr.adoc
@@ -90,7 +90,7 @@ effects regardless of _rd_ and _rs1_ fields.
 
 5+^|*Immediate operand*
 
-|Instruction |_rd_ is `x0` |__uimm__latexmath:[$=$]0 |Reads CSR |Writes
+|Instruction |_rd_ is `x0` |_uimm_=0 |Reads CSR |Writes
 CSR
 
 |CSRRWI |Yes |- |No |Yes


### PR DESCRIPTION
Redux of #2410.