### PR TITLE
Use unicode symbols instead of HTML entities

### DIFF
--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -47,15 +47,9 @@ endif::[]
 :hide-uri-scheme:
 :stem: latexmath
 :footnote:
-:le: ≤
-:ge: ≥
-:ne: ≠
-:approx: ≈
-:inf: ∞
-:circ: ○
-:bullet: ∙
-:times: ×
 :imagesdir: images
+
+include::symbols.adoc[]
 
 _Contributors to all versions of the spec in alphabetical order (please contact editors to suggest corrections):
 Krste Asanović,

--- a/src/riscv-unprivileged.adoc
+++ b/src/riscv-unprivileged.adoc
@@ -44,16 +44,10 @@ endif::[]
 :hide-uri-scheme:
 :stem: latexmath
 :footnote:
-:le: ≤
-:ge: ≥
-:ne: ≠
-:approx: ≈
-:inf: ∞
-:circ: ○
-:bullet: ∙
-:times: ×
 :csrname: envcfg
 :imagesdir: images
+
+include::symbols.adoc[]
 
 _Contributors to all versions of the spec in alphabetical order (please contact editors to suggest corrections):
 Arvind,

--- a/src/symbols.adoc
+++ b/src/symbols.adoc
@@ -1,0 +1,10 @@
+// Macros that can be used in place of unicode characters to make writing them
+// easier, e.g. "X {ge} Y".
+:le: ≤
+:ge: ≥
+:ne: ≠
+:approx: ≈
+:inf: ∞
+:circ: ○
+:bullet: ∙
+:times: ×


### PR DESCRIPTION
Instead of HTML entities for the special symbol macros, use their unicode characters directly. This doesn't have any effect on the PDF or HTML output, but it makes the tags JSON output easier to read, and also makes the Asciidoc source easier to read (you don't have to look up any weird hex codes to see what `{circ}` looks like).