### PR TITLE
Fix non-normative description of RV32V_Zdinx

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2242,10 +2242,10 @@ by naming the immediate `uimm` in the assembly syntax.
 
 NOTE: When adding a vector extension to the Zfinx/Zdinx/Zhinx
 extensions, floating-point scalar arguments are taken from the `x`
-registers.  NaN-boxing is not supported in these extensions, and so
-the vector floating-point scalar value is produced using the same
-rules as for an integer scalar operand (i.e., when XLEN > SEW use the
-lowest SEW bits, when XLEN < SEW use the sign-extended value).
+registers.
+NaN-boxing is not supported in these extensions, and so operands narrower
+than XLEN bits are not checked for a NaN box; bits XLEN-1:EEW are ignored.
+For RV32_Zdinx, EEW=64 scalar arguments are supplied by an `x`-register pair.
 
 Vector arithmetic instructions are masked under control of the `vm`
 field.


### PR DESCRIPTION
EEW=64 FP operands are supplied by register pairs.