### PR TITLE
Fix Issue #2430 

### DIFF
--- a/src/riscv-privileged.adoc
+++ b/src/riscv-privileged.adoc
@@ -52,7 +52,7 @@ endif::[]
 :ne: &#8800;
 :approx: &#8776;
 :inf: &#8734;
-:circ: &#x25CB;
+:circ: &#x2218;
 :bullet: &#x2219;
 :times: &#x00D7;
 :imagesdir: images


### PR DESCRIPTION
## Problem

The `:circ:` attribute is inconsistently defined between the two main specification files:

- In `riscv-unprivileged.adoc` (line 52): `:circ: &#x2218;` (ring operator, U+2218)
- In `riscv-privileged.adoc` (line 55): `:circ: &#x25CB;` (white circle, U+25CB)

All other similar attributes (`:le:`, `:ge:`, `:ne:`, `:approx:`, `:inf:`, `:bullet:`, `:times:`) are defined identically in both files, suggesting this is an inconsistency rather than intentional.

The `{circ}` attribute is actually used in `mm-formal.adoc` (line 613) which is included in the unprivileged spec, so the unprivileged definition (`&#x2218;`) appears to be the correct one.

## Solution

This PR updates `riscv-privileged.adoc` to use `&#x2218;` (ring operator) to match the definition in `riscv-unprivileged.adoc`, ensuring consistent rendering across both volumes.

## Changes

- Changed `:circ:` attribute in `src/riscv-privileged.adoc` from `&#x25CB;` to `&#x2218;`