### PR TITLE
Removing the last 2 calls to latexmath

### DIFF
--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -658,7 +658,7 @@ However, here the SEW-width format is limited to BF16.
 
 [NOTE]
 ====
-If the input is normal or {inf}, the BF16 encoded value is shifted
+If the input is normal or infinity, the BF16 encoded value is shifted
 to the left by 16 places and the
 least significant 16 bits are written with 0s.
 ====


### PR DESCRIPTION
Fixes issue #2436 

In PR #2411 I thought I removed all calls to latexmath. There are still 2 in mm_format.adoc that I should remove:

These 2 can just be replaced with _dep_ to get the equivalent italics that the latexmath provides.

```
. add _reg_name_ to _i.reg_writes_ with
latexmath:[$deps$] and _reg_value_; and
. update the state of _i_ to Plain(_next_state_).

where latexmath:[$deps$] is a pair of the set of all _read_sources_ from
_i.reg_reads_, and a flag that is true iff
_i_ is a load instruction instance that has already been
entirely satisfied.
```