### PR TITLE
Issue #2443: Removed target_address, replaced misleading use of jal, added comment about clearing LSB

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2503,7 +2503,7 @@ switch(XLEN) {
 }
 
 //fetch from the jump table
-pc = InstMemory[table_address][XLEN-1:0]&~0x1;	// Clear bit 0.
+pc = InstMemory[table_address][XLEN-1:0]&~0x1;  // Clear bit 0.
 
 ----
 
@@ -2582,6 +2582,6 @@ switch(XLEN) {
 //fetch from the jump table
 
 ra = pc+2;
-pc = InstMemory[table_address][XLEN-1:0]&~0x1;	// Clear bit 0.
+pc = InstMemory[table_address][XLEN-1:0]&~0x1;  // Clear bit 0.
 
 ----


### PR DESCRIPTION
The cm.jt and cm.jalt pseudo-code was slightly confusing, and referenced the j and jal instructions for little additional benefit. This cleans up the pseudo-code by removing one of the temporary variables and overall simplification.