### PR TITLE
Issue #2443: Removed target_address, replaced misleading use of jal, added comment about clearing LSB

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -2494,7 +2494,7 @@ Operation::
 ----
 //This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
-# target_address is temporary internal state, it doesn't represent a real register
+# table_address is temporary internal state, it doesn't represent a real register
 # InstMemory is byte indexed
 
 switch(XLEN) {
@@ -2503,9 +2503,7 @@ switch(XLEN) {
 }
 
 //fetch from the jump table
-target_address[XLEN-1:0] = InstMemory[table_address][XLEN-1:0];
-
-j target_address[XLEN-1:0]&~0x1;
+pc = InstMemory[table_address][XLEN-1:0]&~0x1;  // Clear bit 0.
 
 ----
 
@@ -2573,7 +2571,7 @@ Operation::
 ----
 //This is not SAIL, it's pseudocode. The SAIL hasn't been written yet.
 
-# target_address is temporary internal state, it doesn't represent a real register
+# table_address is temporary internal state, it doesn't represent a real register
 # InstMemory is byte indexed
 
 switch(XLEN) {
@@ -2582,8 +2580,8 @@ switch(XLEN) {
 }
 
 //fetch from the jump table
-target_address[XLEN-1:0] = InstMemory[table_address][XLEN-1:0];
 
-jal ra, target_address[XLEN-1:0]&~0x1;
+ra = pc+2;
+pc = InstMemory[table_address][XLEN-1:0]&~0x1;  // Clear bit 0.
 
 ----


### PR DESCRIPTION
The cm.jt and cm.jalt pseudo-code was slightly confusing, and referenced the j and jal instructions for little additional benefit. This cleans up the pseudo-code by removing one of the temporary variables and overall simplification.