### PR TITLE
Add workflow to allow /clarification label via comment

### DIFF
--- a/.github/workflows/clarification.yml
+++ b/.github/workflows/clarification.yml
@@ -1,0 +1,23 @@
+---
+name: Label "Clarification" on Comment
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: startsWith(github.event.comment.body, '/clarification')
+    steps:
+      - name: Add Clarification Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Clarification']
+            })


### PR DESCRIPTION
This adds a GitHub Action that listens for issue comments starting with "/clarification" and applies the "Clarification" label, allowing users without triage permissions to categorize issues.

- Adds .github/workflows/label-clarification.yml
- Triggers on issue comments starting with /clarification
- Uses github-script to apply the label safely