### PR TITLE
Remove remark about implementing wide coutners with traps

### DIFF
--- a/src/counters.adoc
+++ b/src/counters.adoc
@@ -51,9 +51,8 @@ upper 32 bits of the respective counters.
 ====
 We required the counters be 64 bits wide, even when XLEN=32, as
 otherwise it is very difficult for software to determine if values have
-overflowed. For a low-end implementation, the upper 32 bits of each
-counter can be implemented using software counters incremented by a trap
-handler triggered by overflow of the lower 32 bits. The sample code
+overflowed.
+The sample code
 given below shows how the full 64-bit width value can be safely read
 using the individual 32-bit width pseudoinstructions.
 ====


### PR DESCRIPTION
It is degenerately true that implementations can use traps to M-mode for just about anything.  Remarking on it in this case is a source of confusion, and it isn't a terribly likely implementation strategy, anyway.

Resolves #769