### PR TITLE
Add CBO instructions to permission check text

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -3140,10 +3140,10 @@ include::images/bytefield/pmpcfg.edn[]
 
 Attempting to fetch an instruction from a PMP region that does not have
 execute permissions raises an instruction access-fault exception.
-Attempting to execute a load or load-reserved instruction which accesses
+Attempting to execute a load, load-reserved, or cache-block management instruction which accesses
 a physical address within a PMP region without read permissions raises a
 load access-fault exception. Attempting to execute a store,
-store-conditional, or AMO instruction which accesses a physical address
+store-conditional, AMO, or cache-block zero instruction which accesses a physical address
 within a PMP region without write permissions raises a store
 access-fault exception.
 

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1386,9 +1386,9 @@ Read-write-execute page.
 
 Attempting to fetch an instruction from a page that does not have
 execute permissions raises a fetch page-fault exception. Attempting to
-execute a load or load-reserved instruction whose effective address lies
+execute a load, load-reserved, or cache-block management instruction whose effective address lies
 within a page without read permissions raises a load page-fault
-exception. Attempting to execute a store, store-conditional, or AMO
+exception. Attempting to execute a store, store-conditional, AMO, or cache-block zero instruction
 instruction whose effective address lies within a page without write
 permissions raises a store page-fault exception.
 


### PR DESCRIPTION
Add cache-block instructions to the list of instructions that are affected by permission checks. This is meant to be implied by the text elsewhere saying that CMOs require load/store permission, but it is nice to be explicit.

See #2243 