### PR TITLE
Fix bit-width for RoundKeyB in vaeskf2.vi Sail pseudocode

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -1812,7 +1812,7 @@ function clause execute (VAESKF2(rnd, vd, vs2)) = {
 
   foreach (i from eg_start to eg_len-1) {
       let CurrentRoundKey[3:0]  : bits(128)  = get_velem(vs2, EGW=128, i);
-      let RoundKeyB[3:0] : bits(32)  = get_velem(vd, EGW=128, i); // Previous round key
+      let RoundKeyB[3:0] : bits(128)  = get_velem(vd, EGW=128, i); // Previous round key
 
       let w[0] : bits(32) = if (rnd[0]==1) then
         aes_subword_fwd(CurrentRoundKey[3]) XOR RoundKeyB[0];


### PR DESCRIPTION
In the Sail pseudocode for vaeskf2.vi, the definition of RoundKeyB appears to have an incorrect bit-width specification.
The code currently uses:
`let RoundKeyB[3:0] : bits(32) = get_velem(vd, EGW=128, i); // Previous round key`
However, get_velem(vd, EGW=128, i) returns a 128-bit element group. It should instead be:
`let RoundKeyB[3:0] : bits(128) = get_velem(vd, EGW=128, i); `

Suggestion to address [riscv/riscv-crypto#403](https://github.com/riscv/riscv-crypto/issues/403#issuecomment-3637250308)