### PR TITLE
Escape a { character

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -763,7 +763,7 @@ Instructions for accelerating
 encryption, decryption, and key-schedule
 functions of the SM4 block cipher.
 
-The SM4 block cipher is specified in _32907-2016: {SM4} Block Cipher Algorithm_
+The SM4 block cipher is specified in _32907-2016: \{SM4} Block Cipher Algorithm_
 cite:[gbt:sm4]
 
 There are other various sources available that describe the SM4 block cipher.


### PR DESCRIPTION
Missed escaping a { character in a citation.