### PR TITLE
Improve wording of hart ID constraint

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -359,7 +359,7 @@ boundaries to ease human readability.
 integer ID of the hardware thread running the code.#
 [#norm:mhartid_always_rd]#This register must be readable in any implementation.#
 Hart IDs might not necessarily be
-numbered contiguously in a multiprocessor system, but at least one hart
+numbered contiguously in a multiprocessor system, but one hart
 must have a hart ID of zero. Hart IDs must be unique within the
 execution environment.
 


### PR DESCRIPTION
"At least one hart must have an ID of 0" and "IDs must be unique" together imply that exactly one hart has an ID of 0.  The text is less confusing if we drop the "at least" part.

Resolves #1446.