### PR TITLE
Issue #2523 fixes

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -750,17 +750,13 @@ Carry-less multiplication is the multiplication in the polynomial ring over GF(2
 
 *clmulr* produces bits 2{times}XLEN−2:XLEN-1 of the 2{times}XLEN carry-less product.
 
-Note that the Zbkc <<zbkc>> extension is a subset of Zbc, and removes the *clmulr* instruction to reduce implementation costs for cryptography-focused implementations.
-
-[%header,cols="^1,^1,^1,4,8"]
+[%header,cols="^1,^1,4,8"]
 |===
 |RV32
 |RV64
-|Part of Zkbc?
 |Mnemonic
 |Instruction
 
-|{check}
 |{check}
 |{check}
 |clmul _rd_, _rs1_, _rs2_
@@ -768,13 +764,11 @@ Note that the Zbkc <<zbkc>> extension is a subset of Zbc, and removes the *clmul
 
 |{check}
 |{check}
-|{check}
 |clmulh _rd_, _rs1_, _rs2_
 |<<#insns-clmulh>>
 
 |{check}
 |{check}
-|
 |clmulr _rd_, _rs1_, _rs2_
 |<<#insns-clmulr>>
 


### PR DESCRIPTION
This rewrites Zbkc as a subset of Zbc, and refers to that section for the instruction details, to avoid duplicate entries for clmul and clmulh when searching. It also adds a column to the table in Zbc to specify which of the Zbc instructions are part of Zbkc.

Let me know if any further tweaks are desired.

Resolves #2523 