### PR TITLE
[#2386] unifying carry-less spelling in vector crypto chapter

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -540,9 +540,9 @@ This extension is a superset of the <<Zvkb>> extension.
 <<<
 
 [[zvbc,Zvbc]]
-==== `Zvbc` - Vector Carryless Multiplication
+==== `Zvbc` - Vector Carry-less Multiplication
 
-General purpose carryless multiplication instructions which are commonly used in cryptography
+General purpose carry-less multiplication instructions which are commonly used in cryptography
 and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
 
 These instructions are only defined for `SEW`=64.
@@ -881,7 +881,7 @@ While Zvkg and Zvbc are not part of this extension, it is recommended that at le
 <<<
 
 [[zvknc,Zvknc]]
-==== `Zvknc` - NIST Algorithm Suite with carryless multiply
+==== `Zvknc` - NIST Algorithm Suite with carry-less multiply
 
 This extension is shorthand for the following set of other extensions:
 
@@ -899,7 +899,7 @@ This extension is shorthand for the following set of other extensions:
 [NOTE]
 ====
 This extension combines the NIST Algorithm Suite with the
-vector carryless multiply extension to enable AES-GCM.
+vector carry-less multiply extension to enable AES-GCM.
 ====
 
 <<<
@@ -956,7 +956,7 @@ While Zvkg and Zvbc are not part of this extension, it is recommended that at le
 <<<
 
 [[zvksc,Zvksc]]
-==== `Zvksc` - ShangMi Algorithm Suite with carryless multiplication
+==== `Zvksc` - ShangMi Algorithm Suite with carry-less multiplication
 
 This extension is shorthand for the following set of other extensions:
 
@@ -974,7 +974,7 @@ This extension is shorthand for the following set of other extensions:
 [NOTE]
 ====
 This extension combines the ShangMi Algorithm Suite with the
-vector carryless multiply extension to enable SM4-GCM.
+vector carry-less multiply extension to enable SM4-GCM.
 ====
 
 <<<
@@ -2239,13 +2239,13 @@ significant 64 bits of the carry-less product.
 
 [NOTE]
 ====
-The 64-bit carryless multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
-We do not make these instructions exclusive as the 64-bit carryless multiply is readily derived from the
+The 64-bit carry-less multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
+We do not make these instructions exclusive as the 64-bit carry-less multiply is readily derived from the
 instructions in the `zvkg` extension and can have utility in other areas.
 Likewise, we treat other SEW values as reserved so as not to preclude
 future extensions from using this opcode with different element widths.
 For example, a future extension might define an `SEW`=32 version of this instruction to enable `Zve32*` implementations to have
-vector carryless multiplication instructions.
+vector carry-less multiplication instructions.
 ====
 
 Operation::
@@ -2604,7 +2604,7 @@ It produces the next partial hash (Y~i+1~) by adding the current partial
 hash (Y~i~) to the cipher text block (X~i~) and then multiplying (over GF(2^128^))
 this sum by the Hash Subkey (H).
 
-The multiplication over GF(2^128^) is a carryless multiply of two 128-bit polynomials
+The multiplication over GF(2^128^) is a carry-less multiply of two 128-bit polynomials
 modulo GHASH's irreducible polynomial (x^128^ + x^7^ + x^2^ + x + 1).
 
 The operation can be compactly defined as
@@ -2729,7 +2729,7 @@ This instruction treats all of the inputs and outputs as 128-bit polynomials and
 performs operations over GF[2].
 It produces the product over GF(2^128^) of the two 128-bit inputs.
 
-The multiplication over GF(2^128^) is a carryless multiply of two 128-bit polynomials
+The multiplication over GF(2^128^) is a carry-less multiply of two 128-bit polynomials
 modulo GHASH's irreducible polynomial (x^128^ + x^7^ + x^2^ + x + 1).
 
 The NIST specification (see <<zvkg>>) orders the coefficients from left to right x~0~x~1~x~2~...x~127~
@@ -4429,7 +4429,7 @@ Crypto Vector instructions except Zvbb and Zvbc
 |===
 
 [[crypto_vector_instructions_Zvbb_Zvbc]]
-=== Vector Bitmanip and Carryless Multiply Instructions
+=== Vector Bitmanip and Carry-less Multiply Instructions
 
 OP-V (0x57)
 *Zvbb*, *Zvkb*, and *Zvbc* Vector instructions *in bold*


### PR DESCRIPTION
Vector crypto chapter was using a different spelling, carryless, compared to the usually accepted form, carry-less, which is also the spelling used in the scalar crypto chapter.  This patch unifies the spelling to carry-less.

On the branch, it seems there is no longer any instance of "carry-less"
```
$  git grep -i "carryless" | wc -l                                                                               
0
```