### PR TITLE
vgmul.vv: correct reduction polynomial in Sail comment

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -2664,7 +2664,7 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
       bool reduce = bit_to_bool(H[127]);
       H = H << 1; // left shift H by 1
       if (reduce)
-        H ^= 0x87; // Reduce using x^7 + x^2 + x^1 + 1 polynomial
+        H ^= 0x87; // Reduce using x^128 + x^7 + x^2 + x^1 + 1 polynomial
     }
 
     let result = brev8(Z); // bit reverse bytes to get back to GCM standard ordering


### PR DESCRIPTION
Section 32.3.17 (vgmul.vv).

The specification text states:
"The multiplication over GF(2^128) is a carry-less multiply of two 128-bit polynomials
modulo GHASH’s irreducible polynomial (x^128 + x^7 + x^2 + x + 1)."

However, the Sail pseudocode comment currently describes the reduction polynomial as
"x^7 + x^2 + x + 1", omitting the x^128 term.

This PR updates the comment to match the polynomial explicitly defined in the
specification text. Comment-only change; no functional change is intended.
