### PR TITLE
Fix a typo in operation of vsha2c[hl].vv instruction

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -3277,7 +3277,7 @@ function clause execute (VSHA2c(vs2, vs1, vd)) = {
   foreach (i from eg_start to eg_len-1) {
    let {a @ b @ e @ f} : bits(4*SEW) = get_velem(vs2, 4*SEW, i);
    let {c @ d @ g @ h} : bits(4*SEW) = get_velem(vd, 4*SEW, i);
-   let MessageShedPlusC[3:0] : bits(4*SEW) = get_velem(vs1, 4*SEW, i);
+   let MessageSchedPlusC[3:0] : bits(4*SEW) = get_velem(vs1, 4*SEW, i);
    let {W1, W0} == VSHA2cl ? MessageSchedPlusC[1:0] : MessageSchedPlusC[3:2]; // l vs h difference is the words selected
 
    let T1 : bits(SEW) = h + sum1(e) + ch(e,f,g) + W0;


### PR DESCRIPTION
As title said, this patch fixes a typo.