### PR TITLE
Fix Zbkb-sc, Zbkc-sc, and Zbkx-sc references

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -188,14 +188,14 @@ operate in. NIST ciphers are a part of most standardised internet
 protocols, while ShangMi ciphers are required for use in China.
 ====
 
-[[zbkb-sc,Zbkb-sc]]
+[[zbkb-sc,Zbkb]]
 ==== `Zbkb` - Bitmanip instructions for Cryptography
 
 This extension contains bit-manipulation instructions that are particularly
 useful for cryptography, most of which are also in the `Zbb` extension.
 Please refer to <<b-st-ext.adoc#zbkb>>.
 
-[[zbkc-sc,Zbkc-sc]]
+[[zbkc-sc,Zbkc]]
 ==== `Zbkc` - Carry-less multiply instructions
 
 Constant time carry-less multiply for Galois/Counter Mode.
@@ -205,7 +205,7 @@ across other instructions.
 
 Please refer to <<b-st-ext.adoc#zbkc>>.
 
-[[zbkx-sc,Zbkx-sc]]
+[[zbkx-sc,Zbkx]]
 ==== `Zbkx` - Crossbar permutation instructions
 
 These instructions are useful for implementing SBoxes in constant time, and


### PR DESCRIPTION
Make these references display as Zbkb, Zbkc, Zbkx without the -sc suffix.