### PR TITLE
Update misaligned atomicity granule summary in A chapter to match Machine chapter

### DIFF
--- a/src/a-st-ext.adoc
+++ b/src/a-st-ext.adoc
@@ -388,7 +388,7 @@ If present, the misaligned atomicity granule PMA specifies the size
 of a misaligned atomicity granule, a power-of-two number of bytes.
 The misaligned atomicity granule PMA applies only to AMOs, loads and stores
 defined in the base ISAs, and loads and stores of no more than XLEN bits
-defined in the F, D, and Q extensions.
+defined in the F, D, and Q extensions, and compressed encodings thereof.
 For an instruction in that set, if all accessed bytes lie within the same
 misaligned atomicity granule, the instruction will not raise an exception for
 reasons of address alignment, and the instruction will give rise to only one


### PR DESCRIPTION
The complete explanation of the misaligned atomicity granule in the PMA section of the Machine mode chapter includes compressed instructions, but the brief summary of the PMA in the A extension chapter was missing them. Update the text to match.