### PR TITLE
Fix 'Reserved for counter-overflow interrupt' text

### DIFF
--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -2226,7 +2226,7 @@ Machine external interrupt
 14-15 +
 {ge}16
 |Supervisor guest external interrupt +
-_Reserved for counter-overflow interrupt_ +
+Counter-overflow interrupt +
 _Reserved_ +
 _Designated for platform use_
 |0 +


### PR DESCRIPTION
In the `mcause` and `scause` this is no longer listed as reserved - looks like it was just missed in they hypervisor chapter.