### PR TITLE
Clarify which vstart values are reserved for whole register instructions

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2040,8 +2040,11 @@ numbers are placed contiguously in memory.
 The instructions operate with an effective vector length,
 `evl`=NFIELDS*VLEN/EEW, regardless of current settings in `vtype` and
 `vl`.  The usual property that no elements are written if `vstart`
-{ge} `vl` does not apply to these instructions.  Instead, no elements
-are written if `vstart` {ge} `evl`.
+{ge} `vl` does not apply to these instructions.
+Similarly, the property that the instructions are reserved if `vstart`
+exceeds the largest element index for the current `vtype` setting
+does not apply.
+Instead, the instructions are reserved if `vstart` {ge} `evl`.
 
 The instructions operate similarly to unmasked unit-stride load and
 store instructions, with the base address passed in the scalar `x`
@@ -4810,9 +4813,12 @@ length `evl`= EMUL * VLEN/SEW.
 NOTE: These instructions are intended to aid compilers to shuffle
 vector registers without needing to know or change `vl`.
 
-NOTE: The usual property that no elements are written if `vstart` {ge} `vl`
+The usual property that no elements are written if `vstart` {ge} `vl`
 does not apply to these instructions.
-Instead, no elements are written if `vstart` {ge} `evl`.
+Similarly, the property that the instructions are reserved if `vstart`
+exceeds the largest element index for the current `vtype` setting
+does not apply.
+Instead, the instructions are reserved if `vstart` {ge} `evl`.
 
 NOTE: If `vd` is equal to `vs2`, the instruction does not change any
 vector register state.


### PR DESCRIPTION
The usual property that the instructions are reserved when `vstart >= VLMAX` does not apply here; instead, the relevant effective maximum vector length for these instructions is `evl`.  (Recall that these instructions always operate on whole registers, so effective vector length and effective VLMAX are equal.)

Note that the spec had an additional statement no elements will be processed if `vstart >= evl`.  If we combine this with the property that `vstart >= evl` is reserved, the reserved property dominates, so we can remove the old clause.  The old behavior is still legal, as it is one valid interpretation of "reserved".

Fixes #2564.