### PR TITLE
Clarify misaligned address exception text

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -1985,8 +1985,8 @@ can unconditionally raise the misaligned-address exception without
 performing address translation or protection checks. Implementations
 that support misaligned accesses only to some physical addresses must
 translate and check the address before determining whether the
-misaligned access may proceed. In this case any page-fault or access-fault
-exception raised during the address translation process would take priority
+misaligned access may proceed. In this case, any page-fault or access-fault
+exception raised during the address translation process may take priority
 over misaligned-address exceptions.
 
 ***


### PR DESCRIPTION
The old text was a little confusingly worded and made it sound like you should raise a page fault or access fault exception in response to misaligned accesses. It was really just saying that they take priority.

Fixes #2578