### PR TITLE
[UDB] Add architectural parameter tags to mtval register

### DIFF
--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -2028,35 +2028,35 @@ priority order at which the hardware error is discovered.
 
 ==== Machine Trap Value (`mtval`) Register
 
-The `mtval` register is an MXLEN-bit read-write register formatted as
-shown in <<mtvalreg>>. When a trap is taken into
+[#norm:mtval_def_sz_acc]#The `mtval` register is an MXLEN-bit read-write register# formatted as
+shown in <<mtvalreg>>. [#norm:mtval_trap_behavior]#When a trap is taken into
 M-mode, `mtval` is either set to zero or written with exception-specific
 information to assist software in handling the trap. Otherwise, `mtval`
 is never written by the implementation, though it may be explicitly
-written by software. The hardware platform will specify which exceptions
+written by software.# The hardware platform will specify which exceptions
 must set `mtval` informatively, which may unconditionally set it to
 zero, and which may exhibit either behavior, depending on the underlying event
 that caused the exception.
-If the hardware platform specifies that no exceptions set `mtval`
-to a nonzero value, then `mtval` is read-only zero.
+[#norm:mtval_opt_zero]#If the hardware platform specifies that no exceptions set `mtval`
+to a nonzero value, then `mtval` is read-only zero.#
 
-If `mtval` is written with a nonzero value when a breakpoint,
+[#norm:mtval_addr_fault]#If `mtval` is written with a nonzero value when a breakpoint,
 address-misaligned, access-fault, page-fault, or hardware-error exception
 occurs on an
 instruction fetch, load, or store, then `mtval` will contain the
-faulting virtual address.
+faulting virtual address.#
 
-On a breakpoint exception raised by an EBREAK or C.EBREAK instruction, `mtval`
-is written with either zero or the virtual address of the instruction.
+[#norm:mtval_ebreak]#On a breakpoint exception raised by an EBREAK or C.EBREAK instruction, `mtval`
+is written with either zero or the virtual address of the instruction.#
 
 NOTE: For breakpoint exceptions raised by [C.]EBREAK, the virtual address of
 the instruction is already recorded in `mepc`.
 Recording the same address in `mtval` is redundant; the option is provided for
 backwards compatibility.
 
-When page-based virtual memory is enabled, `mtval` is written with the
+[#norm:mtval_pg_fault]#When page-based virtual memory is enabled, `mtval` is written with the
 faulting virtual address, even for physical-memory access-fault
-exceptions. This design reduces datapath cost for most implementations,
+exceptions.# This design reduces datapath cost for most implementations,
 particularly those with hardware page-table walkers.
 
 [[mtvalreg]]
@@ -2064,21 +2064,21 @@ particularly those with hardware page-table walkers.
 include::images/bytefield/mtvalreg.edn[]
 
 
-If `mtval` is written with a nonzero value when a misaligned load or
+[#norm:mtval_misalign_acc_fault]#If `mtval` is written with a nonzero value when a misaligned load or
 store causes an access-fault, page-fault, or hardware-error exception,
 then `mtval` will
 contain the virtual address of the portion of the access that caused the
-fault.
+fault.#
 
-If `mtval` is written with a nonzero value when an instruction
+[#norm:mtval_inst_acc_fault]#If `mtval` is written with a nonzero value when an instruction
 access-fault, page-fault, or hardware-error exception occurs on a hart with
 variable-length instructions, then `mtval` will contain the virtual
 address of the portion of the instruction that caused the fault, while
-`mepc` will point to the beginning of the instruction.
+`mepc` will point to the beginning of the instruction.#
 
 The `mtval` register can optionally also be used to return the faulting
 instruction bits on an illegal-instruction exception (`mepc` points to
-the faulting instruction in memory). If `mtval` is written with a
+the faulting instruction in memory). [#norm:mtval_ill_inst]#If `mtval` is written with a
 nonzero value when an illegal-instruction exception occurs, then `mtval`
 will contain the shortest of:
 
@@ -2086,10 +2086,10 @@ will contain the shortest of:
 
 * the first ILEN bits of the faulting instruction
 
-* the first MXLEN bits of the faulting instruction
+* the first MXLEN bits of the faulting instruction#
 
-The value loaded into `mtval` on an illegal-instruction exception is
-right-justified and all unused upper bits are cleared to zero.
+[#norm:mtval_ill_inst_fmt]#The value loaded into `mtval` on an illegal-instruction exception is
+right-justified and all unused upper bits are cleared to zero.#
 
 [NOTE]
 ====
@@ -2114,46 +2114,46 @@ two cases (or alternatively, the system configuration information can be
 interrogated to install the appropriate trap handling before runtime).
 ====
 
-On a trap caused by a software-check exception, the `mtval` register holds
-the cause for the exception. The following encodings are defined:
+[#norm:mtval_sw_check]#On a trap caused by a software-check exception, the `mtval` register holds
+the cause for the exception.# The following encodings are defined:
 
 * 0 - No information provided.
 * 2 - Landing Pad Fault. Defined by the Zicfilp extension (<<priv-forward>>).
 * 3 - Shadow Stack Fault. Defined by the Zicfiss extension (<<priv-backward>>).
 
-For other traps, `mtval` is set to zero, but a future standard may
-redefine `mtval`’s setting for other traps.
+[#norm:mtval_other_traps]#For other traps, `mtval` is set to zero, but a future standard may
+redefine `mtval`’s setting for other traps.#
 
-If `mtval` is not read-only zero, it is a *WARL* register that must be able to
-hold all valid virtual addresses and the value zero. It need not be
+[#norm:mtval_warl]#If `mtval` is not read-only zero, it is a *WARL* register that must be able to
+hold all valid virtual addresses and the value zero.# [#norm:mtval_inv_addr]#It need not be
 capable of holding all possible invalid addresses. Prior to writing
 `mtval`, implementations may convert an invalid address into some other
-invalid address that `mtval` is capable of holding. If the feature to
+invalid address that `mtval` is capable of holding.# [#norm:mtval_ill_inst_cap]#If the feature to
 return the faulting instruction bits is implemented, `mtval` must also
 be able to hold all values less than 2^__N__^, where
-_N_ is the smaller of MXLEN and ILEN.
+_N_ is the smaller of MXLEN and ILEN.#
 
 ==== Machine Configuration Pointer (`mconfigptr`) Register
 
-The `mconfigptr` register is an MXLEN-bit read-only CSR, formatted as shown in
-<<mconfigptrreg>>, that holds the physical
+[#norm:mconfigptr_def_sz_acc]#The `mconfigptr` register is an MXLEN-bit read-only CSR#, formatted as shown in
+<<mconfigptrreg>>, [#norm:mconfigptr_purpose]#that holds the physical
 address of a configuration data structure. Software can traverse this
 data structure to discover information about the harts, the platform,
-and their configuration.
+and their configuration.#
 
 [[mconfigptrreg]]
 .Machine Configuration Pointer (`mconfigptr`) register.
 include::images/bytefield/mconfigptrreg.edn[]
 
 
-The pointer alignment in bits must be no smaller than MXLEN:
+[#norm:mconfigptr_align]#The pointer alignment in bits must be no smaller than MXLEN:
 i.e., if MXLEN is
 8{times}__n__, then `mconfigptr`[log~2n~-1:0]
-must be zero.
+must be zero.#
 
-The `mconfigptr` register must be implemented, but it may be zero to indicate the
+[#norm:mconfigptr_mandatory]#The `mconfigptr` register must be implemented#, but [#norm:mconfigptr_zero_op]#it may be zero to indicate the
 configuration data structure does not exist or that an alternative
-mechanism must be used to locate it.
+mechanism must be used to locate it.#
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR identifies and tags architectural parameters in the `mtval` (Machine Trap Value) and `mconfigptr` (Machine Configuration Pointer) register sections of `src/machine.adoc` to support the RISC-V Unified Database (UDB) project.

### Methodology
* **Target:** `mtval` (Section 3.1.20) and `mconfigptr` (Section 3.1.22).
* **Standard:** Applied AsciiDoc inline anchors (`[#norm:id]#text#`) following the existing convention used in `mtvec` (e.g., using abbreviations like `_sz_acc`, `_warl`).
* **Source:** Verified against the normative text in the latest Privileged Architecture specification.

### Scope of Changes
**1. mtval (Machine Trap Value)**
* **Definition:** `mtval_def_sz_acc`, `mtval_opt_zero`
* **Trap Behavior:** `mtval_trap_behavior`, `mtval_ebreak`, `mtval_pg_fault`, `mtval_ill_inst`
* **Constraints:** `mtval_warl`, `mtval_inv_addr`

**2. mconfigptr (Machine Configuration Pointer)**
* **Definition:** `mconfigptr_def_sz_acc`, `mconfigptr_purpose`
* **Constraints:** `mconfigptr_align`, `mconfigptr_mandatory`, `mconfigptr_zero_op`