### PR TITLE
Clarify that Zicfiss depends on the Zaamo extension.

### DIFF
--- a/src/unpriv-cfi.adoc
+++ b/src/unpriv-cfi.adoc
@@ -376,7 +376,7 @@ system or the administrator) configuration, could either deny the request or
 deactivate the Zicfiss extension for the application. It is strongly recommended
 that the policy enforces a strict security posture and denies the request.
 
-The Zicfiss extension depends on the Zicsr and Zimop extensions. Furthermore,
+The Zicfiss extension depends on the Zicsr, Zimop and Zaamo extensions. Furthermore,
 if the Zcmop extension is implemented, the Zicfiss extension also provides the
 `C.SSPUSH` and `C.SSPOPCHK` instructions. Moreover, use of Zicfiss in U-mode
 requires S-mode to be implemented. Use of Zicfiss in M-mode is not supported.


### PR DESCRIPTION
Fixes #2596.