### PR TITLE
Clarify fflags field width consistency with fcsrwith fcsr

### DIFF
--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -107,7 +107,7 @@ integer register _rd_, with zero in all other bits. FSRM swaps the value in
 `frm` by copying the original value into integer register _rd_, and then
 writing a new value obtained from the three least-significant bits of integer
 register _rs1_ into `frm`. FRFLAGS and FSFLAGS are defined analogously for the
-Accrued Exception Flags field `fflags` (`fcsr` bits 4--0).The `fflags` and `frm` CSRs are 32-bit wide, consistent with the `fcsr` CSR.
+`fflags` and `frm` are 32-bit read/write CSRs.
 
 
 [[norm:fcsr_rsv]]


### PR DESCRIPTION
This change clarifies the width of the `fflags` and `frm` CSRs by explicitly stating that they are 32-bit wide, consistent with the `fcsr` CSR.

The intent is to remove ambiguity about CSR width while preserving existing behavior, as `fflags` and `frm` are defined as subfields of `fcsr`.

This is a documentation clarification only and does not introduce any functional or behavioral change.
