### PR TITLE
Clarify CSR privilege encoding convention for hypervisor CSRs.

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -28,7 +28,7 @@ The standard RISC-V ISA sets aside a 12-bit encoding space (csr[11:0])
 for up to 4,096 CSRs. By convention, the upper 4 bits of the CSR address
 (csr[11:8]) are used to encode the read and write accessibility of the
 CSRs according to privilege level as shown in <<csrrwpriv>>. [#norm:Zicsr_rw]#The top two bits (csr[11:10]) indicate whether the register is read/write (`00`,`01`, or `10`) or read-only (`11`).#
-[#norm:Zicsr_access]#The next two bits (csr[9:8]) encode the lowest privilege level that can access the CSR.#
+[#norm:Zicsr_access]#The next two bits (csr[9:8]) encode the lowest privilege level that can access the CSR, with the pattern `10` representing hypervisor CSRs.#
 
 [NOTE]
 ====


### PR DESCRIPTION
Fixes #2630.