### PR TITLE
Zicfiss SSE clarifications and corrections

### DIFF
--- a/normative_rule_defs/priv-cfi.yaml
+++ b/normative_rule_defs/priv-cfi.yaml
@@ -30,7 +30,7 @@ normative_rule_definitions:
   - name: Zicfiss_ssp_vs_mode
     tags: ["norm:zicfiss_vs_henvcfg_sse", "norm:zicfiss_ssp_csr"]
   - name: Zicfiss_ssp_vu_mode
-    tags: ["norm:zicfiss_vu_henvcfg_senvcfg_sse", "norm:zicfiss_ssp_csr"]
+    tags: ["norm:zicfiss_vu_senvcfg_sse", "norm:zicfiss_ssp_csr"]
   - name: Zicfiss_ssp_hs_modes
     tags: ["norm:zicfiss_sse_access", "norm:zicfiss_ssp_csr"]
   - name: Zicfiss_smode_xsse

--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -2772,9 +2772,9 @@
     "norm:zicfiss_m_menvcfg_sse": "If the privilege mode is less than M and csr:menvcfg[sse] is 0, an\nillegal-instruction exception is raised.",
     "norm:zicfiss_u_senvcfg_sse": "Otherwise, if in U-mode and csr:senvcfg[sse] is 0, an illegal-instruction\nexception is raised.",
     "norm:zicfiss_vs_henvcfg_sse": "Otherwise, if in VS-mode and csr:henvcfg[sse] is 0, a virtual-instruction\nexception is raised.",
-    "norm:zicfiss_vu_henvcfg_senvcfg_sse": "Otherwise, if in VU-mode and either csr:henvcfg[sse] or csr:senvcfg[sse] is 0,\na virtual-instruction exception is raised.",
+    "norm:zicfiss_vu_senvcfg_sse": "Otherwise, if in VU-mode and csr:senvcfg[sse] is 0,\na virtual-instruction exception is raised.",
     "norm:zicfiss_sse_access": "Otherwise, the access is allowed.",
-    "norm:zicfiss_smode_xsse": "When S-mode is not implemented, then xSSE is 0 at both M and U privilege modes.",
+    "norm:zicfiss_smode_xsse": "When S-mode is not implemented, then xSSE is 0.",
     "norm:ss_page_enc": "The\nencoding R=0, W=1, and X=0, is defined to represent an SS page.",
     "norm:ssmp_menvcfg_sse": "When\ncsr:menvcfg[sse]=0, this encoding remains reserved.",
     "norm:ssmp_henvcfg_sse": "Similarly, when V=1 and\ncsr:henvcfg[sse]=0, this encoding remains reserved at VS and VU levels.",
@@ -12372,7 +12372,7 @@
                           "norm:zicfiss_m_menvcfg_sse",
                           "norm:zicfiss_u_senvcfg_sse",
                           "norm:zicfiss_vs_henvcfg_sse",
-                          "norm:zicfiss_vu_henvcfg_senvcfg_sse",
+                          "norm:zicfiss_vu_envcfg_sse",
                           "norm:zicfiss_sse_access"
                         ]
                       },

--- a/src/priv/cfi.adoc
+++ b/src/priv/cfi.adoc
@@ -138,9 +138,11 @@ csr:envcfg[sse] fields. The conditions are specified as follows:
   exception is raised.#
 * [#norm:zicfiss_vs_henvcfg_sse]#Otherwise, if in VS-mode and csr:henvcfg[sse] is 0, a virtual-instruction
   exception is raised.#
-* [#norm:zicfiss_vu_henvcfg_senvcfg_sse]#Otherwise, if in VU-mode and either csr:henvcfg[sse] or csr:senvcfg[sse] is 0,
+* [#norm:zicfiss_vu_senvcfg_sse]#Otherwise, if in VU-mode and csr:senvcfg[sse] is 0,
   a virtual-instruction exception is raised.#
 * [#norm:zicfiss_sse_access]#Otherwise, the access is allowed.#
+
+Access to the `ssp` CSR is not contingent on S-mode being implemented.
 
 ===== Shadow-Stack-Enabled (SSE) State
 
@@ -161,7 +163,7 @@ When S-mode is implemented, it is determined as follows:
 |===
 
 [[norm:zicfiss_smode_xsse]]
-When S-mode is not implemented, then `xSSE` is 0 at both M and U privilege modes.
+When S-mode is not implemented, then `xSSE` is 0.
 
 [NOTE]
 ====
@@ -194,7 +196,7 @@ illegal-instruction exception. Execution of programs that use these instructions
 on such machines is not supported.
 
 Activating ext:zicfiss[] in M-mode is currently not supported. Additionally, when
-S-mode is not implemented, activation in U-mode is also not supported. These
+S-mode is not implemented, activation is not supported in any privilege mode. These
 functionalities may be introduced in a future standard extension.
 ====
 

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -828,7 +828,7 @@ apply when `V=1`:
 * 32-bit Zicfiss instructions will revert to their behavior as defined by Zimop.
 * 16-bit Zicfiss instructions will revert to their behavior as defined by Zcmop.
 * The `pte.xwr=010b` encoding in VS-stage page tables becomes reserved.
-* The `senvcfg.SSE` field will read as zero and is read-only.
+* The `senvcfg.SSE` field is read-only zero.
 * When `menvcfg.SSE` is one, `SSAMOSWAP.W/D` raises a virtual-instruction
   exception.
 


### PR DESCRIPTION
1. The spec says when `henvcfg.SSE` is 0 then `senvcfg.SSE` is read-only and reads as 0. However it also says when `menvcfg.SSE` is 0, then `henvcfg.SSE` and `senvcfg.SSE` "are read-only zero". That is both very unclear (does it actually change their underlying values?) and inconsistent with `henvcfg.SSE`'s behaviour. I suspect it was a mistake. This changes them both to be "read-only and read as 0".

2. The `ssp` CSR access conditions redundently say either `henvcfg.SSE=0` OR `senvcfg.SSE=0` raise an exception in VU mode. This is redundant becahse `henvcfg.SSE=0` causes `senvcfg.SSE` to read as 0 (see above), so you only need to check `senvcfg.SSE`. Simplifying this case also makes the link between this check and xSSE slightly clearer.

3. Execution of the Zicfiss instructions (including SSAMOSWAP) depends on S-mode being implemented, but access to the CSR doesn't. That isn't very obvious so I made this explicit.

4. The "When S-mode is not implemented then `xSSE` is 0 at both M and U privilege modes." sentence doesn't make any mention of VS or VU modes. I assume they were added later and this sentence was overlooked. In any case `xSSE` is simply 0 in all modes if S-mode is not implemented so it's clearer to say that. Same for the change in the NOTE.

I think the behaviour of `SSE` is still not described clearly (I would expect many implementation bugs here!) but I believe this at least makes it consistent. For reference I believe the simplest description of the behaviour would be this mostly valid Sail:

```
// "Raw" value of xenvcfg.SSE according to the current privilege.
// This is not the same as xSSE from the ISA manual becuase it is 1 for
// machine mode and it is not 0 if supervisor is not implemented.
function zicfiss_xSSE_raw(priv : Privilege) -> bool =
  bool_bits(match priv {
    Machine           => 0b1
    Supervisor        => menvcfg[SSE],
    VirtualSupervisor => read_henvcfg()[SSE], // The `read_` takes care of the "reads as 0".
    User              => read_senvcfg()[SSE],
    VirtualUser       => read_senvcfg()[SSE],
  })

// xSSE from the ISA manual. 0 in machine mode or if S-mode is not implemented.
function zicfiss_xSSE(priv : Privilege) -> bool =
  priv != Machine & extensionEnabled(Ext_S) & zicfiss_xSSE_raw()

// Return true if we should raise a virtual instruction exception instead
// of an illegal instruction.
function zicfiss_exception_is_virtual(priv : Privilege) -> bool =
  menvcfg[SSE] == 0b1 & (priv == VirtualSupervisor | priv == VirtualUser)

function access_ssp(priv : Privilege) = {
    if not(zicfiss_xSSE_raw(priv))
    then return (if zicfiss_exception_is_virtual(priv) then Virtual_Instruction else Illegal_Instruction);
    // ... ok
}

function execute_sspush() = {
    if not(zicfiss_xSSE(cur_privilege)) then return RETIRE_SUCCESS;

    // ... normal execution
}

function execute_ssamoswap() = {
    if not(zicfiss_xSSE(priv))
    then return (if zicfiss_exception_is_virtual(priv) then Virtual_Instruction else Illegal_Instruction);

    // ... normal execuion
}
```