### PR TITLE
Mention where `mvip` is defined.

### DIFF
--- a/src/smcdeleg.adoc
+++ b/src/smcdeleg.adoc
@@ -132,7 +132,7 @@ and `hvien` is implemented and writable.
 
 [NOTE]
 ====
-_The `hvip` register is defined by the hypervisor (H) extension, while the `mvien` and `hvien` registers are defined by the Smaia/Ssaia extensions._
+_The `hvip` register is defined by the hypervisor (H) extension, while the `mvip`, `mvien` and `hvien` registers are defined by the Smaia/Ssaia extensions._
 
 _By virtue of implementing `hvip`.LCOFI, it is implicit that the LCOFI bit (bit 13) in each of `vsie` and `vsip` is also implemented._
 


### PR DESCRIPTION
`mvip` was left out in the registers mentioned as coming from the AIA spec.