### PR TITLE
Fix broken character in RVC quadrant diagrams

### DIFF
--- a/src/images/bytefield/rvc-instr-quad0.edn
+++ b/src/images/bytefield/rvc-instr-quad0.edn
@@ -1,6 +1,7 @@
 [bytefield]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(defattrs :math [:math {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )
 (def row-header-fn nil)
 (def left-margin 0)

--- a/src/images/bytefield/rvc-instr-quad1.edn
+++ b/src/images/bytefield/rvc-instr-quad1.edn
@@ -1,6 +1,7 @@
 [bytefield]
 ----
 (defattrs :plain [:plain {:font-weight "bold" :font-family "M+ 1p Fallback"}])
+(defattrs :math [:math {:font-family "M+ 1p Fallback"}])
 (def row-height 50 )
 (def row-header-fn nil)
 (def left-margin 0)

--- a/src/images/bytefield/rvc-instr-quad2.edn
+++ b/src/images/bytefield/rvc-instr-quad2.edn
@@ -1,6 +1,7 @@
 [bytefield]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(defattrs :math [:math {:font-family "M+ 1p Fallback"}])
 (def row-height 50 )
 (def row-header-fn nil)
 (def left-margin 0)


### PR DESCRIPTION
The C.NOP (HINT, imm≠0) not-equal symbol was not being rendered correctly since asciidoctor-pdf falls back to only CP1252 characters if no explicit font is set and we end up with a logic not glyph (¬). See https://docs.asciidoctor.org/pdf-converter/latest/theme/font-support/

Explicitly set the font family for the :math attributes to fix this.

Found by building with asciidoctor-pdf with --verbose.