### PR TITLE
Missed two minor fixes in PR 2674 (norm rule changes for Parameters SIG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-sail
 
 .PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub build-tags docker-pull-latest submodule-check
-.PHONY: build-norm-rules build-norm-rules-json build-norm-rules-html check-tags update-ref-tags
+.PHONY: build-norm-rules build-norm-rules-json build-norm-rules-html check-tags update-ref
 
 all: build
 
@@ -149,6 +149,8 @@ build-tags: $(DOCS_NORM_TAGS)
 check-tags:
 	@bash ./scripts/check-tag-changes.sh
 
+# Copy built normative tags JSON files to ref directory and use sed to ensure they end with a newline.
+# Required by GitHub pre-commit checks for this repo.
 update-ref: $(DOCS_NORM_TAGS)
 	cp -f $(DOCS_NORM_TAGS) ref
 	sed -i -e '$$a\' ref/*.json

--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1401,7 +1401,7 @@ normative_rule_definitions:
     tag: "norm:uncached_ignores_cached"
 
   # Physical Memory Protection (PMP)
-  - name: PMP_GRANULARITY_PARAM
+  - name: PMP_GRANULARITY
     summary: Minimum PMP region granularity supported by the platform
     tags: ["norm:pmp_granularity"]
     impl-def-behavior: true


### PR DESCRIPTION
Fixes found by Copilot review - Remove _PARAM in norm rule name and fix .PHONY in Makefile for update-refs target

Fixes issue #2679 