### PR TITLE
Use new update-ref Makefile target instead of manual commands

### DIFF
--- a/.github/scripts/comment-pr-changes.js
+++ b/.github/scripts/comment-pr-changes.js
@@ -23,10 +23,8 @@ ${tagChanges || 'No detailed changes available.'}
 
 **How to update reference files (if needed):**
 \`\`\`bash
-make build-tags
-cp build/riscv-unprivileged-norm-tags.json ref/
-cp build/riscv-privileged-norm-tags.json ref/
-git add ref/
+make update-ref
+git add ref/*.json
 git commit -m "Update normative tag reference files"
 \`\`\`
 


### PR DESCRIPTION
Fixes #2681 

Original:

```
How to update reference files (if needed):

make build-tags
cp build/riscv-unprivileged-norm-tags.json ref/
cp build/riscv-privileged-norm-tags.json ref/
git add ref/
git commit -m "Update normative tag reference files"
```

Updated using new makefile target:

```
How to update reference files (if needed):

make update-ref
git add ref/*.json
git commit -m "Update normative tag reference files"
```