### PR TITLE
Renamed SATP_ASIDLEN to ASIDLEN to match ISA manual and removed bogus norm rule for hypervisor related to this.

### DIFF
--- a/normative_rule_defs/hypervisor.yaml
+++ b/normative_rule_defs/hypervisor.yaml
@@ -274,8 +274,6 @@ normative_rule_definitions:
     tags: ["norm:vsatp_sz_acc_op", "norm:satp-ppn_sv32_sz"]
   - name: vsatp-ppn_sv39_sv48_sv57_sz
     tags: ["norm:vsatp_sz_acc_op", "norm:satp-ppn_sv39_sz", "norm:satp-ppn_sv48_sz", "norm:satp-ppn_sv57_sz"]
-  - name: vsatp-asidlen
-    tags: ["norm:vsatp_sz_acc_op", "norm:satp_asidlen"]
   - name: vsatp_mode_unsupported_v0
     tags: ["norm:vsatp_mode_unsupported_v0"]
   - name: VSATP_MODE_UNSUPPORTED_V0_WARL

--- a/normative_rule_defs/supervisor.yaml
+++ b/normative_rule_defs/supervisor.yaml
@@ -216,9 +216,9 @@ normative_rule_definitions:
     tags: ["norm:satp-mode_sxlen64"]
   - name: satp-mode_op_unsupported
     tags: ["norm:satp-mode_op_unsupported"]
-  - name: SATP_ASIDLEN
+  - name: ASIDLEN
     impl-def-behavior: true
-    tags: ["norm:satp_asidlen"]
+    tags: ["norm:asidlen"]
   - name: satp_op_active
     tags: ["norm:satp_op_active"]
   - name: satp_op_sfence-vma

--- a/ref/riscv-privileged-norm-tags.json
+++ b/ref/riscv-privileged-norm-tags.json
@@ -924,7 +924,7 @@
     "norm:satp-mode_sxlen32": "When SXLEN=32, the only other valid setting for MODE is Sv32, a paged virtual-memory scheme described in .",
     "norm:satp-mode_sxlen64": "When SXLEN=64, three paged virtual-memory schemes are defined: Sv39, Sv48, and Sv57, described in , , and , respectively. One additional scheme, Sv64, will be defined in a later version of this specification. The remaining MODE settings are reserved for future use and may define different interpretations of the other fields in satp.",
     "norm:satp-mode_op_unsupported": "Implementations are not required to support all MODE settings, and if satp is written with an unsupported MODE, the entire write has no effect; no fields in satp are modified.",
-    "norm:satp_asidlen": "The number of ASID bits is UNSPECIFIED and may be zero. The number of implemented ASID bits, termed ASIDLEN, may be determined by writing one to every bit position in the ASID field, then reading back the value in satp to see which bit positions in the ASID field hold a one. The least-significant bits of ASID are implemented first: that is, if ASIDLEN &gt; 0, ASID[ASIDLEN-1:0] is writable. The maximal value of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for Sv39, Sv48, and Sv57.",
+    "norm:asidlen": "The number of ASID bits is UNSPECIFIED and may be zero. The number of implemented ASID bits, termed ASIDLEN, may be determined by writing one to every bit position in the ASID field, then reading back the value in satp to see which bit positions in the ASID field hold a one. The least-significant bits of ASID are implemented first: that is, if ASIDLEN &gt; 0, ASID[ASIDLEN-1:0] is writable. The maximal value of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for Sv39, Sv48, and Sv57.",
     "norm:satp_op_active": "The satp CSR is considered active when the effective privilege mode is S-mode or U-mode. Executions of the address-translation algorithm may only begin using a given value of satp when satp is active.",
     "norm:satp_op_sfence-vma": "Note that writing satp does not imply any ordering constraints between page-table updates and subsequent address translations, nor does it imply any invalidation of address-translation caches. If the new address space’s page tables have been modified, or if an ASID is reused, it may be necessary to execute an SFENCE.VMA instruction (see ) after, or in some cases before, writing satp.",
     "norm:stimecmp-stimecmph_sz_acc": "The stimecmp CSR is a 64-bit register and\nhas 64-bit precision on all RV32 and RV64 systems.\nIn RV32 only, accesses to the stimecmp CSR access the low 32 bits,\nwhile accesses to the stimecmph CSR access the high 32 bits of stimecmp.",
@@ -3318,7 +3318,7 @@
                   "norm:satp-mode_sxlen32",
                   "norm:satp-mode_sxlen64",
                   "norm:satp-mode_op_unsupported",
-                  "norm:satp_asidlen",
+                  "norm:asidlen",
                   "norm:satp_op_active",
                   "norm:satp_op_sfence-vma"
                 ]

--- a/src/supervisor.adoc
+++ b/src/supervisor.adoc
@@ -1049,7 +1049,7 @@ Implementations are not required to support all MODE settings, and if
 `satp` is written with an unsupported MODE, the entire write has no
 effect; no fields in `satp` are modified.
 
-[[norm:satp_asidlen]]
+[[norm:asidlen]]
 The number of ASID bits is UNSPECIFIED and may be zero. The number of implemented
 ASID bits, termed _ASIDLEN_, may be determined by writing one to every
 bit position in the ASID field, then reading back the value in `satp` to


### PR DESCRIPTION
Simple change.