### PR TITLE
docs: Add Zihpm extension to colophon

### DIFF
--- a/src/colophon.adoc
+++ b/src/colophon.adoc
@@ -24,6 +24,7 @@ h|Extension h|Version h|Status
 |*Zifencei* |*2.0* |*Ratified*
 |*Zicsr* |*2.0* |*Ratified*
 |*Zicntr* |*2.0* |*Ratified*
+|*Zihpm* | *2.0* | *Ratified*
 |*Zihintntl* |*1.0* |*Ratified*
 |*Zihintpause* |*2.0* |*Ratified*
 |*Zimop* | *1.0* | *Ratified*


### PR DESCRIPTION
This PR adds the missing Zihpm extension (Version 2.0, Ratified) to the colophon, right below Zicntr.

Fixes #2691