### PR TITLE
Add some missed Sdtrig CSRs to the currently allocated CSR list.

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -1003,8 +1003,12 @@ Upper 32 bits of `mhpmevent31`, RV32 only.
 `0x7A1`  +
 `0x7A2`  +
 `0x7A3` +
+`0x7A4` +
+`0x7A5` +
 `0x7A8`
 |MRW +
+MRW +
+MRW +
 MRW +
 MRW +
 MRW +
@@ -1013,12 +1017,16 @@ MRW
 `tdata1` +
 `tdata2` +
 `tdata3` +
+`tinfo`  +
+`tcontrol` +
 `mcontext`
 
 |Debug/Trace trigger register select. +
 First Debug/Trace trigger data register. +
 Second Debug/Trace trigger data register. +
 Third Debug/Trace trigger data register. +
+Trigger info register. +
+Trigger control register. +
 Machine-mode context register.
 
 4+^|Debug Mode Registers


### PR DESCRIPTION
Add `tinfo` and `tcontrol`.