### PR TITLE
Improves notes about vmslt{u}.vi and vmsge{u}.vi.

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2810,7 +2810,7 @@ when the high bit of the `simm5` immediate is set, `vmsleu.vi` and
 `2^SEW^-16` to `2^SEW^-1`, allowing corresponding `vmsltu.vi` and
 `vmsgeu.vi` compares against unsigned immediates in the range `2^SEW^-15`
 to `2^SEW^`. Note that `vmsltu.vi` and `vmsgeu.vi` with immediate
-`2^SEW^` is not useful as it is always true/false.
+`2^SEW^` is not useful as it is always true or false, respectively.
 
 NOTE: The `vmsgt` forms for register scalar and immediates are provided
 to allow a single compare instruction to provide the correct


### PR DESCRIPTION
Put the vmsge{u}.vi text immediately after vmslt{u}.vi and make it a NOTE. They describe a very similar idea. Maybe they should be a single note? I think it was one note in an earlier version of the V spec.

Add vmsgtu.vi to the note about vmsleu.vi allowing compares with immediates in the range 2^SEW-16 to 2^SEW-1.