### PR TITLE
ci: harden Actions workflows and restore 'Normative Rule Changes Detected' PR comment

### DIFF
--- a/.github/workflows/check-normative-tags-comment.yml
+++ b/.github/workflows/check-normative-tags-comment.yml
@@ -1,0 +1,195 @@
+---
+# ============================================================================
+# Workflow: Check Normative Tag Changes (Comment)
+# ----------------------------------------------------------------------------
+# Purpose:
+#   Post or update the "Normative Rule Changes Detected" comment on a pull
+#   request after the read-only `check-normative-tags-pr.yml` workflow
+#   completes. The comment summarises the diff between the PR's built
+#   normative tags and the committed reference files under ref/, so that
+#   reviewers can quickly tell whether a PR (intentionally or not) adds,
+#   modifies, or deletes normatively tagged text.
+#
+# Why this is a separate workflow:
+#   The companion `check-normative-tags-pr.yml` workflow runs on the
+#   `pull_request` event and is intentionally read-only: PR code is
+#   untrusted (anyone, including fork authors, can modify `make build-tags`
+#   or any script it calls), so we must never give that workflow write
+#   access to the repository, issues, or pull requests.
+#
+#   This workflow instead runs on `workflow_run: completed`, which is
+#   triggered *after* the PR workflow finishes. Crucially, `workflow_run`
+#   always executes the copy of the workflow file that is committed on the
+#   default branch and runs under the base repository's permissions —
+#   never the PR's code. This lets us safely grant `pull-requests: write`
+#   here without exposing it to arbitrary PR input.
+#
+#   This split is the pattern explicitly recommended by GitHub Security Lab
+#   for commenting on PRs from forks. See:
+#   https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Inputs (from the triggering workflow's artifact):
+#   Artifact name: `normative-tag-change-report`
+#     - tag_changes.txt : the rendered Markdown report body.
+#     - pr_number.txt   : the PR number this report belongs to. This is
+#                         required because `workflow_run.pull_requests` is
+#                         empty for PRs opened from forks, so we cannot
+#                         derive the PR number from the event payload.
+#
+# Expected results:
+#   - When the PR workflow reports no changes: this workflow exits early
+#     and does nothing (no comment is created or updated).
+#   - When the PR workflow reports additions/modifications/deletions: a
+#     single bot comment titled "Normative Rule Changes Detected" is
+#     created on the PR, or the existing one is updated in place (see
+#     the de-duplication logic in `.github/scripts/comment-pr-changes.js`).
+#   - If the PR workflow itself failed to produce an artifact (e.g. build
+#     error), this workflow exits cleanly without posting, so reviewers
+#     are not spammed with half-formed reports.
+# ============================================================================
+
+name: Check Normative Tag Changes (Comment)
+
+on:
+  workflow_run:
+    # Must match the `name:` of check-normative-tags-pr.yml exactly.
+    workflows: ["Check Normative Tag Changes (PR)"]
+    types:
+      - completed
+
+# Least-privilege permissions. `pull-requests: write` is what lets us post
+# the comment; `actions: read` is needed to list/download artifacts from
+# the triggering workflow run.
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    # Only act on successful PR workflow runs that actually originated
+    # from a pull_request event. Skipping non-PR triggers (e.g. a manual
+    # re-run of the PR workflow on a branch) avoids spurious comment
+    # attempts.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      # ----------------------------------------------------------------------
+      # Locate the `normative-tag-change-report` artifact produced by the
+      # triggering run. We use the REST API (not actions/download-artifact's
+      # cross-run shortcut) so we can handle the "artifact missing" case
+      # gracefully without failing the whole workflow.
+      # ----------------------------------------------------------------------
+      - name: Download tag change report artifact
+        id: download
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+
+            const match = artifacts.data.artifacts.find(
+              a => a.name === 'normative-tag-change-report'
+            );
+            if (!match) {
+              core.info('No normative-tag-change-report artifact found; nothing to comment.');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            const zip = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: match.id,
+              archive_format: 'zip',
+            });
+
+            fs.writeFileSync('report.zip', Buffer.from(zip.data));
+            core.setOutput('found', 'true');
+
+      # Unzip the downloaded artifact into the workspace so subsequent
+      # steps can read `tag_changes.txt` and `pr_number.txt` as plain files.
+      - name: Extract artifact
+        if: steps.download.outputs.found == 'true'
+        run: unzip -o report.zip
+
+      # ----------------------------------------------------------------------
+      # Read the PR number and the report body, export them to the job's
+      # environment, and decide whether a comment should actually be posted
+      # (i.e. whether the report contains any Added/Modified/Deleted rows).
+      # ----------------------------------------------------------------------
+      - name: Load report into environment
+        id: load
+        if: steps.download.outputs.found == 'true'
+        run: |
+          if [ ! -f pr_number.txt ] || [ ! -f tag_changes.txt ]; then
+            echo "Expected files missing from artifact; skipping."
+            echo "should_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER=$(tr -d '[:space:]' < pr_number.txt)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "pr_number.txt was empty; skipping."
+            echo "should_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          # Only comment when the report actually contains change rows.
+          # This keeps unrelated PRs (that happened to touch src/ but did
+          # not alter any normative tags) from getting noisy bot comments.
+          if grep -qE "(Added|Modified|Deleted) [0-9]+ tag" tag_changes.txt; then
+            echo "should_comment=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_comment=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "TAG_CHANGES<<EOF"
+            cat tag_changes.txt
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      # ----------------------------------------------------------------------
+      # Check out the BASE repo (default branch) to pick up the trusted
+      # copy of `.github/scripts/comment-pr-changes.js`. We deliberately
+      # do NOT check out the PR head: that code is untrusted and would
+      # defeat the purpose of this split-workflow design.
+      # ----------------------------------------------------------------------
+      - name: Checkout base branch scripts
+        if: steps.load.outputs.should_comment == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      # ----------------------------------------------------------------------
+      # Post or update the bot comment on the PR. The existing
+      # comment-pr-changes.js script already handles de-duplication by
+      # searching for a prior bot comment containing "Normative Rule
+      # Changes Detected" and updating it in place, so repeated runs on
+      # the same PR do not create duplicate comments.
+      # ----------------------------------------------------------------------
+      - name: Post or update PR comment
+        if: steps.load.outputs.should_comment == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ steps.load.outputs.pr_number }}
+        with:
+          script: |
+            // `comment-pr-changes.js` reads `context.payload.pull_request.number`
+            // in its normal (pull_request-triggered) usage. When we invoke it
+            // from a `workflow_run` event that field is absent, so we patch
+            // the payload with the PR number we recovered from the artifact.
+            context.payload.pull_request = { number: Number(process.env.PR_NUMBER) };
+
+            const script = require('./.github/scripts/comment-pr-changes.js');
+            const tagChanges = process.env.TAG_CHANGES;
+            await script({ github, context, tagChanges });

--- a/.github/workflows/check-normative-tags-pr.yml
+++ b/.github/workflows/check-normative-tags-pr.yml
@@ -1,0 +1,108 @@
+---
+name: Check Normative Tag Changes (PR)
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'normative_rule_defs/**'
+      - 'ref/**'
+      - 'scripts/check-tag-changes.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  check-tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for bypass label
+        id: bypass
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q "normative-change-approved"; then
+            echo "has_bypass=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Bypass label 'normative-change-approved' found - breaking changes will be reported but not failed."
+          else
+            echo "has_bypass=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build normative tags
+        run: make build-tags
+
+      - name: Check for tag changes
+        id: check
+        run: |
+          set +e
+
+          {
+            echo "## Normative Tag Change Report"
+            echo ""
+          } > tag_changes.txt
+
+          HAS_ANY_CHANGES=false
+          HAS_BREAKING_CHANGES=false
+
+          for spec in unprivileged privileged; do
+            {
+              echo "### ${spec^} Specification"
+              echo ""
+              echo '```'
+            } >> tag_changes.txt
+
+            OUTPUT=$(ruby docs-resources/tools/detect_tag_changes.rb \
+              --verbose \
+              "ref/riscv-$spec-norm-tags.json" \
+              "build/riscv-$spec-norm-tags.json" 2>&1)
+            EXIT_CODE=$?
+
+            {
+              echo "$OUTPUT"
+              echo '```'
+              echo ""
+            } >> tag_changes.txt
+
+            if echo "$OUTPUT" | grep -qE "(Added|Modified|Deleted) [0-9]+ tag"; then
+              HAS_ANY_CHANGES=true
+            fi
+
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              HAS_BREAKING_CHANGES=true
+            fi
+          done
+
+          echo "has_any_changes=$HAS_ANY_CHANGES" >> "$GITHUB_OUTPUT"
+          echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tag change report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: normative-tag-change-report-${{ github.event.pull_request.number }}
+          path: tag_changes.txt
+          retention-days: 7
+
+      - name: Add report to workflow summary
+        if: always()
+        run: cat tag_changes.txt >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on breaking changes (unless bypass label is present)
+        if: steps.check.outputs.has_breaking_changes == 'true' && steps.bypass.outputs.has_bypass != 'true'
+        run: |
+          echo "::error::Breaking normative tag changes detected. Add label 'normative-change-approved' to bypass."
+          exit 1
+
+      - name: Report bypass mode
+        if: steps.check.outputs.has_breaking_changes == 'true' && steps.bypass.outputs.has_bypass == 'true'
+        run: echo "::warning::Breaking normative tag changes detected, but bypass label is present."
+
+      - name: Report normative changes detected
+        if: steps.check.outputs.has_any_changes == 'true'
+        run: echo "::warning::Normative tag changes detected (additions, modifications, or deletions)."

--- a/.github/workflows/check-normative-tags-pr.yml
+++ b/.github/workflows/check-normative-tags-pr.yml
@@ -1,4 +1,44 @@
 ---
+# ============================================================================
+# Workflow: Check Normative Tag Changes (PR)
+# ----------------------------------------------------------------------------
+# Purpose:
+#   Detect additions, modifications, and deletions of normatively tagged text
+#   in pull requests against this repository. Produces a human-readable diff
+#   report comparing the PR's built tags against the committed reference
+#   files under ref/.
+#
+# Security model:
+#   This workflow runs on the `pull_request` event, which means it executes
+#   *untrusted* PR code (anyone can open a PR, including from a fork). For
+#   that reason this workflow is deliberately **read-only**:
+#     - `permissions:` is restricted to `contents: read`.
+#     - It does NOT post PR comments or create issues itself.
+#     - It does NOT have access to repository secrets beyond the default
+#       GITHUB_TOKEN, which from forks is read-only anyway.
+#
+#   The PR comment ("Normative Rule Changes Detected") is posted by a
+#   separate, trusted workflow (`check-normative-tags-comment.yml`) that
+#   runs on the base branch via the `workflow_run` event. That workflow
+#   downloads the artifact uploaded here and posts the comment with
+#   `pull-requests: write` permission. This two-workflow split is the
+#   GitHub-recommended pattern for safely commenting on PRs from forks.
+#   See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Expected results:
+#   - A workflow summary showing any Added / Modified / Deleted tags per
+#     specification (unprivileged, privileged).
+#   - An uploaded artifact named `normative-tag-change-report` containing
+#     `tag_changes.txt` (the report) and `pr_number.txt` (the PR number
+#     this report belongs to — needed by the commenting workflow because
+#     `workflow_run.pull_requests` is empty for fork PRs).
+#   - A check failure if *breaking* changes (modifications or deletions)
+#     are detected, unless the PR carries the label
+#     `normative-change-approved`.
+#   - Shortly after this workflow completes, the companion workflow will
+#     post or update a "Normative Rule Changes Detected" comment on the PR.
+# ============================================================================
+
 name: Check Normative Tag Changes (PR)
 
 on:
@@ -9,6 +49,9 @@ on:
       - 'ref/**'
       - 'scripts/check-tag-changes.sh'
 
+# Read-only by design. All write operations (issue creation, PR comments,
+# reference-file updates) happen in other workflows triggered on trusted
+# events (`push` on main, or `workflow_run` completion).
 permissions:
   contents: read
 
@@ -17,6 +60,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # ----------------------------------------------------------------------
+      # Detect the opt-in bypass label on the PR. Maintainers can add the
+      # `normative-change-approved` label to acknowledge that a breaking
+      # change (modification/deletion of a normative tag) is intentional,
+      # which prevents this workflow from failing the PR.
+      # ----------------------------------------------------------------------
       - name: Check for bypass label
         id: bypass
         run: |
@@ -28,15 +77,29 @@ jobs:
             echo "has_bypass=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # ----------------------------------------------------------------------
+      # Check out the PR head. `persist-credentials: false` ensures the
+      # auth token is not written to the local git config, so a malicious
+      # build step in the PR can't use it to push. Submodules are fetched
+      # because the tag-detection scripts under docs-resources/ are a
+      # submodule.
+      # ----------------------------------------------------------------------
       - name: Checkout PR code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           persist-credentials: false
 
+      # Build the current PR's normative tag JSON files into build/.
       - name: Build normative tags
         run: make build-tags
 
+      # ----------------------------------------------------------------------
+      # Run the tag-change detector for every specification. The detector
+      # exits non-zero when modifications or deletions are found (treated
+      # as breaking), and zero when only additions or no changes exist.
+      # We capture both the report text and the has-any/has-breaking flags.
+      # ----------------------------------------------------------------------
       - name: Check for tag changes
         id: check
         run: |
@@ -81,18 +144,40 @@ jobs:
           echo "has_any_changes=$HAS_ANY_CHANGES" >> "$GITHUB_OUTPUT"
           echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> "$GITHUB_OUTPUT"
 
+      # ----------------------------------------------------------------------
+      # Persist the PR number alongside the report. The companion
+      # `check-normative-tags-comment.yml` workflow runs on `workflow_run`
+      # and cannot rely on `github.event.workflow_run.pull_requests` because
+      # that array is empty for PRs opened from forks. Embedding the PR
+      # number in the artifact is the documented workaround.
+      # ----------------------------------------------------------------------
+      - name: Record PR number for the commenting workflow
+        if: always()
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      # ----------------------------------------------------------------------
+      # Upload BOTH files (report + PR number) under a fixed artifact name.
+      # The commenting workflow looks up artifacts by this exact name, so
+      # it must not include variable data such as the PR number.
+      # ----------------------------------------------------------------------
       - name: Upload tag change report
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: normative-tag-change-report-${{ github.event.pull_request.number }}
-          path: tag_changes.txt
+          name: normative-tag-change-report
+          path: |
+            tag_changes.txt
+            pr_number.txt
           retention-days: 7
 
+      # Mirror the report into the PR's Checks > Summary tab for quick
+      # inspection without downloading the artifact.
       - name: Add report to workflow summary
         if: always()
         run: cat tag_changes.txt >> "$GITHUB_STEP_SUMMARY"
 
+      # Hard-fail the check on breaking changes unless the bypass label
+      # is present. Additions alone never fail the check.
       - name: Fail on breaking changes (unless bypass label is present)
         if: steps.check.outputs.has_breaking_changes == 'true' && steps.bypass.outputs.has_bypass != 'true'
         run: |

--- a/.github/workflows/check-normative-tags.yml
+++ b/.github/workflows/check-normative-tags.yml
@@ -8,13 +8,10 @@ on:
       - 'normative_rule_defs/**'
       - 'ref/**'
       - 'scripts/check-tag-changes.sh'
-  pull_request_target:
-    paths:
-      - 'src/**'
-      - 'normative_rule_defs/**'
-      - 'ref/**'
-      - 'scripts/check-tag-changes.sh'
   workflow_dispatch:  # Allows manual testing from GitHub UI
+
+permissions:
+  contents: read
 
 env:
   # Branches that trigger issue creation on push/merge
@@ -27,27 +24,11 @@ jobs:
     permissions:
       issues: write
       contents: write
-      pull-requests: write
 
     steps:
-      - name: Check for bypass label
-        id: bypass
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          if echo "$LABELS" | grep -q "normative-change-approved"; then
-            echo "has_bypass=true" >> $GITHUB_OUTPUT
-            echo "::notice::Bypass label 'normative-change-approved' found - check will report but not fail"
-          else
-            echo "has_bypass=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Keep push/workflow_dispatch on a branch so later auto-commit can push.
-          # For pull_request_target, analyze the PR head commit contents.
-          ref: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref || github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Build normative tags
@@ -59,8 +40,10 @@ jobs:
         run: |
           set +e  # Don't exit on error, we want to capture the output
 
-          echo "## Normative Tag Change Report" > tag_changes.txt
-          echo "" >> tag_changes.txt
+          {
+            echo "## Normative Tag Change Report"
+            echo ""
+          } > tag_changes.txt
 
           HAS_ANY_CHANGES=false
           HAS_BREAKING_CHANGES=false
@@ -68,19 +51,23 @@ jobs:
           # Iterate through all configured specifications
           SPECS="unprivileged privileged"
           for spec in $SPECS; do
-            echo "### ${spec^} Specification" >> tag_changes.txt
-            echo "" >> tag_changes.txt
-            echo '```' >> tag_changes.txt
+            {
+              echo "### ${spec^} Specification"
+              echo ""
+              echo '```'
+            } >> tag_changes.txt
 
             OUTPUT=$(ruby docs-resources/tools/detect_tag_changes.rb \
               --verbose \
-              ref/riscv-$spec-norm-tags.json \
-              build/riscv-$spec-norm-tags.json 2>&1)
+              "ref/riscv-$spec-norm-tags.json" \
+              "build/riscv-$spec-norm-tags.json" 2>&1)
             EXIT_CODE=$?
 
             echo "$OUTPUT" | tee -a tag_changes.txt
-            echo '```' >> tag_changes.txt
-            echo "" >> tag_changes.txt
+            {
+              echo '```'
+              echo ""
+            } >> tag_changes.txt
 
             # Check if ANY changes were detected (additions, modifications, or deletions)
             if echo "$OUTPUT" | grep -qE "(Added|Modified|Deleted) [0-9]+ tag"; then
@@ -88,18 +75,22 @@ jobs:
             fi
 
             # Check if modifications or deletions were detected (breaking changes)
-            if [ $EXIT_CODE -ne 0 ]; then
+            if [ "$EXIT_CODE" -ne 0 ]; then
               HAS_BREAKING_CHANGES=true
             fi
           done
 
           # Save output for later steps
-          echo "TAG_CHANGES<<EOF" >> $GITHUB_ENV
-          cat tag_changes.txt >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            echo "TAG_CHANGES<<EOF"
+            cat tag_changes.txt
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
-          echo "has_any_changes=$HAS_ANY_CHANGES" >> $GITHUB_OUTPUT
-          echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
+          {
+            echo "has_any_changes=$HAS_ANY_CHANGES"
+            echo "has_breaking_changes=$HAS_BREAKING_CHANGES"
+          } >> "$GITHUB_OUTPUT"
 
           # Exit with failure if breaking changes were detected
           if [ "$HAS_BREAKING_CHANGES" = "true" ]; then
@@ -113,10 +104,10 @@ jobs:
           CURRENT_BRANCH="${GITHUB_REF#refs/heads/}"
           echo "Current branch: $CURRENT_BRANCH"
           if echo "${{ env.ISSUE_TRIGGER_BRANCHES }}" | grep -qE "(^|,)${CURRENT_BRANCH}(,|$)"; then
-            echo "is_trigger_branch=true" >> $GITHUB_OUTPUT
+            echo "is_trigger_branch=true" >> "$GITHUB_OUTPUT"
             echo "Branch '$CURRENT_BRANCH' is configured to trigger issues"
           else
-            echo "is_trigger_branch=false" >> $GITHUB_OUTPUT
+            echo "is_trigger_branch=false" >> "$GITHUB_OUTPUT"
             echo "Branch '$CURRENT_BRANCH' is not configured to trigger issues"
           fi
 
@@ -127,8 +118,8 @@ jobs:
           for spec in unprivileged privileged; do
             ruby docs-resources/tools/detect_tag_changes.rb \
               --update-reference \
-              ref/riscv-$spec-norm-tags.json \
-              build/riscv-$spec-norm-tags.json
+              "ref/riscv-$spec-norm-tags.json" \
+              "build/riscv-$spec-norm-tags.json"
           done
 
       - name: Commit updated reference files
@@ -144,39 +135,15 @@ jobs:
           git commit -m "Auto-update normative tag reference files"
           git push origin "HEAD:${GITHUB_REF#refs/heads/}"
 
-      - name: Comment on PR with detected changes
-        if: >-
-          steps.check.outputs.has_any_changes == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-          steps.bypass.outputs.has_bypass != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const script = require('./.github/scripts/comment-pr-changes.js');
-            const tagChanges = process.env.TAG_CHANGES;
-            await script({github, context, tagChanges});
-
       - name: Create issue on merge to configured branches
         if: >-
           steps.check.outputs.has_any_changes == 'true' &&
           github.event_name == 'push' &&
           steps.branch-check.outputs.is_trigger_branch == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const script = require('./.github/scripts/create-tag-change-issue.js');
-            const tagChanges = process.env.TAG_CHANGES;
-            await script({github, context, tagChanges});
-
-      - name: Report changes (bypass mode)
-        if: >-
-          steps.check.outputs.has_any_changes == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-          steps.bypass.outputs.has_bypass == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const script = require('./.github/scripts/comment-bypass-mode.js');
             const tagChanges = process.env.TAG_CHANGES;
             await script({github, context, tagChanges});
 
@@ -184,4 +151,4 @@ jobs:
         if: steps.check.outputs.has_any_changes == 'true'
         run: |
           echo "::warning::Normative tag changes detected (additions, modifications, or deletions)."
-          echo "::notice::Review the PR comments or created issue for details."
+          echo "::notice::Review the created issue for details when this runs on configured push branches."

--- a/.github/workflows/check-ready-to-merge.yml
+++ b/.github/workflows/check-ready-to-merge.yml
@@ -11,6 +11,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+
 jobs:
   fail-by-label:
     if: contains(github.event.pull_request.labels.*.name, 'Pending Ratification')

--- a/.github/workflows/clarification.yml
+++ b/.github/workflows/clarification.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   label_issue:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
     if: startsWith(github.event.comment.body, '/clarification')
     steps:
       - name: Add Clarification Label
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -22,6 +22,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,27 +32,27 @@ jobs:
     steps:
     # Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
 
     # Set the short SHA for use in artifact names
       - name: Set short SHA
-        run: echo "SHORT_SHA=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
     # Get the current date
       - name: Get current date
-        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
     # Build PDF and HTML ISA manual versions and normative rule files using the container
       - name: Build Files
         id: build_files
-        run: make -j$(nproc)
+        run: make -j"$(nproc)"
 
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -58,7 +61,7 @@ jobs:
     # Upload the riscv-privileged HTML file
       - name: Upload riscv-privileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -67,7 +70,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
       - name: Upload riscv-privileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -76,7 +79,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
       - name: Upload riscv-unprivileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -85,7 +88,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
       - name: Upload riscv-unprivileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -94,7 +97,7 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
       - name: Upload riscv-unprivileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-unprivileged.epub
@@ -103,7 +106,7 @@ jobs:
     # Upload norm-rules.html
       - name: Upload norm-rules.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: norm-rules-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/norm-rules.html
@@ -112,7 +115,7 @@ jobs:
     # Upload norm-rules.json
       - name: Upload norm-rules.json
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: norm-rules-${{ env.SHORT_SHA }}.json
           path: ${{ github.workspace }}/build/norm-rules.json
@@ -120,7 +123,6 @@ jobs:
 
       - name: Create Release
         if: steps.build_files.outcome == 'success' && github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true'
-        #uses: softprops/action-gh-release@v2.2.2
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           draft: false
@@ -157,7 +159,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: dist
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -180,4 +182,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -9,12 +9,15 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   on-success:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
 
@@ -22,19 +25,19 @@ jobs:
           echo The PR was successfully merged.
 
       - name: Set short SHA
-        run: echo "SHORT_SHA=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Get current date
-        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
       - name: Build Files
         id: build_files
-        run: make -j$(nproc) RELEASE_TYPE=intermediate
+        run: make -j"$(nproc)" RELEASE_TYPE=intermediate
 
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -42,7 +45,7 @@ jobs:
     # Upload the riscv-privileged HTML file
       - name: Upload riscv-privileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -50,7 +53,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
       - name: Upload riscv-privileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -58,7 +61,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
       - name: Upload riscv-unprivileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -66,7 +69,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
       - name: Upload riscv-unprivileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -74,13 +77,13 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
       - name: Upload riscv-unprivileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-unprivileged.epub
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,10 +6,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-      - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Summary

This PR does two things:

### 1. Security hardening (original scope)
- Remove `pull_request_target` from normative tag checks.
- Split normative checks into two workflows:
  - untrusted PR workflow (`check-normative-tags-pr.yml`) with read-only token and no write operations.
  - trusted push/workflow_dispatch workflow (`check-normative-tags.yml`) for reference updates and issue creation.
- Add workflow-level least-privilege defaults (`permissions: contents: read`) and keep write scopes only where required.
- Pin all third-party GitHub Actions to immutable commit SHAs.
- Fix shellcheck/actionlint workflow script warnings.

### 2. Restore "Normative Rule Changes Detected" PR comment (follow-up)
Removing `pull_request_target` also removed the auto-posted PR comment. Restoring it via the GitHub-recommended `workflow_run` split so we can comment on PRs — **including fork PRs** — without ever running untrusted code with write permissions.

- **`check-normative-tags-pr.yml`** — also writes `pr_number.txt` next to `tag_changes.txt` and uploads both under the fixed artifact name `normative-tag-change-report`. The PR number must live in the artifact because `workflow_run.pull_requests` is empty for fork PRs.
- **`check-normative-tags-comment.yml`** (new) — runs on `workflow_run: completed`, executes only base-branch code, downloads the artifact, and posts/updates the PR comment through the existing `.github/scripts/comment-pr-changes.js` (which already de-dupes so re-runs update in place).

Addresses @jordancarlin's ask in #2958 (comment).

## Security model

| Workflow | Trigger | Permissions | Runs PR code? |
|---|---|---|---|
| `check-normative-tags-pr.yml` | `pull_request` | `contents: read` | Yes (untrusted, no write access) |
| `check-normative-tags-comment.yml` | `workflow_run` | `pull-requests: write`, `actions: read`, `contents: read` | No (base-branch copy only) |
| `check-normative-tags.yml` | `push` on main | `issues: write`, `contents: write` | No (trusted branch) |

Pattern reference: [GitHub Security Lab — Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

## Expected behaviour after merge
- Normative tag changes on a PR → bot comment appears within seconds of the PR check finishing (same for same-repo and fork PRs).
- No normative tag changes → no comment (grep gate).
- Failed PR check → no comment (conclusion guard).
- Subsequent pushes to the same PR → existing bot comment updated in place.

## Security issues addressed
- Mitigates pwn-request class risk from privileged execution of untrusted PR code.
- Reduces token blast radius via least-privilege permissions.
- Reduces third-party action supply-chain risk via SHA pinning.

## Validation
- `actionlint .github/workflows/*.yml` passes cleanly.
- No remaining `pull_request_target` references in workflows.
- No unpinned `uses:` entries remain in workflows.

## Test plan (after merge)
- [ ] Open a throwaway PR that adds a new `[#...,norm=...]` tag → expect a bot comment with "Added N tag(s)".
- [ ] Open a throwaway PR that modifies an existing tagged block → expect PR check failure and a bot comment with "Modified N tag(s)".
- [ ] Add label `normative-change-approved` → expect PR check to pass with a warning; comment still posted.
- [ ] Open a PR that edits `src/` without touching any normative tag → expect no bot comment.
- [ ] Push a second commit to a PR that already has a bot comment → expect the comment to be updated in place (not duplicated).
- [ ] Open a PR from a fork that modifies a normative tag → expect the bot comment to appear (main reason for the `workflow_run` split).