### PR TITLE
Allow ELEN>VLEN in Vector extension 

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4908,8 +4908,8 @@ e q r d c b v a    # v11 destination after vrgather using viota.m under mask
 [#norm:vmv-nr-r_op]#The `vmv<nr>r.v` instructions copy whole vector registers (i.e., all
 VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
-copy.  The instructions operate as if EEW=min(VLEN, SEW), EMUL = NREG, and effective
-length `evl`= EMUL * VLEN/EEW.#
+copy.  The instructions operate as if EEW = min(VLEN, SEW), EMUL = NREG, and effective
+length `evl` = EMUL * VLEN/EEW.#
 
 NOTE: These instructions are intended to aid compilers to shuffle
 vector registers without needing to know or change `vl`.

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -3930,9 +3930,9 @@ destination format is converted to the destination format's largest finite value
 === Vector Reduction Operations
 
 [#norm:vreduction_scalar_def]#Vector reduction operations take a vector register group of elements
-and a scalar held in element 0 of a vector register (or a vector register group), and perform a
+and a scalar held in element 0 of a vector register group, and perform a
 reduction using some binary operator, to produce a scalar result in
-element 0 of a vector register (or a vector register group).#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
+element 0 of a vector register group.#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
 are held in element 0 of a group with EMUL=ceil(EEW/VLEN) regardless of LMUL setting.#
 
 NOTE: The previous edition specified use of a single vector register (EMUL=1). EMUL = ceil(EEW/VLEN) allows for a case

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -27,9 +27,16 @@ Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
 
 NOTE: Future extensions may allow ELEN {gt} VLEN by holding one
-element using bits from multiple vector registers. In this case ELEN/VLEN
-ratio, the number of vector registers required to hold one ELEN-sized
-element, becomes greater than 1.
+element using bits from multiple vector registers. The formulas in this
+specification have been updated to allow this. The changes only
+affect ELEN {gt} VLEN cases, when ELEN {le} VLEN nothing is changed.
+E.g.: EMUL for "scalar in vector" inputs/outputs of reductions is now
+defined as ceil(EEW/VLEN), so it is still 1 (specifying a single register,
+as before) when EEW {le} VLEN. Element width for whole vector register
+moves and loads is now defined as min(VLEN, EEW), giving unchanged
+EEW when EEW {le} VLEN. Therefore, nothing is changed for all standard
+extensions defined in this specification, all of which require
+ELEN {le} VLEN.
 
 NOTE: The upper limit on VLEN allows software to know that indices
 will fit into 16 bits (largest VLMAX of 65,536 occurs for LMUL=8 and
@@ -316,11 +323,6 @@ consider the use of this case to be __reserved__.
 
 NOTE: It is recommended that assemblers provide a warning (not an
 error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
-
-NOTE: The above formulas have been updated to use min(ELEN, VLEN)
-instead of ELEN in the previous edition of the specification, to allow
-future vector extensions to have ELEN > VLEN. For extensions where ELEN {le} VLEN,
-min(ELEN,VLEN) = ELEN and so all formulas and rules remain unchanged.
 
 [[norm:lmul]]
 LMUL is set by the signed `vlmul` field in `vtype` (i.e., LMUL =
@@ -3936,9 +3938,6 @@ reduction using some binary operator, to produce a scalar result in
 element 0 of a vector register group.#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
 are held in element 0 of a group with EMUL=ceil(EEW/VLEN) regardless of LMUL setting.#
 
-NOTE: The previous edition specified use of a single vector register (EMUL=1). EMUL = ceil(EEW/VLEN) allows for a case
-of EEW/VLEN > 1. If EEW < VLEN, ceil(EEW/VLEN) = 1, resulting in EMUL=1, a single vector, as before.
-
 [#norm:vreduction_vd_overlap_vs]#The destination vector register can overlap the source operands,
 including the mask register.#
 
@@ -4536,10 +4535,6 @@ The integer scalar read/write instructions transfer a single
 value between a scalar `x` register and element 0 of a vector
 register group with EMUL = ceil(EEW/VLEN).  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
 
-NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups.
-The change to EMUL = ceil(EEW/VLEN) allows for the case of EEW > VLEN. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
-
-
 ----
 vmv.x.s rd, vs2  # x[rd] = vs2[0] (vs1=0)
 vmv.s.x vd, rs1  # vd[0] = x[rs1] (vs2=0)
@@ -4572,9 +4567,6 @@ and `vmv.s.x` are reserved.#
 The floating-point scalar read/write instructions transfer a single
 value between a scalar `f` register and element 0 of a vector
 register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
-
-NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups.
-The change to EMUL=ceil(EEW/VLEN) allows for the case of EEW/VLEN > 1. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
 
 ----
 vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -21,14 +21,15 @@ Each hart supporting a vector extension defines two parameters:
 
 . [#norm:elen]#The maximum size in bits of a vector element that any operation can produce or consume, _ELEN_ {ge} 8, which
 must be a power of 2.#
-. [#norm:vlen]#The number of bits in a single vector register, _VLEN_ {ge} ELEN, which must be a power of 2, and must be no greater than 2^16^.#
+. [#norm:vlen]#The number of bits in a single vector register, _VLEN_, which must be a power of 2, and must be no greater than 2^16^.#
 
 Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
 
 NOTE: Future extensions may allow ELEN {gt} VLEN by holding one
-element using bits from multiple vector registers, but this
-extension does not include this option.
+element using bits from multiple vector registers. In this case ELEN/VLEN 
+ratio, the number of vector registers required to hold one ELEN-sized 
+element, becomes greater than 1. 
 
 NOTE: The upper limit on VLEN allows software to know that indices
 will fit into 16 bits (largest VLMAX of 65,536 occurs for LMUL=8 and
@@ -280,15 +281,19 @@ register-resident vectors.
 Implementations must provide fractional LMUL settings that allow the
 narrowest supported type to occupy a fraction of a vector register
 corresponding to the ratio of the narrowest supported type's width to
-that of the largest supported type's width.  In general, the
-requirement is to support LMUL {ge} SEW~MIN~/ELEN, where SEW~MIN~ is
-the narrowest supported SEW value and ELEN is the widest supported SEW
-value.  In the standard extensions, SEW~MIN~=8.  For
+that of the largest supported type's width or to the vector register length, 
+if the latter is smaller than the largest supported type (ELEN/VLEN > 1).  
+In general, the requirement is to support LMUL {ge} SEW~MIN~/min(ELEN, VLEN), 
+where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest 
+supported SEW value and VLEN is the number of bits in a vector register.  
+In the standard extensions, SEW~MIN~=8.  For
 standard vector extensions with ELEN=32, fractional LMULs of 1/2 and
-1/4 must be supported.  For standard vector extensions with ELEN=64,
+1/4 must be supported.  For standard vector extensions with ELEN=64 and ELEN/VLEN {le} 1,
 fractional LMULs of 1/2, 1/4, and 1/8 must be supported.
+For a vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4 
+must be supported.
 
-NOTE: When LMUL < SEW~MIN~/ELEN, there is no guarantee
+NOTE: When LMUL < SEW~MIN~/min(ELEN, VLEN), there is no guarantee
 an implementation would have enough bits in the fractional vector
 register to store at least one element, as VLEN=ELEN is a
 valid implementation choice. For example, with VLEN=ELEN=32,
@@ -297,20 +302,25 @@ storage in a vector register.
 
 [[norm:vtype_sew_val]]
 For a given supported fractional LMUL setting, implementations must support
-SEW settings between SEW~MIN~ and LMUL * ELEN, inclusive.
+SEW settings between SEW~MIN~ and LMUL * min(ELEN, VLEN), inclusive. 
 
 [[norm:vtype_lmul_fval_rsv]]
-The use of `vtype` encodings with LMUL < SEW~MIN~/ELEN is
+The use of `vtype` encodings with LMUL < SEW~MIN~/min(ELEN, VLEN) is
 __reserved__, but implementations can set `vill` if they do not
 support these configurations.
 
 NOTE: Requiring all implementations to set `vill` in this case would
 prohibit future use of this case in an extension, so to allow for a
-future definition of LMUL<SEW~MIN~/ELEN behavior, we
+future definition of LMUL<SEW~MIN~/min(ELEN, VLEN) behavior, we
 consider the use of this case to be __reserved__.
 
 NOTE: It is recommended that assemblers provide a warning (not an
-error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/ELEN.
+error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
+
+NOTE: The above formula have been updated to use min(ELEN, VLEN) 
+instead of ELEN in the previous edition of the specification, to allow 
+future vector extensions to have ELEN > VLEN. For extensions where ELEN {le} VLEN, 
+min(ELEN,VLEN) = ELEN and so all formula and rules remain unchanged.
 
 [[norm:lmul]]
 LMUL is set by the signed `vlmul` field in `vtype` (i.e., LMUL =
@@ -776,6 +786,12 @@ lowest-numbered vector register and moving to the
 next-highest-numbered vector register in the group once each vector
 register is filled.
 
+If a vector extension supports EEW/VLEN > 1, one element can span multiple 
+vector registers and to have EEW bits to hold one element the requirement is that 
+the LMUL {ge} EEW/VLEN. In this case 
+each element occupies multiple consecutive vector registers, the least 
+significant bits of each element go to the lower-numbered vector register.
+
 ----
  LMUL > 1 examples
 
@@ -834,6 +850,14 @@ register is filled.
  v4*n+1              7       6       5       4
  v4*n+2              B       A       9       8
  v4*n+3              F       E       D       C
+
+ VLEN=32b, SEW=64b, LMUL=4
+
+ Byte         3 2 1 0
+ v4*n               0
+ v4*n+1             
+ v4*n+2             1
+ v4*n+3             
 ----
 
 [[sec-mapping-mixed]]
@@ -1033,6 +1057,8 @@ LMUL=8 is reserved as this would imply a result EMUL=16.
 Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
+If a vector extension supports EEW/VLEN > 1, EEW-wide widened scalar 
+values are held in a vector register group with EMUL = EEW/VLEN
 
 ==== Vector Masking
 
@@ -2079,6 +2105,12 @@ Hence, it would have sufficed to provide only EEW=8 variants.
 The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
+
+In vector extensions supporting ELEN/VLEN {gt} 1 element size can exceed 
+the number of bits available in a vector register or a vector register 
+group. In that case whole vector register load and store instructions 
+still operate on the specified number of vector register(s), using the 
+least significant bits of the element.
 
 The vector whole register store instructions are encoded similar to
 unmasked unit-stride store of elements with EEW=8.
@@ -3898,12 +3930,13 @@ destination format is converted to the destination format's largest finite value
 === Vector Reduction Operations
 
 [#norm:vreduction_scalar_def]#Vector reduction operations take a vector register group of elements
-and a scalar held in element 0 of a vector register, and perform a
+and a scalar held in element 0 of a vector register (or a vector register group), and perform a
 reduction using some binary operator, to produce a scalar result in
-element 0 of a vector register.#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
-are held in element 0 of a single vector register, not a vector
-register group, so any vector register can be the scalar source or
-destination of a vector reduction regardless of LMUL setting.#
+element 0 of a vector register (or a vector register group).#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
+are held in element 0 of a group with EMUL=ceil(EEW/VLEN) regardless of LMUL setting.#
+
+NOTE: The previous edition specified use of a single vector register (EMUL=1). EMUL = ceil(EEW/VLEN) allows for a case 
+of EEW/VLEN > 1. If EEW < VLEN, ceil(EEW/VLEN) = 1, resulting in EMUL=1, a single vector, as before.
 
 [#norm:vreduction_vd_overlap_vs]#The destination vector register can overlap the source operands,
 including the mask register.#
@@ -4500,7 +4533,11 @@ around within the vector registers.
 
 The integer scalar read/write instructions transfer a single
 value between a scalar `x` register and element 0 of a vector
-register.  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL and vector register groups.#
+register group with EMUL = ceil(EEW/VLEN).  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
+
+NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups. 
+The change to EMUL = ceil(EEW/VLEN) allows for the case of EEW > VLEN. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
+
 
 ----
 vmv.x.s rd, vs2  # x[rd] = vs2[0] (vs1=0)
@@ -4515,7 +4552,8 @@ ignored.  If SEW < XLEN, the value is sign-extended to XLEN bits.#
 NOTE: [#norm:vmv-x-s_vstartgevl_vl0]#`vmv.x.s` performs its operation even if `vstart` {ge} `vl` or `vl`=0.#
 
 [#norm:vmv-s-x_op]#The `vmv.s.x` instruction copies the scalar integer register to element 0 of
-the destination vector register.  If SEW < XLEN, the least-significant bits
+the destination vector register group with EMUL = ceil(EEW/VLEN)). 
+If SEW < XLEN, the least-significant bits
 are copied and the upper XLEN-SEW bits are ignored.  If SEW > XLEN, the value
 is sign-extended to SEW bits.  The other elements in the destination vector
 register ( 0 < index < VLEN/SEW) are treated as tail elements using the current tail agnostic/undisturbed policy.#  [#norm:vmv-s-x_vstart_ge_vl]#If `vstart` {ge} `vl`, no
@@ -4530,9 +4568,12 @@ and `vmv.s.x` are reserved.#
 [[sec-vector-float-move]]
 ==== Floating-Point Scalar Move Instructions
 
-The floating-point scalar read/write instructions transfer a single
-value between a scalar `f` register and element 0 of a vector
-register.  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]#The instructions ignore LMUL and vector register groups.#
+The floating-point scalar read/write instructions transfer a single 
+value between a scalar `f` register and element 0 of avector
+register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
+
+NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups. 
+The change to EMUL=ceil(EEW/VLEN) allows for the case of EEW/VLEN > 1. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
 
 ----
 vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)
@@ -4877,6 +4918,10 @@ VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
 copy.  The instructions operate as if EEW=SEW, EMUL = NREG, effective
 length `evl`= EMUL * VLEN/SEW.#
+
+If a vector extension supports SEW/VLEN > 1, the calculated `evl` can be fractional, less than 1.
+In this case the instruction shall still copy EMUL = NREG vector registers, transferring the LSBs of the element.
+The fractional `evl` is still valid for the purposes of checking for `vstart` {ge} `evl`.
 
 NOTE: These instructions are intended to aid compilers to shuffle
 vector registers without needing to know or change `vl`.

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4569,7 +4569,7 @@ and `vmv.s.x` are reserved.#
 ==== Floating-Point Scalar Move Instructions
 
 The floating-point scalar read/write instructions transfer a single
-value between a scalar `f` register and element 0 of avector
+value between a scalar `f` register and element 0 of a vector
 register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
 
 NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups.

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -783,10 +783,10 @@ next-highest-numbered vector register in the group once each vector
 register is filled.
 
 If a vector extension supports EEW > VLEN, one element can span multiple
-vector registers and to have EEW bits to hold one element the requirement is that
-the LMUL {ge} EEW/VLEN. In this case
-each element occupies multiple consecutive vector registers, the least
-significant bits of each element go to the lower-numbered vector register.
+vector registers, in which case the least-significant bits of the element
+are held in the lowest-numbered vector register.
+Instructions that access vector register groups with EMUL < EEW/VLEN are
+reserved.
 
 ----
  LMUL > 1 examples

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2095,8 +2095,9 @@ handlers, and OS context switches.  Software can determine the number
 of bytes transferred by reading the `vlenb` register.
 
 [[norm:vector_ls_seg_wholereg_eew]]
-The load instructions have an EEW encoded in the `mew` and `width`
+The load instructions have the element width encoded in the `mew` and `width`
 fields following the pattern of regular unit-stride loads.
+EEW is computed as EEW=min(VLEN, EEW_encoded).
 
 NOTE: Because in-register byte layouts are identical to in-memory byte
 layouts, the same data is written to the destination register group
@@ -4916,12 +4917,8 @@ e q r d c b v a    # v11 destination after vrgather using viota.m under mask
 [#norm:vmv-nr-r_op]#The `vmv<nr>r.v` instructions copy whole vector registers (i.e., all
 VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
-copy.  The instructions operate as if EEW=SEW, EMUL = NREG, effective
-length `evl`= EMUL * VLEN/SEW.#
-
-If a vector extension supports SEW/VLEN > 1, the calculated `evl` can be fractional, less than 1.
-In this case the instruction shall still copy EMUL = NREG vector registers, transferring the LSBs of the element.
-The fractional `evl` is still valid for the purposes of checking for `vstart` {ge} `evl`.
+copy.  The instructions operate as if EEW=min(VLEN, SEW), EMUL = NREG, effective
+length `evl`= EMUL * VLEN/EEW.#
 
 NOTE: These instructions are intended to aid compilers to shuffle
 vector registers without needing to know or change `vl`.

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -1645,7 +1645,7 @@ vse64.v   vs3, (rs1), vm  #   64-bit unit-stride store
 Additional unit-stride mask load and store instructions are
 provided to transfer mask values to/from memory.  These
 operate similarly to unmasked byte loads or stores (EEW=8), except that
-the effective vector length is ``evl``=ceil(``vl``/8) (i.e. EMUL=1),
+the effective vector length is ``evl`` = ceil(``vl``/8) (i.e. EMUL=1),
 and the destination register is always written with a tail-agnostic
 policy.
 
@@ -3935,7 +3935,7 @@ destination format is converted to the destination format's largest finite value
 and a scalar held in element 0 of a vector register group, and perform a
 reduction using some binary operator, to produce a scalar result in
 element 0 of a vector register group.#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
-are held in element 0 of a group with EMUL=ceil(EEW/VLEN), regardless of LMUL setting.#
+are held in element 0 of a group with EMUL = ceil(EEW/VLEN), regardless of LMUL setting.#
 
 [#norm:vreduction_vd_overlap_vs]#The destination vector register can overlap the source operands,
 including the mask register.#
@@ -4565,7 +4565,7 @@ and `vmv.s.x` are reserved.#
 
 The floating-point scalar read/write instructions transfer a single
 value between a scalar `f` register and element 0 of a vector
-register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
+register group with EMUL = ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
 
 ----
 vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -26,17 +26,12 @@ must be a power of 2.#
 Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
 
-NOTE: Future extensions may allow ELEN > VLEN by holding one
-element using bits from multiple vector registers. The formulas in this
-specification have been updated to allow this. The changes only
-affect ELEN > VLEN cases, when ELEN {le} VLEN nothing is changed.
-E.g.: EMUL for "scalar in vector" inputs/outputs of reductions is now
-defined as ceil(EEW/VLEN), so it is still 1 (specifying a single register,
-as before) when EEW {le} VLEN. Element width for whole vector register
-moves and loads is now defined as min(VLEN, EEW), giving unchanged
-EEW when EEW {le} VLEN. Therefore, nothing is changed for all standard
-extensions defined in this specification, all of which require
-ELEN {le} VLEN.
+NOTE: Following the ratification of the V extension, this specification
+has been revised to admit the possibility of future extensions that
+allow ELEN > VLEN, wherein one element is held using bits from
+multiple vector registers.
+These relaxations have no impact on implementations with ELEN {le}
+VLEN or on existing software that assumes ELEN {le} VLEN.
 
 NOTE: The upper limit on VLEN allows software to know that indices
 will fit into 16 bits (largest VLMAX of 65,536 occurs for LMUL=8 and

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -317,10 +317,10 @@ consider the use of this case to be __reserved__.
 NOTE: It is recommended that assemblers provide a warning (not an
 error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
 
-NOTE: The above formula have been updated to use min(ELEN, VLEN) 
+NOTE: The above formulas have been updated to use min(ELEN, VLEN) 
 instead of ELEN in the previous edition of the specification, to allow 
 future vector extensions to have ELEN > VLEN. For extensions where ELEN {le} VLEN, 
-min(ELEN,VLEN) = ELEN and so all formula and rules remain unchanged.
+min(ELEN,VLEN) = ELEN and so all formulas and rules remain unchanged.
 
 [[norm:lmul]]
 LMUL is set by the signed `vlmul` field in `vtype` (i.e., LMUL =

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -21,15 +21,15 @@ Each hart supporting a vector extension defines two parameters:
 
 . [#norm:elen]#The maximum size in bits of a vector element that any operation can produce or consume, _ELEN_ {ge} 8, which
 must be a power of 2.#
-. [#norm:vlen]#The number of bits in a single vector register, _VLEN_, which must be a power of 2, and must be no greater than 2^16^.#
+. [#norm:vlen]#The number of bits in a single vector register, _VLEN_ {ge} 8, which must be a power of 2, and must be no greater than 2^16^.#
 
 Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
 
-NOTE: Future extensions may allow ELEN {gt} VLEN by holding one
+NOTE: Future extensions may allow ELEN > VLEN by holding one
 element using bits from multiple vector registers. The formulas in this
 specification have been updated to allow this. The changes only
-affect ELEN {gt} VLEN cases, when ELEN {le} VLEN nothing is changed.
+affect ELEN > VLEN cases, when ELEN {le} VLEN nothing is changed.
 E.g.: EMUL for "scalar in vector" inputs/outputs of reductions is now
 defined as ceil(EEW/VLEN), so it is still 1 (specifying a single register,
 as before) when EEW {le} VLEN. Element width for whole vector register
@@ -288,8 +288,7 @@ register-resident vectors.
 Implementations must provide fractional LMUL settings that allow the
 narrowest supported type to occupy a fraction of a vector register
 corresponding to the ratio of the narrowest supported type's width to
-that of the largest supported type's width or to the vector register length,
-if the latter is smaller than the largest supported type (ELEN/VLEN > 1).
+the smaller of VLEN and the largest supported type's width.
 In general, the requirement is to support LMUL {ge} SEW~MIN~/min(ELEN, VLEN),
 where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest
 supported SEW value and VLEN is the number of bits in a vector register.
@@ -1060,7 +1059,7 @@ Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
 If a vector extension supports EEW/VLEN > 1, EEW-wide widened scalar
-values are held in a vector register group with EMUL = EEW/VLEN
+values are held in a vector register group with EMUL = EEW/VLEN.
 
 ==== Vector Masking
 
@@ -2109,11 +2108,11 @@ The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
 
-In vector extensions supporting ELEN/VLEN {gt} 1, element size can exceed
+In vector extensions supporting ELEN/VLEN > 1, element size can exceed
 the number of bits available in a vector register or a vector register
-group. In that case whole vector register load instructions
+group. In that case, the whole vector register load instructions
 still operate on the specified number of vector register(s), using the
-least significant bits of the element.
+least-significant bits of the element.
 
 The vector whole register store instructions are encoded similar to
 unmasked unit-stride store of elements with EEW=8.
@@ -3936,7 +3935,7 @@ destination format is converted to the destination format's largest finite value
 and a scalar held in element 0 of a vector register group, and perform a
 reduction using some binary operator, to produce a scalar result in
 element 0 of a vector register group.#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
-are held in element 0 of a group with EMUL=ceil(EEW/VLEN) regardless of LMUL setting.#
+are held in element 0 of a group with EMUL=ceil(EEW/VLEN), regardless of LMUL setting.#
 
 [#norm:vreduction_vd_overlap_vs]#The destination vector register can overlap the source operands,
 including the mask register.#
@@ -4566,7 +4565,7 @@ and `vmv.s.x` are reserved.#
 
 The floating-point scalar read/write instructions transfer a single
 value between a scalar `f` register and element 0 of a vector
-register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
+register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
 
 ----
 vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)
@@ -4909,7 +4908,7 @@ e q r d c b v a    # v11 destination after vrgather using viota.m under mask
 [#norm:vmv-nr-r_op]#The `vmv<nr>r.v` instructions copy whole vector registers (i.e., all
 VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
-copy.  The instructions operate as if EEW=min(VLEN, SEW), EMUL = NREG, effective
+copy.  The instructions operate as if EEW=min(VLEN, SEW), EMUL = NREG, and effective
 length `evl`= EMUL * VLEN/EEW.#
 
 NOTE: These instructions are intended to aid compilers to shuffle

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -27,9 +27,9 @@ Standard vector extensions (<<sec-vector-extensions>>) and
 architecture profiles may set further constraints on _ELEN_ and _VLEN_.
 
 NOTE: Future extensions may allow ELEN {gt} VLEN by holding one
-element using bits from multiple vector registers. In this case ELEN/VLEN 
-ratio, the number of vector registers required to hold one ELEN-sized 
-element, becomes greater than 1. 
+element using bits from multiple vector registers. In this case ELEN/VLEN
+ratio, the number of vector registers required to hold one ELEN-sized
+element, becomes greater than 1.
 
 NOTE: The upper limit on VLEN allows software to know that indices
 will fit into 16 bits (largest VLMAX of 65,536 occurs for LMUL=8 and
@@ -281,16 +281,16 @@ register-resident vectors.
 Implementations must provide fractional LMUL settings that allow the
 narrowest supported type to occupy a fraction of a vector register
 corresponding to the ratio of the narrowest supported type's width to
-that of the largest supported type's width or to the vector register length, 
-if the latter is smaller than the largest supported type (ELEN/VLEN > 1).  
-In general, the requirement is to support LMUL {ge} SEW~MIN~/min(ELEN, VLEN), 
-where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest 
-supported SEW value and VLEN is the number of bits in a vector register.  
+that of the largest supported type's width or to the vector register length,
+if the latter is smaller than the largest supported type (ELEN/VLEN > 1).
+In general, the requirement is to support LMUL {ge} SEW~MIN~/min(ELEN, VLEN),
+where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest
+supported SEW value and VLEN is the number of bits in a vector register.
 In the standard extensions, SEW~MIN~=8.  For
 standard vector extensions with ELEN=32, fractional LMULs of 1/2 and
 1/4 must be supported.  For standard vector extensions with ELEN=64 and ELEN/VLEN {le} 1,
 fractional LMULs of 1/2, 1/4, and 1/8 must be supported.
-For a vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4 
+For a vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4
 must be supported.
 
 NOTE: When LMUL < SEW~MIN~/min(ELEN, VLEN), there is no guarantee
@@ -302,7 +302,7 @@ storage in a vector register.
 
 [[norm:vtype_sew_val]]
 For a given supported fractional LMUL setting, implementations must support
-SEW settings between SEW~MIN~ and LMUL * min(ELEN, VLEN), inclusive. 
+SEW settings between SEW~MIN~ and LMUL * min(ELEN, VLEN), inclusive.
 
 [[norm:vtype_lmul_fval_rsv]]
 The use of `vtype` encodings with LMUL < SEW~MIN~/min(ELEN, VLEN) is
@@ -317,9 +317,9 @@ consider the use of this case to be __reserved__.
 NOTE: It is recommended that assemblers provide a warning (not an
 error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
 
-NOTE: The above formulas have been updated to use min(ELEN, VLEN) 
-instead of ELEN in the previous edition of the specification, to allow 
-future vector extensions to have ELEN > VLEN. For extensions where ELEN {le} VLEN, 
+NOTE: The above formulas have been updated to use min(ELEN, VLEN)
+instead of ELEN in the previous edition of the specification, to allow
+future vector extensions to have ELEN > VLEN. For extensions where ELEN {le} VLEN,
 min(ELEN,VLEN) = ELEN and so all formulas and rules remain unchanged.
 
 [[norm:lmul]]
@@ -786,10 +786,10 @@ lowest-numbered vector register and moving to the
 next-highest-numbered vector register in the group once each vector
 register is filled.
 
-If a vector extension supports EEW/VLEN > 1, one element can span multiple 
-vector registers and to have EEW bits to hold one element the requirement is that 
-the LMUL {ge} EEW/VLEN. In this case 
-each element occupies multiple consecutive vector registers, the least 
+If a vector extension supports EEW/VLEN > 1, one element can span multiple
+vector registers and to have EEW bits to hold one element the requirement is that
+the LMUL {ge} EEW/VLEN. In this case
+each element occupies multiple consecutive vector registers, the least
 significant bits of each element go to the lower-numbered vector register.
 
 ----
@@ -855,9 +855,9 @@ significant bits of each element go to the lower-numbered vector register.
 
  Byte         3 2 1 0
  v4*n               0
- v4*n+1             
+ v4*n+1
  v4*n+2             1
- v4*n+3             
+ v4*n+3
 ----
 
 [[sec-mapping-mixed]]
@@ -1057,7 +1057,7 @@ LMUL=8 is reserved as this would imply a result EMUL=16.
 Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
-If a vector extension supports EEW/VLEN > 1, EEW-wide widened scalar 
+If a vector extension supports EEW/VLEN > 1, EEW-wide widened scalar
 values are held in a vector register group with EMUL = EEW/VLEN
 
 ==== Vector Masking
@@ -2106,10 +2106,10 @@ The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
 
-In vector extensions supporting ELEN/VLEN {gt} 1 element size can exceed 
-the number of bits available in a vector register or a vector register 
-group. In that case whole vector register load and store instructions 
-still operate on the specified number of vector register(s), using the 
+In vector extensions supporting ELEN/VLEN {gt} 1 element size can exceed
+the number of bits available in a vector register or a vector register
+group. In that case whole vector register load and store instructions
+still operate on the specified number of vector register(s), using the
 least significant bits of the element.
 
 The vector whole register store instructions are encoded similar to
@@ -3935,7 +3935,7 @@ reduction using some binary operator, to produce a scalar result in
 element 0 of a vector register (or a vector register group).#  [#norm:vreduction_scalar_disregard_LMUL]#The scalar input and output operands
 are held in element 0 of a group with EMUL=ceil(EEW/VLEN) regardless of LMUL setting.#
 
-NOTE: The previous edition specified use of a single vector register (EMUL=1). EMUL = ceil(EEW/VLEN) allows for a case 
+NOTE: The previous edition specified use of a single vector register (EMUL=1). EMUL = ceil(EEW/VLEN) allows for a case
 of EEW/VLEN > 1. If EEW < VLEN, ceil(EEW/VLEN) = 1, resulting in EMUL=1, a single vector, as before.
 
 [#norm:vreduction_vd_overlap_vs]#The destination vector register can overlap the source operands,
@@ -4535,7 +4535,7 @@ The integer scalar read/write instructions transfer a single
 value between a scalar `x` register and element 0 of a vector
 register group with EMUL = ceil(EEW/VLEN).  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
 
-NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups. 
+NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups.
 The change to EMUL = ceil(EEW/VLEN) allows for the case of EEW > VLEN. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
 
 
@@ -4552,7 +4552,7 @@ ignored.  If SEW < XLEN, the value is sign-extended to XLEN bits.#
 NOTE: [#norm:vmv-x-s_vstartgevl_vl0]#`vmv.x.s` performs its operation even if `vstart` {ge} `vl` or `vl`=0.#
 
 [#norm:vmv-s-x_op]#The `vmv.s.x` instruction copies the scalar integer register to element 0 of
-the destination vector register group with EMUL = ceil(EEW/VLEN)). 
+the destination vector register group with EMUL = ceil(EEW/VLEN)).
 If SEW < XLEN, the least-significant bits
 are copied and the upper XLEN-SEW bits are ignored.  If SEW > XLEN, the value
 is sign-extended to SEW bits.  The other elements in the destination vector
@@ -4568,11 +4568,11 @@ and `vmv.s.x` are reserved.#
 [[sec-vector-float-move]]
 ==== Floating-Point Scalar Move Instructions
 
-The floating-point scalar read/write instructions transfer a single 
+The floating-point scalar read/write instructions transfer a single
 value between a scalar `f` register and element 0 of avector
 register group with EMUL=ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
 
-NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups. 
+NOTE: The previous edition specified that these instructions ignore LMUL and vector register groups.
 The change to EMUL=ceil(EEW/VLEN) allows for the case of EEW/VLEN > 1. If EEW {le} VLEN, EMUL = ceil(EEW/VLEN) = 1, as before.
 
 ----

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2108,7 +2108,7 @@ with this EEW, which aids implementations that rearrange data internally.
 
 In vector extensions supporting ELEN/VLEN {gt} 1, element size can exceed
 the number of bits available in a vector register or a vector register
-group. In that case whole vector register load and store instructions
+group. In that case whole vector register load instructions
 still operate on the specified number of vector register(s), using the
 least significant bits of the element.
 

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2106,7 +2106,7 @@ The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
 
-In vector extensions supporting ELEN/VLEN {gt} 1 element size can exceed
+In vector extensions supporting ELEN/VLEN {gt} 1, element size can exceed
 the number of bits available in a vector register or a vector register
 group. In that case whole vector register load and store instructions
 still operate on the specified number of vector register(s), using the

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -30,8 +30,8 @@ NOTE: Following the ratification of the V extension, this specification
 has been revised to admit the possibility of future extensions that
 allow ELEN > VLEN, wherein one element is held using bits from
 multiple vector registers.
-These relaxations have no impact on implementations with ELEN {le}
-VLEN or on existing software that assumes ELEN {le} VLEN.
+These relaxations have no impact on implementations or software using
+the ratified vector extensions, which require ELEN {le} VLEN.
 
 NOTE: The upper limit on VLEN allows software to know that indices
 will fit into 16 bits (largest VLMAX of 65,536 occurs for LMUL=8 and
@@ -288,11 +288,11 @@ In general, the requirement is to support LMUL {ge} SEW~MIN~/min(ELEN, VLEN),
 where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest
 supported SEW value and VLEN is the number of bits in a vector register.
 In the standard extensions, SEW~MIN~=8.  For
-standard vector extensions with ELEN=32, fractional LMULs of 1/2 and
-1/4 must be supported.  For standard vector extensions with ELEN=64 and ELEN {le} VLEN,
+vector extensions with ELEN=32, fractional LMULs of 1/2 and
+1/4 must be supported.  For vector extensions with ELEN=64 and ELEN {le} VLEN,
 fractional LMULs of 1/2, 1/4, and 1/8 must be supported.
-For a vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4
-must be supported.
+For vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs
+of 1/2 and 1/4 must be supported.
 
 NOTE: When LMUL < SEW~MIN~/min(ELEN, VLEN), there is no guarantee
 an implementation would have enough bits in the fractional vector
@@ -782,7 +782,7 @@ lowest-numbered vector register and moving to the
 next-highest-numbered vector register in the group once each vector
 register is filled.
 
-If a vector extension supports EEW > VLEN, one element can span multiple
+If an implementation supports EEW > VLEN, one element can span multiple
 vector registers, in which case the least-significant bits of the element
 are held in the lowest-numbered vector register.
 Instructions that access vector register groups with EMUL < EEW/VLEN are
@@ -1053,7 +1053,7 @@ LMUL=8 is reserved as this would imply a result EMUL=16.
 Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
-If a vector extension supports EEW > VLEN, EEW-wide widened scalar
+If an implementation supports EEW > VLEN, EEW-wide widened scalar
 values are held in a vector register group with EMUL = EEW/VLEN.
 
 ==== Vector Masking
@@ -2093,7 +2093,7 @@ of bytes transferred by reading the `vlenb` register.
 [[norm:vector_ls_seg_wholereg_eew]]
 The load instructions have the element width encoded in the `mew` and `width`
 fields following the pattern of regular unit-stride loads.
-EEW is computed as EEW=min(VLEN, EEW_encoded).
+EEW is computed as EEW=min(VLEN*NFIELDS, EEW_encoded).
 
 NOTE: Because in-register byte layouts are identical to in-memory byte
 layouts, the same data is written to the destination register group
@@ -2102,12 +2102,6 @@ Hence, it would have sufficed to provide only EEW=8 variants.
 The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
-
-In vector extensions supporting ELEN > VLEN, element size can exceed
-the number of bits available in a vector register or a vector register
-group. In that case, the whole vector register load instructions
-still operate on the specified number of vector register(s), using the
-least-significant bits of the element.
 
 The vector whole register store instructions are encoded similar to
 unmasked unit-stride store of elements with EEW=8.
@@ -4903,7 +4897,7 @@ e q r d c b v a    # v11 destination after vrgather using viota.m under mask
 [#norm:vmv-nr-r_op]#The `vmv<nr>r.v` instructions copy whole vector registers (i.e., all
 VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
-copy.  The instructions operate as if EEW = min(VLEN, SEW), EMUL = NREG, and effective
+copy.  The instructions operate as if EMUL = NREG, EEW = min(VLEN*EMUL, SEW), and effective
 length `evl` = EMUL * VLEN/EEW.#
 
 NOTE: These instructions are intended to aid compilers to shuffle

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -294,7 +294,7 @@ where SEW~MIN~ is the narrowest supported SEW value, ELEN is the widest
 supported SEW value and VLEN is the number of bits in a vector register.
 In the standard extensions, SEW~MIN~=8.  For
 standard vector extensions with ELEN=32, fractional LMULs of 1/2 and
-1/4 must be supported.  For standard vector extensions with ELEN=64 and ELEN/VLEN {le} 1,
+1/4 must be supported.  For standard vector extensions with ELEN=64 and ELEN {le} VLEN,
 fractional LMULs of 1/2, 1/4, and 1/8 must be supported.
 For a vector extensions with SEW~MIN~=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4
 must be supported.
@@ -787,7 +787,7 @@ lowest-numbered vector register and moving to the
 next-highest-numbered vector register in the group once each vector
 register is filled.
 
-If a vector extension supports EEW/VLEN > 1, one element can span multiple
+If a vector extension supports EEW > VLEN, one element can span multiple
 vector registers and to have EEW bits to hold one element the requirement is that
 the LMUL {ge} EEW/VLEN. In this case
 each element occupies multiple consecutive vector registers, the least
@@ -1058,7 +1058,7 @@ LMUL=8 is reserved as this would imply a result EMUL=16.
 Widened scalar values, e.g., input and output to a widening reduction
 operation, are held in the first element of a vector register and
 have EMUL=1.
-If a vector extension supports EEW/VLEN > 1, EEW-wide widened scalar
+If a vector extension supports EEW > VLEN, EEW-wide widened scalar
 values are held in a vector register group with EMUL = EEW/VLEN.
 
 ==== Vector Masking
@@ -2108,7 +2108,7 @@ The full set of EEW variants is provided so that the encoded EEW can be used
 as a hint to indicate the destination register group will next be accessed
 with this EEW, which aids implementations that rearrange data internally.
 
-In vector extensions supporting ELEN/VLEN > 1, element size can exceed
+In vector extensions supporting ELEN > VLEN, element size can exceed
 the number of bits available in a vector register or a vector register
 group. In that case, the whole vector register load instructions
 still operate on the specified number of vector register(s), using the

--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -4521,7 +4521,7 @@ around within the vector registers.
 
 The integer scalar read/write instructions transfer a single
 value between a scalar `x` register and element 0 of a vector
-register group with EMUL = ceil(EEW/VLEN).  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL, EMUL is computed as ceil(EEW/VLEN).#
+register group with EMUL = ceil(EEW/VLEN).  [#norm:vmv-x-s_vmv-s-x_ignoreLMUL]#The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
 
 ----
 vmv.x.s rd, vs2  # x[rd] = vs2[0] (vs1=0)
@@ -4536,7 +4536,7 @@ ignored.  If SEW < XLEN, the value is sign-extended to XLEN bits.#
 NOTE: [#norm:vmv-x-s_vstartgevl_vl0]#`vmv.x.s` performs its operation even if `vstart` {ge} `vl` or `vl`=0.#
 
 [#norm:vmv-s-x_op]#The `vmv.s.x` instruction copies the scalar integer register to element 0 of
-the destination vector register group with EMUL = ceil(EEW/VLEN)).
+the destination vector register group with EMUL = ceil(EEW/VLEN).
 If SEW < XLEN, the least-significant bits
 are copied and the upper XLEN-SEW bits are ignored.  If SEW > XLEN, the value
 is sign-extended to SEW bits.  The other elements in the destination vector


### PR DESCRIPTION
Change/amend wording and formulas in Vector extension to allow ELEN>VLEN configurations, along the lines agreed upon in Vector SIG. To allow e.g. ELEN=64, VLEN=32 extensions.