### PR TITLE
Add Zicond to Zkt section

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -4039,6 +4039,20 @@ encoding forms of these instructions.
 |          | {check} | sraw  _rd_, _rs1_, _rs2_
 |===
 
+===== Zicond (Conditional Zero)
+
+All instructions are included.
+
+[%header,cols="^1,^1,4"]
+|===
+|RV32
+|RV64
+|Mnemonic
+
+| {check} | {check} | czero.eqz _rd_, _rs1_, _rs2_
+| {check} | {check} | czero.nez _rd_, _rs1_, _rs2_
+|===
+
 ===== RVM (Multiply)
 
 Multiplication is included; division and remaindering excluded.


### PR DESCRIPTION
The Zicond text already says the instructions are in Zkt, but we neglected to add them to the Zkt list.