### PR TITLE
Unbreak bullet-list formatting that was broken by normative rules.

### DIFF
--- a/src/smcdeleg.adoc
+++ b/src/smcdeleg.adoc
@@ -79,10 +79,10 @@ While the privilege mode is M or S and `siselect` holds a value in the
 range 0x40-0x5F, illegal-instruction exceptions are raised for the
 following cases:
 
-[#norm:ssccfg_illegal_sireg_cde0]#* attempts to access any `sireg*` when `menvcfg`.CDE = 0;#
-[#norm:ssccfg_illegal_sireg3_6]#* attempts to access `sireg3` or `sireg6`;#
-[#norm:ssccfg_illegal_sireg4_5_xlen64]#* attempts to access `sireg4` or `sireg5` when XLEN = 64;#
-[#norm:ssccfg_illegal_sireg_not_delegated]#* attempts to access `sireg*` when `siselect` = 0x41, or when the counter
+* [#norm:ssccfg_illegal_sireg_cde0]#attempts to access any `sireg*` when `menvcfg`.CDE = 0;#
+* [#norm:ssccfg_illegal_sireg3_6]#attempts to access `sireg3` or `sireg6`;#
+* [#norm:ssccfg_illegal_sireg4_5_xlen64]#attempts to access `sireg4` or `sireg5` when XLEN = 64;#
+* [#norm:ssccfg_illegal_sireg_not_delegated]#attempts to access `sireg*` when `siselect` = 0x41, or when the counter
 selected by `siselect` is not delegated to S-mode (the corresponding bit
 in `mcounteren` = 0).#
 
@@ -100,7 +100,8 @@ by extensions Smcsrind/Sscsrind, a virtual-instruction  exception is
 raised for attempts from VS-mode or VU-mode to directly access `vsiselect`
 or `vsireg*`, or attempts from VU-mode to access `siselect` or `sireg*`. Furthermore, while `vsiselect` holds a value in the range 0x40-0x5F:
 
-[#norm:ssccfg_hyp_m_s_vsireg_illegal]#* An attempt to access any `vsireg*` from M or S mode raises an illegal-instruction exception.# [#norm:ssccfg_hyp_vs_access_sireg_conditional]#* An attempt from VS-mode to access any `sireg*` (really `vsireg*`) raises an illegal-instruction exception if `menvcfg`.CDE = 0, or a virtual-instruction exception if `menvcfg`.CDE = 1.#
+* [#norm:ssccfg_hyp_m_s_vsireg_illegal]#An attempt to access any `vsireg*` from M or S mode raises an illegal-instruction exception.#
+* [#norm:ssccfg_hyp_vs_access_sireg_conditional]#An attempt from VS-mode to access any `sireg*` (really `vsireg*`) raises an illegal-instruction exception if `menvcfg`.CDE = 0, or a virtual-instruction exception if `menvcfg`.CDE = 1.#
 
 === Supervisor Counter Inhibit (`scountinhibit`) Register
 


### PR DESCRIPTION
This got broken in #2571.