### PR TITLE
Add funct6 to vmv<nr>r in Zvbb/Zvbc vector instruction table

### DIFF
--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -4507,7 +4507,7 @@ OP-V (0x57)
 | 100101 |V|X|I| vsll       | 100101 |V|X| vmul        | 100101 | | |
 | 100110 | | | |            | 100110 |V|X| vmulhsu     | 100110 | | |
 | 100111 |V|X| | vsmul      | 100111 |V|X| vmulh       | 100111 | |F| vfrsub
-|        | | |I| vmv<nr>r   |        | | |             |        | | |
+| 100111 | | |I| vmv<nr>r   |        | | |             |        | | |
 | 101000 |V|X|I| vsrl       | 101000 | | |             | 101000 |V|F| vfmadd
 | 101001 |V|X|I| vsra       | 101001 |V|X| vmadd       | 101001 |V|F| vfnmadd
 | 101010 |V|X|I| vssrl      | 101010 | | |             | 101010 |V|F| vfmsub


### PR DESCRIPTION
Add missing func6 encoding for `vmv<nr>r` instructions in doc/vector/riscv-crypto-vector-inst-table-zvbb-zvbc.adoc.

The current table does not list the func6 field for `vmv<nr>r` instructions, which makes the encoding information incomplete.

This patch adds the corresponding func6 encoding based on the specification, to ensure the instruction table is consistent and complete.

This is a documentation-only change.