### PR TITLE
MSTATUS_UXL_LEGAL_VALS_SMODE not impl-def

### DIFF
--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -239,7 +239,6 @@ normative_rule_definitions:
     tag: "norm:mstatus_uxl_rdonly_mxlen64"
   - name: MSTATUS_UXL_LEGAL_VALS_SMODE
     tag: "norm:mstatus_uxl_legal_vals_smode"
-    impl-def-behavior: true
     kind: extension
     instance: Sm
   - name: mstatus_mprv_ldst_op


### PR DESCRIPTION
Fixes #2768 

Just removed property identifying this as impl-def.