### PR TITLE
Sets :appendix-number: to @

### DIFF
--- a/src/priv-appendices.adoc
+++ b/src/priv-appendices.adoc
@@ -1,3 +1,4 @@
+:appendix-number: @
 [appendix]
 == Privileged Architecture Explanatory Material
 


### PR DESCRIPTION
Asciidoctor increments the appendix number before setting it.  Setting it to @, the character right before A in the ASCII character set results in Asciidoctor restarting the Appendix numbering at A.

This fix assumes that the Appendix numbering should restart for each Volume.  Note that for future volumes this would be required in their appendix as well.