### PR TITLE
Increase ToC level for the whole spec

### DIFF
--- a/src/riscv-spec.adoc
+++ b/src/riscv-spec.adoc
@@ -27,7 +27,7 @@ endif::[]
 :sectnumlevels: 4
 :sectlinks:
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :source-highlighter: rouge
 :table-caption: Table
 :figure-caption: Figure


### PR DESCRIPTION
Increase ToC level for the spec so the CSR section of each privilege mode and instruction section can be found in the ToC.