### PR TITLE
Implement root redirect to index.html

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -122,6 +122,8 @@ jobs:
           cp build/norm-rules.html dist/snapshot/norm-rules/norm-rules.html
           cp build/norm-rules.json dist/snapshot/norm-rules/norm-rules.json
           cp build/riscv-spec.html dist/snapshot/norm-rules/riscv-spec.html
+          # Add root redirect
+          printf '<!DOCTYPE html>\n<html>\n<head>\n  <meta charset="utf-8">\n  <meta http-equiv="refresh" content="0; url=snapshot/spec/">\n  <link rel="canonical" href="snapshot/spec/">\n  <title>RISC-V ISA Manual</title>\n</head>\n<body>\n  <p>Redirecting to <a href="snapshot/spec/">RISC-V ISA Manual</a>…</p>\n</body>\n</html>\n' > dist/index.html
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
       - name: Upload pages artifact


### PR DESCRIPTION
Add root redirect to the index.html file for RISC-V ISA Manual.  A bare https://riscv.github.io/riscv-isa-manual/ hit, which currently 404s, will now redirect to snapshot/spec/.  This fixes a 404 produced from the https://github.com/riscv/riscv-isa-manual/deployments/github-pages page.