### PR TITLE
Use the phrase "IEEE 754-2008" consistently

### DIFF
--- a/src/d-st-ext.adoc
+++ b/src/d-st-ext.adoc
@@ -44,9 +44,13 @@ including variadic functions, user-level threading libraries, virtual machine
 migration, and debugging.
 ====
 
-Floating-point _n_-bit transfer operations move external
-values held in IEEE standard formats into and out of the `f` registers,
-and comprise floating-point loads and stores (FL__n__/FS__n__) and floating-point move instructions (FMV._n_.X/FMV.X._n_). [#norm:FP_transfer_instrs_narrow_transfer_in]#A narrower _n_-bit transfer, _n_<FLEN, into the `f` registers will create a valid NaN-boxed value#. [#norm:FP_transfer_instrs_narrow_transfer_out]#A narrower
+Floating-point _n_-bit transfer operations move external values held in
+the IEEE 754-2008 formats into and out of the `f` registers, and
+comprise floating-point loads and stores (FL__n__/FS__n__) and
+floating-point move instructions (FMV._n_.X/FMV.X._n_).
+[#norm:FP_transfer_instrs_narrow_transfer_in]#A narrower _n_-bit
+transfer, _n_<FLEN, into the `f` registers will create a valid NaN-boxed
+value#. [#norm:FP_transfer_instrs_narrow_transfer_out]#A narrower
 _n_-bit transfer out of the floating-point registers will
 transfer the lower _n_ bits of the register ignoring the
 upper FLEN-_n_ bits#.
@@ -71,8 +75,8 @@ non-recoded and recoded implementations of the floating-point unit. The
 new definition also helps catch software errors by propagating NaNs if
 values are used incorrectly.
 
-Non-recoded implementations unpack and pack the operands to IEEE
-standard format on the input and output of every floating-point
+Non-recoded implementations unpack and pack the operands to the IEEE
+754-2008 format on the input and output of every floating-point
 operation. The NaN-boxing cost to a non-recoded implementation is
 primarily in checking if the upper bits of a narrower operation
 represent a legal NaN-boxed value, and in writing all 1s to the upper
@@ -177,12 +181,11 @@ include::images/wavedrom/fsjgnjnx-d.edn[]
 
 For XLEN{ge}64 only, instructions are provided to move bit
 patterns between the floating-point and integer registers.
-[#norm:fmv-x-d_op]#FMV.X.D moves
-the double-precision value in floating-point register _rs1_ to a
-representation in IEEE 754-2008 standard encoding in integer register
-_rd_#. [#norm:fmv-d-x_op]#FMV.D.X moves the double-precision value encoded in IEEE 754-2008
-standard encoding from the integer register _rs1_ to the floating-point
-register _rd_#.
+[#norm:fmv-x-d_op]#FMV.X.D moves the double-precision value in
+floating-point register _rs1_ to a representation in the IEEE 754-2008
+encoding in integer register _rd_#. [#norm:fmv-d-x_op]#FMV.D.X moves the
+double-precision value encoded in the IEEE 754-2008 encoding from the
+integer register _rs1_ to the floating-point register _rd_#.
 
 [[norm:fmv_bits_preserved]]
 FMV.X.D and FMV.D.X do not modify the bits being transferred; in

--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -6,8 +6,10 @@
 
 This chapter describes the standard instruction-set extension for
 single-precision floating-point, which is named "F" and adds
-[#norm:f_ieee_compliance]#single-precision floating-point computational instructions compliant
-with the <<ieee754-2008,IEEE 754-2008 arithmetic standard>>.# [#norm:f_depends_zicsr]#The F extension depends on the "Zicsr" extension for control and status register access.#
+[#norm:f_ieee_compliance]#single-precision floating-point computational
+instructions compliant with the <<ieee754-2008,IEEE 754-2008 arithmetic
+standard>>.# [#norm:f_depends_zicsr]#The F extension depends on the
+"Zicsr" extension for control and status register access.#
 
 === F Register State
 
@@ -178,7 +180,7 @@ floating-point exception flag.
 
 [NOTE]
 ====
-As allowed by the standard, we do not support traps on floating-point
+As allowed by IEEE 754-2008, we do not support traps on floating-point
 exceptions in the F extension, but instead require explicit checks of
 the flags in software. We considered adding branches controlled directly
 by the contents of the floating-point accrued exception flags, but
@@ -197,13 +199,15 @@ quiet bit. For single-precision floating-point, this corresponds to the pattern 
 
 [NOTE]
 ====
-We considered propagating NaN payloads, as is recommended by the
-standard, but this decision would have increased hardware cost.
-Moreover, since this feature is optional in the standard, it cannot be
-used in portable code.
+We considered propagating NaN payloads, as is recommended by IEEE
+754-2008, but this decision would have increased hardware cost. Moreover,
+since this feature is optional in IEEE 754-2008, it cannot be used in
+portable code.
 
 Implementers are free to provide a NaN payload propagation scheme as a
-nonstandard extension enabled by a nonstandard operating mode. However, the canonical NaN scheme described above must always be supported and should be the default mode.
+nonstandard extension enabled by a nonstandard operating mode. However,
+the canonical NaN scheme described above must always be supported and
+should be the default mode.
 ====
 '''
 [NOTE]
@@ -221,12 +225,12 @@ provide exceptional default values.
 === Subnormal Arithmetic
 
 [[norm:ieee_std_subnormal]]
-Operations on subnormal numbers are handled in accordance with the IEEE 754-2008 standard.
+Operations on subnormal numbers are handled in accordance with
+IEEE 754-2008.
 (((operations, subnormal)))
 
 [[norm:ieee_std_tininess]]
-In the parlance of the IEEE standard, tininess is detected after
-rounding.
+In the parlance of IEEE 754-2008, tininess is detected after rounding.
 (((tininess, handling)))
 
 [NOTE]
@@ -356,8 +360,8 @@ exception flag when the multiplicands are {inf} and zero, even when the addend i
 
 [NOTE]
 ====
-The IEEE 754-2008 standard permits, but does not require, raising the
-invalid exception for the operation {inf}×0 + qNaN.
+IEEE 754-2008 permits, but does not require, raising the invalid
+exception for the operation {inf}×0 + qNaN.
 ====
 
 === Single-Precision Floating-Point Conversion and Move Instructions
@@ -434,19 +438,32 @@ include::images/wavedrom/spfloat-sign-inj.edn[]
 
 [NOTE]
 ====
-The sign-injection instructions provide floating-point MV, ABS, and NEG, as well as supporting a few other operations, including the IEEE
-`copySign` operation and sign manipulation in transcendental math function libraries. Although MV, ABS, and NEG only need a single register operand, whereas FSGNJ instructions need two, it is unlikely most microarchitectures would add optimizations to benefit from the reduced number of register reads for these relatively infrequent instructions. Even in this case, a microarchitecture can simply detect when both source registers are the same for FSGNJ instructions and only read a single copy.
+The sign-injection instructions provide floating-point MV, ABS, and NEG,
+as well as supporting a few other operations, including the IEEE
+754-2008 `copySign` operation and sign manipulation in transcendental
+math function libraries. Although MV, ABS, and NEG only need a single
+register operand, whereas FSGNJ instructions need two, it is unlikely
+most microarchitectures would add optimizations to benefit from the
+reduced number of register reads for these relatively infrequent
+instructions. Even in this case, a microarchitecture can simply detect
+when both source registers are the same for FSGNJ instructions and only
+read a single copy.
 ====
 
 Instructions are provided to move bit patterns between the
-floating-point and integer registers. [#norm:fmv-x-w_op]#FMV.X.W moves the single-precision value in floating-point register _rs1_ represented in IEEE 754-2008 encoding to the lower 32 bits of integer register _rd_. The bits are not modified in the transfer, and in particular, the payloads of non-canonical NaNs are preserved. For RV64, the higher 32 bits of the destination register are filled with copies of the floating-point number's sign bit#.
+floating-point and integer registers. [#norm:fmv-x-w_op]#FMV.X.W moves
+the single-precision value in floating-point register _rs1_ represented
+in the IEEE 754-2008 encoding to the lower 32 bits of integer register
+_rd_. The bits are not modified in the transfer, and in particular, the
+payloads of non-canonical NaNs are preserved. For RV64, the higher 32
+bits of the destination register are filled with copies of the
+floating-point number's sign bit#.
 
 [[norm:fmv-w-x_op]]
-FMV.W.X moves the single-precision value encoded in IEEE 754-2008
-standard encoding from the lower 32 bits of integer register _rs1_ to
-the floating-point register _rd_. The bits are not modified in the
-transfer, and in particular, the payloads of non-canonical NaNs are
-preserved.
+FMV.W.X moves the single-precision value encoded in the IEEE 754-2008
+encoding from the lower 32 bits of integer register _rs1_ to the
+floating-point register _rd_. The bits are not modified in the transfer,
+and in particular, the payloads of non-canonical NaNs are preserved.
 
 [NOTE]
 ====
@@ -472,10 +489,13 @@ specified comparison between floating-point registers
 _rs1_ {le} _rs2_) writing 1 to the integer register _rd_ if the
 condition holds, and 0 otherwise.
 
-[#norm:flt-s_fle-s_signaling]#FLT.S and FLE.S perform what the IEEE 754-2008 standard refers to as
-_signaling_ comparisons: that is, they set the invalid operation
-exception flag if either input is NaN#. [#norm:feq-s_quiet]#FEQ.S performs a _quiet_
-comparison: it only sets the invalid operation exception flag if either input is a signaling NaN#. [#norm:feq-s_flt-s_fle-s_NaN_input]#For all three instructions, the result is 0 if either operand is NaN#.
+[#norm:flt-s_fle-s_signaling]#FLT.S and FLE.S perform what IEEE 754-2008
+refers to as _signaling_ comparisons: that is, they set the invalid
+operation exception flag if either input is NaN#.
+[#norm:feq-s_quiet]#FEQ.S performs a _quiet_ comparison: it only sets
+the invalid operation exception flag if either input is a signaling NaN#.
+[#norm:feq-s_flt-s_fle-s_NaN_input]#For all three instructions, the
+result is 0 if either operand is NaN#.
 
 include::images/wavedrom/spfloat-comp.edn[]
 [[spfloat-comp]]

--- a/src/q-st-ext.adoc
+++ b/src/q-st-ext.adoc
@@ -3,11 +3,11 @@
 This chapter describes the Q standard extension for 128-bit
 quad-precision binary floating-point instructions compliant with the
 IEEE 754-2008 arithmetic standard. The quad-precision binary
-floating-point instruction-set extension is named "Q"; it depends on
-the double-precision floating-point extension D. [#norm:Q_flen_128]#The floating-point
-registers are now extended to hold either a single, double, or
-quad-precision floating-point value (FLEN=128).# The NaN-boxing scheme
-described in <<nanboxing>> is now extended
+floating-point instruction-set extension is named "Q"; it depends on the
+double-precision floating-point extension D.
+[#norm:Q_flen_128]#The floating-point registers are now extended to hold
+either a single, double, or quad-precision floating-point value (FLEN=128).#
+The NaN-boxing scheme described in <<nanboxing>> is now extended
 recursively to allow a single-precision value to be NaN-boxed inside a
 double-precision value which is itself NaN-boxed inside a quad-precision
 value.

--- a/src/zfa.adoc
+++ b/src/zfa.adoc
@@ -2,13 +2,13 @@
 == "Zfa" Extension for Additional Floating-Point Instructions, Version 1.0
 
 This chapter describes the Zfa standard extension, which adds
-instructions for immediate loads, IEEE 754-2019 cite:[ieee754-2019]
-`minimum` and `maximum` operations, round-to-integer operations, and
-quiet floating-point comparisons. For RV32D, the Zfa extension also adds
-instructions to transfer double-precision floating-point values to and
-from integer registers, and for RV64Q, it adds analogous instructions
-for quad-precision floating-point values. The Zfa extension depends on
-the F extension.
+instructions for immediate loads, IEEE 754-2019 `minimum` and `maximum`
+operations, round-to-integer operations, and quiet floating-point
+comparisons. For RV32D, the Zfa extension also adds instructions to
+transfer double-precision floating-point values to and from integer
+registers, and for RV64Q, it adds analogous instructions for
+quad-precision floating-point values. The Zfa extension depends on the
+F extension.
 
 === Load-Immediate Instructions
 
@@ -127,7 +127,7 @@ These instructions are encoded like their FMIN and FMAX counterparts,
 but with instruction bit 13 set to 1.
 [NOTE]
 ====
-These instructions implement the IEEE 754-2019 minimum and maximum
+These instructions implement the IEEE 754-2019 `minimum` and `maximum`
 operations.
 ====
 === Round-to-Integer Instructions
@@ -164,8 +164,8 @@ encoded like FCVT.Q.S, but with _rs2_=4 and 5, respectively,
 [NOTE]
 ====
 The FROUNDNX._fmt_ instructions implement the IEEE 754-2019
-roundToIntegralExact operation, and the FROUND._fmt_ instructions
-implement the other operations in the roundToIntegral family.
+`roundToIntegralExact` operation, and the FROUND._fmt_ instructions
+implement the other operations in the `roundToIntegral` family.
 ====
 === Modular Convert-to-Integer Instruction
 

--- a/src/zfh.adoc
+++ b/src/zfh.adoc
@@ -5,10 +5,10 @@ This chapter describes the Zfh standard extension for 16-bit
 half-precision binary floating-point instructions compliant with the
 IEEE 754-2008 arithmetic standard. The Zfh extension depends on the
 single-precision floating-point extension, F. The NaN-boxing scheme
-described in <<nanboxing>> is extended to allow a
-half-precision value to be NaN-boxed inside a single-precision value
-(which may be recursively NaN-boxed inside a double- or quad-precision
-value when the D or Q extension is present).
+described in <<nanboxing>> is extended to allow a half-precision value
+to be NaN-boxed inside a single-precision value (which may be
+recursively NaN-boxed inside a double- or quad-precision value when the
+D or Q extension is present).
 
 [NOTE]
 ====
@@ -107,13 +107,14 @@ include::images/wavedrom/flt-to-flt-sgn-inj-instr.edn[]
 [[flt-to-flt-sgn-inj-instr]]
 
 Instructions are provided to move bit patterns between the
-floating-point and integer registers. [#norm:fmv-x-h_op]#FMV.X.H moves the half-precision
-value in floating-point register _rs1_ to a representation in IEEE
-754-2008 standard encoding in integer register _rd_, filling the upper
-XLEN-16 bits with copies of the floating-point number's sign bit#.
+floating-point and integer registers. [#norm:fmv-x-h_op]#FMV.X.H moves
+the half-precision value in floating-point register _rs1_ to a
+representation in the IEEE 754-2008 encoding in integer register _rd_,
+filling the upper XLEN-16 bits with copies of the floating-point
+number's sign bit#.
 
 [[norm:fmv-h-x_op]]
-FMV.H.X moves the half-precision value encoded in IEEE 754-2008 standard
+FMV.H.X moves the half-precision value encoded in the IEEE 754-2008
 encoding from the lower 16 bits of integer register _rs1_ to the
 floating-point register _rd_, NaN-boxing the result.
 


### PR DESCRIPTION
It consistently uses *the IEEE 754-2008 arithmetic standard* for the first time in the chapter, and *IEEE 754-2008* afterwards. The standard format is referred as *the IEEE 754-2008 format.* Only scalar FP extensions are updated in this PR to receive feedbacks before working on the whole text.

Reference: https://github.com/riscv/riscv-isa-manual/issues/2810