### PR TITLE
Tidy IEEE 754 bibliography entries

### DIFF
--- a/src/resources/riscv-spec.bib
+++ b/src/resources/riscv-spec.bib
@@ -1,19 +1,19 @@
 @Misc{ieee754-2008,
   key = "{IEEE}",
-  title =       "{ANSI/IEEE Std 754-2008}, {IEEE} Standard for
-                  Floating-Point Arithmetic",
-  publisher = {"Institute of Electrical and Electronic Engineers"},
+  title = {{IEEE} Standard for Floating-Point Arithmetic},
+  publisher = {{Institute of Electrical and Electronic Engineers}},
+  howpublished = {ANSI/IEEE Std 754-2008},
   doi = {10.1109/IEEESTD.2008.4610935},
-  year =         2008
+  year = 2008
 }
 
 @Misc{ieee754-2019,
   key = "{IEEE}",
-  title =       "{ANSI/IEEE Std 754-2019}, {IEEE} Standard for
-                  Floating-Point Arithmetic",
-  publisher = {"Institute of Electrical and Electronic Engineers"},
+  title = {{IEEE} Standard for Floating-Point Arithmetic},
+  publisher = {{Institute of Electrical and Electronic Engineers}},
+  howpublished = {ANSI/IEEE Std 754-2019},
   doi = {10.1109/IEEESTD.2019.8766229},
-  year =         2019
+  year = 2019
 }
 
 @inproceedings{riscI-isca1981,


### PR DESCRIPTION
- Use `howpublished` for the standard number like other entries
- Format `publisher` so that unnecessary quotes do not appear

Reference: https://github.com/riscv/riscv-isa-manual/issues/2810