### PR TITLE
RVV: use official IEEE 754 terms

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -2270,7 +2270,7 @@ NOTE: In this discussion, fixed-point operations are
 considered to be integer operations.
 
 All standard vector floating-point arithmetic operations follow the
-IEEE-754/2008 standard.  [#norm:V_fp_frm]#All vector floating-point operations use the dynamic rounding mode in the `frm` register.#  [#norm:V_inv_frm_rsv]#Use of the `frm` field
+IEEE 754-2008 arithmetic standard.  [#norm:V_fp_frm]#All vector floating-point operations use the dynamic rounding mode in the `frm` register.#  [#norm:V_inv_frm_rsv]#Use of the `frm` field
 when it contains an invalid rounding mode by any vector floating-point
 instruction--even those that do not depend on the rounding mode, or
 when `vl`=0, or when `vstart` {ge} `vl`--is reserved.#
@@ -3291,7 +3291,7 @@ as a signed integer.#
 === Vector Floating-Point Instructions
 
 The standard vector floating-point instructions treat elements as
-IEEE-754/2008-compatible values.  [#norm:V_fp_EEW_IEEE_nsupported_rsv]#If the EEW of a vector
+IEEE 754-2008-compatible values.  [#norm:V_fp_EEW_IEEE_nsupported_rsv]#If the EEW of a vector
 floating-point operand does not correspond to a supported IEEE
 floating-point type, the instruction encoding is reserved.#
 
@@ -3299,7 +3299,7 @@ NOTE: Whether floating-point is supported, and for which element
 widths, is determined by the specific vector extension.  The current
 set of extensions include support for 32-bit and 64-bit floating-point
 values. When 16-bit and 128-bit element widths are added, they will be
-also be treated as IEEE-754/2008-compatible values.  Other
+also be treated as IEEE 754-2008-compatible values.  Other
 floating-point formats may be supported in future extensions.
 
 [#norm:Vf_requrires_Vx]#Vector floating-point instructions require the presence of base scalar


### PR DESCRIPTION
Reference: https://github.com/riscv/riscv-isa-manual/issues/2810