### PR TITLE
intro: use the phrase IEEE 754-2008

### DIFF
--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -19,7 +19,8 @@ FPGA), but which allows efficient implementation in any of these.
 a base for customized accelerators or for educational purposes, and
 optional standard extensions, to support general-purpose software
 development.
-* Support for the revised 2008 IEEE-754 floating-point standard. cite:[ieee754-2008]
+* Support for the IEEE 754-2008 cite:[ieee754-2008] floating-point arithmetic
+standard.
 * An ISA supporting extensive ISA extensions and specialized variants.
 * Both 32-bit and 64-bit address space variants for applications,
 operating system kernels, and hardware implementations.
@@ -605,8 +606,8 @@ a hart depends on the EEI.
 
 [NOTE]
 ====
-Our use of "exception" and "trap" is compatible with that in the
-IEEE-754 floating-point standard.
+Our use of "exception" and "trap" is compatible with that in the IEEE
+754-2008 floating-point arithmetic standard.
 ====
 
 How traps are handled and made visible to software running on the hart


### PR DESCRIPTION
Note that while preface contains *IEEE 754-201x,* I decided to leave it as-is since the sentence is about the situation at that time.

Reference: https://github.com/riscv/riscv-isa-manual/issues/2810