### PR TITLE
Clarify that V is compatible with Zfinx

### DIFF
--- a/src/v-st-ext.adoc
+++ b/src/v-st-ext.adoc
@@ -5138,14 +5138,15 @@ do not include those with floating-point operands, and Zve64f does not include t
 with EEW=64 floating-point operands.#
 
 [#norm:Zve32x_dependent_Zicsr]#The Zve32x extension depends on the Zicsr extension.#
-[#norm:Zve32f_Zve64f_dependent_F]#The Zve32f and Zve64f extensions depend upon the F extension,
+[#norm:Zve32f_Zve64f_dependent_F]#The Zve32f and Zve64f extensions depend upon
+either the F extension or the Zfinx extension,
 and implement all
 vector floating-point instructions (<<sec-vector-float>>) for
 floating-point operands with EEW=32. Vector single-width floating-point reduction
 operations (<<sec-vector-float-reduce>>) for EEW=32 are supported.#
 
-The Zve64d extension depends upon the D extension,
-and implements all vector
+The Zve64d extension depends upon either the D extension or the Zdinx
+extension, and implements all vector
 floating-point instructions (<<sec-vector-float>>) for
 floating-point operands with EEW=32 or EEW=64 (including widening
 instructions and conversions between FP32 and FP64). Vector
@@ -5199,8 +5200,8 @@ widening reduction operations (<<sec-vector-integer-reduce>>,
 [#norm:V_instr_perm]#The V extension supports all vector permutation instructions
 (<<sec-vector-permute>>).#
 
-[#norm:V_dependent_F_D]#The V extension depends upon the F and D
-extensions, and implements all vector floating-point instructions
+[#norm:V_dependent_F_D]#The V extension depends upon either the D extension or
+the Zdinx extension, and implements all vector floating-point instructions
 (<<sec-vector-float>>) for floating-point operands with EEW=32
 or EEW=64 (including widening instructions and conversions between
 FP32 and FP64). Vector single-width floating-point reductions
@@ -5245,7 +5246,7 @@ provided.  The floating-point-to-integer narrowing conversions
 (`vfncvt[.rtz].x[u].f.w`) and integer-to-floating-point
 widening conversions (`vfwcvt.f.x[u].v`) become defined when SEW=8.#
 
-[#norm:Zvfh_dependent_Zve32f_Zfhmin]#The Zvfh extension depends on the Zve32f and Zfhmin extensions.#
+[#norm:Zvfh_dependent_Zve32f_Zfhmin]#The Zvfh extension depends on the Zve32f extension and either the Zfhmin extension or the Zhinxmin extension.#
 
 NOTE: Requiring basic scalar half-precision support makes Zvfh's
 vector-scalar instructions substantially more useful.


### PR DESCRIPTION
The V extension is compatible with Zfinx [1], but the current spec language indicating that it depends on F contradicts that.  This PR resolves that contradiction by allowing V to depend on either F or Zfinx, etc.

The longer-term and more elegant solution is to declare ISAs with Zfinx to be distinct base ISAs. The band-aid in this PR is compatible with the long-term plan.

[1] https://github.com/riscv/riscv-isa-manual/blob/5b8f8d6c04b515e633023deecca49de855f452d2/src/v-st-ext.adoc#L941