### PR TITLE
List Zalrsc and Zaamo in preface

### DIFF
--- a/src/preface.adoc
+++ b/src/preface.adoc
@@ -24,6 +24,80 @@ h|Extension h|Version h|Status
 |*Zifencei* |*2.0* |*Ratified*
 |*Zicsr* |*2.0* |*Ratified*
 |*Zicntr* |*2.0* |*Ratified*
+|*Zihpm* |*2.0* | *Ratified*
+|*Zihintntl* |*1.0* |*Ratified*
+|*Zihintpause* |*2.0* |*Ratified*
+|*Zimop* |*1.0* | *Ratified*
+|*Zicond* |*1.0* |*Ratified*
+|*Zilsd* |*1.0* |*Ratified*
+|*M* |*2.0* |*Ratified*
+|*Zmmul* |*1.0* |*Ratified*
+|*A* |*2.1* |*Ratified*
+|*Zalrsc* |*1.0* | *Ratified*
+|*Zaamo* |*1.0* | *Ratified*
+|*Zawrs* |*1.0* |*Ratified*
+|*Zacas* |*1.0* |*Ratified*
+|*Zabha* |*1.0* |*Ratified*
+|*Zalasr* |*1.0* |*Ratified*
+|*RVWMO* |*2.0* |*Ratified*
+|*Ztso* |*1.0* |*Ratified*
+|*CMO* |*1.0* |*Ratified*
+|*F* |*2.2* |*Ratified*
+|*D* |*2.2* |*Ratified*
+|*Q* |*2.2* |*Ratified*
+|*Zfh* |*1.0* |*Ratified*
+|*Zfhmin* |*1.0* |*Ratified*
+|*BF16* |*1.0* |*Ratified*
+|*Zfa* |*1.0* |*Ratified*
+|*Zfinx* |*1.0* |*Ratified*
+|*Zdinx* |*1.0* |*Ratified*
+|*Zhinx* |*1.0* |*Ratified*
+|*Zhinxmin* |*1.0* |*Ratified*
+|*C* |*2.0* |*Ratified*
+|*Zce* |*1.0* |*Ratified*
+|*Zclsd* |*1.0* |*Ratified*
+|*B* |*1.0* |*Ratified*
+|*V* |*1.0* |*Ratified*
+|*Zbkb* |*1.0* |*Ratified*
+|*Zbkc* |*1.0* |*Ratified*
+|*Zbkx* |*1.0* |*Ratified*
+|*Zk* |*1.0* |*Ratified*
+|*Zks* |*1.0* |*Ratified*
+|*Zvbb* |*1.0* |*Ratified*
+|*Zvbc* |*1.0* |*Ratified*
+|*Zvkg* |*1.0* |*Ratified*
+|*Zvkned* |*1.0* |*Ratified*
+|*Zvknhb* |*1.0* |*Ratified*
+|*Zvksed* |*1.0* |*Ratified*
+|*Zvksh* |*1.0* |*Ratified*
+|*Zvkt* |*1.0* |*Ratified*
+|*Zicfiss* |*1.0* |*Ratified*
+|*Zicfilp* |*1.0* |*Ratified*
+|===
+
+The changes in this version of the document include:
+
+* TBD
+
+[.big]*_Preface to Document Version 20260120_*
+
+This document describes the RISC-V unprivileged architecture.
+It contains the following versions of the RISC-V ISA modules,
+all of which have been ratified:
+
+[%autowidth,float="center",align="center",cols="^,<,^",options="header"]
+|===
+|Base |Version |Status
+|*RV32I* |*2.1* |*Ratified*
+|*RV32E* |*2.0* |*Ratified*
+|*RV64E* |*2.0* |*Ratified*
+|*RV64I* |*2.1* |*Ratified*
+
+h|Extension h|Version h|Status
+
+|*Zifencei* |*2.0* |*Ratified*
+|*Zicsr* |*2.0* |*Ratified*
+|*Zicntr* |*2.0* |*Ratified*
 |*Zihpm* | *2.0* | *Ratified*
 |*Zihintntl* |*1.0* |*Ratified*
 |*Zihintpause* |*2.0* |*Ratified*
@@ -33,6 +107,8 @@ h|Extension h|Version h|Status
 |*M* |*2.0* |*Ratified*
 |*Zmmul* |*1.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
+|*Zalrsc* |*1.0* | *Ratified*
+|*Zaamo* |*1.0* | *Ratified*
 |*Zawrs* |*1.0* |*Ratified*
 |*Zacas* |*1.0* |*Ratified*
 |*Zabha* |*1.0* |*Ratified*
@@ -104,6 +180,8 @@ h|Extension h|Version h|Status
 |*M* |*2.0* |*Ratified*
 |*Zmmul* |*1.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
+|*Zalrsc* |*1.0* | *Ratified*
+|*Zaamo* |*1.0* | *Ratified*
 |*Zawrs* |*1.0* |*Ratified*
 |*Zacas* |*1.0* |*Ratified*
 |*Zabha* |*1.0* |*Ratified*
@@ -177,6 +255,8 @@ h|Extension h|Version h|Status
 |*M* |*2.0* |*Ratified*
 |*Zmmul* |*1.0* |*Ratified*
 |*A* |*2.1* |*Ratified*
+|*Zalrsc* |*1.0* | *Ratified*
+|*Zaamo* |*1.0* | *Ratified*
 |*Zawrs* |*1.0* |*Ratified*
 |*Zacas* |*1.0* |*Ratified*
 |*Zabha* |*1.0* |*Ratified*


### PR DESCRIPTION
The `Zalrsc` and `Zaamo` sub-extensions were added in Version 20240411, though they were not listed in the tables in preface. This change adds them retroactively. The version of the extensions is determined as 1.0 like `Zmmul`.