### PR TITLE
Preface: add new extensions from the Profile spec

### DIFF
--- a/src/preface.adoc
+++ b/src/preface.adoc
@@ -73,11 +73,21 @@ h|Extension h|Version h|Status
 |*Zvkt* |*1.0* |*Ratified*
 |*Zicfiss* |*1.0* |*Ratified*
 |*Zicfilp* |*1.0* |*Ratified*
+|*Zama16b* |*1.0* |*Ratified*
+|*Za128rs* |*1.0* |*Ratified*
+|*Za64rs* |*1.0* |*Ratified*
+|*Zic64b* |*1.0* |*Ratified*
+|*Ziccamoa* |*1.0* |*Ratified*
+|*Ziccamoc* |*1.0* |*Ratified*
+|*Ziccif* |*1.0* |*Ratified*
+|*Zicclsm* |*1.0* |*Ratified*
+|*Ziccrse* |*1.0* |*Ratified*
 |===
 
 The changes in this version of the document include:
 
-* TBD
+* Addition of extensions that have already been ratified as part of the profile
+  specifications.
 
 [.big]*_Preface to Document Version 20260120_*
 

--- a/src/priv/preface.adoc
+++ b/src/priv/preface.adoc
@@ -1,5 +1,93 @@
 [colophon]
+// Had to make the above a level 1 heading (two equals signs) to avoid error when building
+// the ISA manual as a book with other "parts". This is opposite to what the adoc says to do
+// but otherwise asciidoctor creates the error message:
+//
+// asciidoctor: ERROR: ext/riscv-isa-manual/src/priv-preface.adoc: line 2: invalid part, must have at least one section (e.g., chapter, appendix, etc.)
+//
+// See asciidoctor doc which seems wrong: https://docs.asciidoctor.org/asciidoc/latest/sections/colophon/
 == Preface
+
+This document describes the RISC-V privileged architecture.
+It contains the following versions of the RISC-V ISA modules,
+all of which have been ratified:
+
+[%autowidth,float="center",align="center",cols="^,<",options="header",]
+|===
+|Module |Version
+|*Machine ISA* +
+*Smstateen Extension* +
+*Smcsrind/Sscsrind Extension* +
+*Smepmp Extension* +
+*Smcntrpmf Extension* +
+*Smrnmi Extension* +
+*Smcdeleg Extension* +
+*Smdbltrp Extension* +
+*Smctr Extension* +
+*Supervisor ISA* +
+*Svade Extension* +
+*Svnapot Extension* +
+*Svpbmt Extension* +
+*Svinval Extension* +
+*Svadu Extension* +
+*Svvptc Extension* +
+*Ssqosid Extension* +
+*Sstc Extension* +
+*Sscofpmf Extension* +
+*Ssdbltrp Extension* +
+*Ssqosid Extension* +
+*Hypervisor ISA* +
+*Shlcofideleg Extension* +
+*Svvptc Extension* +
+*Pointer-Masking Extensions* +
+*Svrsw60t59b Extension* +
+*Shcounterenw Extension* +
+*Shvstvala Extension* +
+*Shvstvecd Extension* +
+*Shvsatpa Extension* +
+*Shgatpa Extension* +
+*Sha Extension*
+
+|*1.13* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.13* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0* +
+*1.0*
+|===
+
+The following changes have been made since version 20260120:
+
+* Addition of extensions that have already been ratified as part of the profile
+  specifications.
+
+[.big]*_Preface to Version 20260120_*
 
 This document describes the RISC-V privileged architecture.
 It contains the following versions of the RISC-V ISA modules,
@@ -67,13 +155,6 @@ The following changes have been made since version 20250508:
 
 * Addition of the Svrsw60t59b extension for additional PTE reserved-for-software bits.
 
-// Had to make the above a level 1 heading (two equals signs) to avoid error when building
-// the ISA manual as a book with other "parts". This is opposite to what the adoc says to do
-// but otherwise asciidoctor creates the error message:
-//
-// asciidoctor: ERROR: ext/riscv-isa-manual/src/priv-preface.adoc: line 2: invalid part, must have at least one section (e.g., chapter, appendix, etc.)
-//
-// See asciidoctor doc which seems wrong: https://docs.asciidoctor.org/asciidoc/latest/sections/colophon/
 [.big]*_Preface to Version 20250508_*
 
 This document describes the RISC-V privileged architecture.


### PR DESCRIPTION
I put them in the tail of the extensions table. One can sort them after the reorganization by Andrew is finished.

Reference: https://github.com/riscv/riscv-isa-manual/pull/2771