### PR TITLE
Zce: Fix examples

### DIFF
--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -75,8 +75,8 @@ The Zce extension is intended to be used for microcontrollers, and includes all 
 
 Therefore common ISA strings can be updated as follows to include the relevant Zc extensions, for example:
 
-* RV32IMC becomes RV32IM_Zce
-* RV32IMCF becomes RV32IMF_Zce
+* RV32IMC_Zcb_Zcmp_Zcmt is equivalent to RV32IM_Zce
+* RV32IMFC_Zcb_Zcmp_Zcmt is equivalent to RV32IMF_Zce
 
 [#misaC]
 === MISA.C


### PR DESCRIPTION
I could not understand why `RV32IMC` becomes `RV32IM_Zce`. If *becomes* means *is equivalent to,* the examples should be these in this change.