### PR TITLE
priv: preface: Move H

### DIFF
--- a/src/priv/preface.adoc
+++ b/src/priv/preface.adoc
@@ -14,10 +14,9 @@ all of which have been ratified:
 
 [%autowidth,float="center",align="center",cols="^,<",options="header",]
 |===
-|Module |Version
-|*Machine ISA* |*1.13*
-|*Supervisor ISA* |*1.13*
-|*Hypervisor Extension* |*1.0*
+|Privilege Level |Version
+|*Machine* |*1.13*
+|*Supervisor* |*1.13*
 
 h|Extension h|Version
 
@@ -51,6 +50,7 @@ h|Extension h|Version
 |*Sscofpmf* |*1.0*
 |*Ssdbltrp* |*1.0*
 
+|*H* |*1.0*
 |*Shlcofideleg* |*1.0*
 |*Shvstvecd* |*1.0*
 |*Shcounterenw* |*1.0*


### PR DESCRIPTION
After <https://github.com/riscv/riscv-isa-manual/issues/2829#issuecomment-4195563237>, I think it is natural to put the both H and Shbare to the extensions table. This change moves H to the extensions table in preparation of that.