### PR TITLE
Clarify the word "canonical" in "canonical NaN"

### DIFF
--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -195,6 +195,12 @@ quiet bit. For single-precision floating-point, this corresponds to the pattern 
 
 [NOTE]
 ====
+The canonical NaN as defined here is unrelated to the definition of
+canonical encodings in IEEE 754-2008 for decimal interchange formats.
+====
+'''
+[NOTE]
+====
 We considered propagating NaN payloads, as is recommended by IEEE
 754-2008, but this decision would have increased hardware cost. Moreover,
 since this feature is optional in IEEE 754-2008, it cannot be used in


### PR DESCRIPTION
We define a "canonical NaN" for each format, which is unrelated to the concept of canonical encodings in IEEE 754. The latter only makes sense for decimal encodings anyway. Add a non-normative note clarifying this.

IEEE 754-2019 adds a clarifying note that "In binary interchange formats, all number and NaN encodings are canonical." However, I think it's more confusing to explain it this way in the context of this note, so I didn't mention it.

cc @Icenowy

See also a similar clarification for WebAssembly: https://github.com/WebAssembly/spec/pull/1614