### PR TITLE
Reorganize notes on FENCE.TSO

### DIFF
--- a/src/profiles/rva20.adoc
+++ b/src/profiles/rva20.adoc
@@ -35,15 +35,9 @@ instruction causes a requested trap to the execution environment.
 
 The `fence.tso` instruction is mandatory.
 
-NOTE: The `fence.tso` instruction was incorrectly described as
-optional in the 2019 ratified specifications. However, `fence.tso` is
-encoded within the standard `fence` encoding such that implementations
-must treat it as a simple global fence if they do not natively support
-TSO-ordering optimizations.  As software can always assume without any
-penalty that `fence.tso` is being exploited by a hardware
-implementation, there is no advantage to making the instruction a
-profile option.  Later versions of the unprivileged ISA
-specifications correctly indicate that `fence.tso` is mandatory.
+NOTE: The `fence.tso` instruction was incorrectly described as optional in the
+2019 ratified specifications. Later versions of <<vol:unpriv>> correctly
+indicate that `fence.tso` is mandatory.
 
 ==== RVA20U64 Mandatory Extensions
 

--- a/src/profiles/rva22.adoc
+++ b/src/profiles/rva22.adoc
@@ -13,10 +13,7 @@ terms of the amount of software that targets this profile.
 
 ==== RVA22U64 Mandatory Base
 
-RV64I is the mandatory base ISA for RVA22U64, including mandatory `fence.tso`, and is little-endian.
-
-NOTE: Later versions of the RV64I unprivileged ISA specification
-ratified in 2021 made clear that `fence.tso` is mandatory.
+RV64I is the mandatory base ISA for RVA22U64 and is little-endian.
 
 As per the unprivileged architecture specification, the `ecall`
 instruction causes a requested trap to the execution environment.
@@ -161,11 +158,7 @@ processors.  RVA22S64 is based on privileged architecture version
 
 ==== RVA22S64 Mandatory Base
 
-RV64I is the mandatory base ISA for RVA22S64, including mandatory
-`fence.tso`, and is little-endian.
-
-NOTE: Later versions of the RV64I unprivileged ISA specification
-ratified in 2021 made clear that `fence.tso` is mandatory.
+RV64I is the mandatory base ISA for RVA22S64 and is little-endian.
 
 The `ecall` instruction operates as per the unprivileged architecture
 specification.  An `ecall` in user mode causes a contained trap to

--- a/src/profiles/rvi20.adoc
+++ b/src/profiles/rvi20.adoc
@@ -28,15 +28,9 @@ Misaligned loads and stores might not be supported.
 
 The `fence.tso` instruction is mandatory.
 
-NOTE: The `fence.tso` instruction was incorrectly described as
-optional in the 2019 ratified specifications. However, `fence.tso` is
-encoded within the standard `fence` encoding such that implementations
-must treat it as a simple global fence if they do not natively support
-TSO-ordering optimizations.  As software can always assume without any
-penalty that `fence.tso` is being exploited by a hardware
-implementation, there is no advantage to making the instruction an
-option.  Later versions of the unprivileged ISA specifications
-correctly indicate that `fence.tso` is mandatory.
+NOTE: The `fence.tso` instruction was incorrectly described as optional in the
+2019 ratified specifications. Later versions of <<vol:unpriv>> correctly
+indicate that `fence.tso` is mandatory.
 
 ==== RVI20U32 Mandatory Extensions
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -869,7 +869,19 @@ store operations in the `FENCE.TSO's` predecessor set unordered with
 ====
 [[norm:fence-tso_ordering_rw_rw_ok]]
 Because `FENCE RW,RW` imposes a superset of the orderings that `FENCE.TSO`
-imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as `FENCE RW,RW`.
+imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as
+`FENCE RW,RW`.
+====
+
+[NOTE]
+====
+The FENCE.TSO instruction was incorrectly described as optional in 2019.
+However, FENCE.TSO is encoded within the standard FENCE encoding such that
+implementations must treat it as a simple global fence if they do not support
+TSO optimizations, as specified in the previous note.
+As software can always assume without any penalty that FENCE.TSO is being
+exploited by a hardware implementation, there is no advantage to making the
+instruction an option.
 ====
 
 [#norm:fence_unused_flds_rsv]#The unused fields in the FENCE


### PR DESCRIPTION
Close https://github.com/riscv/riscv-isa-manual/issues/2822

- Moved the historical note on FENCE.TSO to Volume I
- Simplified the FENCE.TSO note in RVA20 and RVI20
- Removed the FENCE.TSO note in RVA22 as Volume I ratified in 2021 already mandates it

@kasanovic Any opinions?