### PR TITLE
profiles: Update cross reference text

### DIFF
--- a/src/profiles/rva20.adoc
+++ b/src/profiles/rva20.adoc
@@ -36,8 +36,8 @@ instruction causes a requested trap to the execution environment.
 The `fence.tso` instruction is mandatory.
 
 NOTE: The `fence.tso` instruction was incorrectly described as optional in the
-2019 ratified specifications. Later versions of <<vol:unpriv>> correctly
-indicate that `fence.tso` is mandatory.
+2019 ratified specifications. Later versions of <<fence,the specification of
+FENCE.TSO>> correctly indicate that the instruction is mandatory.
 
 ==== RVA20U64 Mandatory Extensions
 

--- a/src/profiles/rvi20.adoc
+++ b/src/profiles/rvi20.adoc
@@ -29,8 +29,8 @@ Misaligned loads and stores might not be supported.
 The `fence.tso` instruction is mandatory.
 
 NOTE: The `fence.tso` instruction was incorrectly described as optional in the
-2019 ratified specifications. Later versions of <<vol:unpriv>> correctly
-indicate that `fence.tso` is mandatory.
+2019 ratified specifications. Later versions of <<fence,the specification of
+FENCE.TSO>> correctly indicate that the instruction is mandatory.
 
 ==== RVI20U32 Mandatory Extensions
 


### PR DESCRIPTION
`<<vol:unpriv>>` expands to Volume I, Section I.