### PR TITLE
Align the extension order with the chapter order

### DIFF
--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -59,7 +59,7 @@ last letter is "p". For example, "Zifencei" names the instruction-fetch fence ex
 described in <<zifencei>>.
 
 The first letter following the "Z" conventionally indicates the most closely
-related alphabetical extension category, IMAFDQLCBKJTPVH. For the "Zfa"
+related alphabetical extension category, IMAFDQLCBJTVPKH. For the "Zfa"
 extension for additional floating-point instructions, for example, the letter
 "f" indicates the extension is related to the "F" standard extension.
 
@@ -179,7 +179,7 @@ For instance, "RV32IV" is equivalent to "RV32I2V1".
 In canonical ISA name strings, components appear in the following order:
 
 . Base ISA
-. One-letter extensions, MAFDQCBPVH, in this order
+. One-letter extensions, MAFDQCBVPH, in this order
 . Z-prefixed extensions
 . Su-prefixed extensions
 . Ss-prefixed extensions
@@ -224,9 +224,9 @@ For instance, RV32IMACV is canonical, whereas RV32IMAVC is not.
 
 |Bit Manipulation |B |
 
-|Packed SIMD |P |
-
 |Vector |V |D
+
+|Packed SIMD |P |
 
 3+^|*Additional Standard Unprivileged Extensions*
 


### PR DESCRIPTION
While the Krste's plan puts P after V, the Z* extension order, IMAFDQLCBKJTPVH, puts P before V. Sooner is better if we align.

cc @kasanovic 