### PR TITLE
naming: Move K back

### DIFF
--- a/src/naming.adoc
+++ b/src/naming.adoc
@@ -59,7 +59,7 @@ last letter is "p". For example, "Zifencei" names the instruction-fetch fence ex
 described in <<zifencei>>.
 
 The first letter following the "Z" conventionally indicates the most closely
-related alphabetical extension category, IMAFDQLCBJTVPKH. For the "Zfa"
+related alphabetical extension category, IMAFDQLCBKJTVPH. For the "Zfa"
 extension for additional floating-point instructions, for example, the letter
 "f" indicates the extension is related to the "F" standard extension.
 


### PR DESCRIPTION
This reverts part of https://github.com/riscv/riscv-isa-manual/commit/aef8ef185d0f60f413f0e98d4eb371da6e2a838e to restore the current behavior on ratified extensions.