### PR TITLE
zc: Move C before Zca

### DIFF
--- a/src/unpriv/zc.adoc
+++ b/src/unpriv/zc.adoc
@@ -18,10 +18,10 @@ The extlink:c[] extension combines ext:zca[], ext:zcf[] if XLEN=32 and the F ext
 is present, and ext:zcd[] if the D extension is present.
 Various additional ext:Zc*[] extensions are also defined.
 
+include::c-st-ext.adoc[]
 include::zca.adoc[]
 include::zcf.adoc[]
 include::zcd.adoc[]
-include::c-st-ext.adoc[]
 include::zcb.adoc[]
 include::zcmt.adoc[]
 include::zcmp.adoc[]


### PR DESCRIPTION
The C extension is placed after Zca, Zcf and Zcd, while the A and B extensions are placed before the sub-extensions. Defining C before Zca etc. does not harm readability IMHO so this PR aligns C with A and B, though the other direction (defining extensions after sub-extensions) is of course fine.