### PR TITLE
Migrate Ziccamoa and Ziccamoc to new macros

### DIFF
--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1316,6 +1316,8 @@ normative_rule_definitions:
     tag: "norm:pma_amo_zacas_req_arith"
   - name: pma_amo_zabha_req
     tag: "norm:pma_amo_zabha_req"
+  - name: pma_amo_ziccamoa_req
+    tag: "norm:pma_amo_ziccamoa_req"
   - name: pma_amo_ziccamoc_req
     tag: "norm:pma_amo_ziccamoc_req"
   - name: pma_rsrv_levels

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2982,6 +2982,7 @@ categories: _LR/SC_ and _AMOs_.
 all atomic operations# required by the attached processors.
 ====
 
+[[sec:amo-pma]]
 ===== AMO PMA
 
 [#norm:pma_amo_levels]#Within AMOs, there are four levels of support: _AMONone_, _AMOSwap_,
@@ -3034,7 +3035,11 @@ instructions require ability to perform an arithmetic comparison and a swap oper
 [#norm:pma_amo_zabha_req]#The AMOs specified by the Zabha extension require the same level of support as
 the corresponding instructions in the Zaamo standard extension or the Zacas extension.#
 
-[#norm:pma_amo_ziccamoc_req]#The Ziccamoc extension requires AMOCASQ level
+[#norm:pma_amo_ziccamoa_req]#The ext:ziccamoa[] extension requires AMOArithmetic
+level support to main memory regions with both the coherence and cacheability
+PMAs.#
+
+[#norm:pma_amo_ziccamoc_req]#The ext:ziccamoc[] extension requires AMOCASQ level
 support to main memory regions with both the coherence and cacheability PMAs.#
 
 ===== Reservability PMA

--- a/src/profiles/rva20.adoc
+++ b/src/profiles/rva20.adoc
@@ -60,8 +60,8 @@ instructions.
 - <<ziccrse,**Ziccrse**>> Main memory regions with both the cacheability and
   coherence PMAs must support RsrvEventual.
 
-- <<ziccamoa,**Ziccamoa**>> Main memory regions with both the cacheability and
-  coherence PMAs must support AMOArithmetic.
+- extlink:ziccamoa[] Main memory regions with both the coherence and
+  cacheability PMAs must support AMOArithmetic.
 
 - <<za128rs,**Za128rs**>> Reservation sets must be contiguous, naturally aligned,
    and at most 128 bytes in size.

--- a/src/profiles/rva22.adoc
+++ b/src/profiles/rva22.adoc
@@ -38,8 +38,8 @@ The following mandatory extensions were present in RVA20U64.
 - <<ziccrse,**Ziccrse**>> Main memory regions with both the cacheability and
   coherence PMAs must support RsrvEventual.
 
-- <<ziccamoa,**Ziccamoa**>> Main memory regions with both the cacheability and
-  coherence PMAs must support AMOArithmetic.
+- extlink:ziccamoa[] Main memory regions with both the coherence and
+  cacheability PMAs must support AMOArithmetic.
 
 - <<zicclsm,**Zicclsm**>> Misaligned loads and stores to main memory regions
   with both the cacheability and coherence PMAs must be supported.

--- a/src/profiles/rva23.adoc
+++ b/src/profiles/rva23.adoc
@@ -43,8 +43,8 @@ The following mandatory extensions were present in RVA22U64.
   (i.e., 32 bits for RVA23) are atomic.
 - <<ziccrse,**Ziccrse**>> Main memory regions with both the cacheability and
   coherence PMAs must support RsrvEventual.
-- <<ziccamoa,**Ziccamoa**>> Main memory regions with both the cacheability and
-  coherence PMAs must support all atomics in the Zaamo extension.
+- extlink:ziccamoa[] Main memory regions with both the coherence and
+  cacheability PMAs must support AMOArithmetic.
 - <<zicclsm,**Zicclsm**>> Misaligned loads and stores to main memory regions
   with both the cacheability and coherence PMAs must be supported.
 - <<za64rs,**Za64rs**>> Reservation sets are contiguous, naturally aligned, and
@@ -115,11 +115,11 @@ future RVA profile.
 
 - <<zabha,**Zabha**>> Byte and halfword atomic memory operations.
 - <<zacas,**Zacas**>> Compare-and-Swap instructions.
-- <<ziccamoc,**Ziccamoc**>> Main memory regions with both the coherence and
-  cacheability PMAs must provide `AMOCASQ` level PMA support.
+- extlink:ziccamoc[] Main memory regions with both the coherence and
+  cacheability PMAs must provide AMOCASQ level PMA support.
 
-NOTE: Ziccamoc ensures Compare and Swap instructions are properly supported in
-main memory regions.
+NOTE: ext:ziccamoc[] ensures compare-and-swap instructions are properly
+supported in main memory regions.
 
 - <<zvbc,**Zvbc**>> Vector carryless multiplication.
 - <<zama16b,**Zama16b**>> Misaligned loads, stores, and AMOs to main memory

--- a/src/profiles/rvb23.adoc
+++ b/src/profiles/rvb23.adoc
@@ -51,8 +51,8 @@ RVA22U64.
   (i.e., 32 bits for RVB23) are atomic.
 - <<ziccrse,**Ziccrse**>> Main memory regions with both the cacheability and
   coherence PMAs must support RsrvEventual.
-- <<ziccamoa,**Ziccamoa**>>  Main memory regions with both the cacheability and
-  coherence PMAs must support all atomics in the Zaamo extension.
+- extlink:ziccamoa[] Main memory regions with both the coherence and
+  cacheability PMAs must support AMOArithmetic.
 - <<zicclsm,**Zicclsm**>> Misaligned loads and stores to main memory regions
   with both the cacheability and coherence PMAs must be supported.
 - <<za64rs,**Za64rs**>> Reservation sets are contiguous, naturally aligned, and
@@ -112,8 +112,8 @@ later RVB profile:
 
 - <<zabha,**Zabha**>> Byte and halfword atomic memory operations.
 - <<zacas,**Zacas**>> Compare-and-Swap instructions.
-- <<ziccamoc,**Ziccamoc**>> Main memory regions with both the cacheability and
-  coherence PMAs must provide `AMOCASQ` level PMA support.
+- extlink:ziccamoc[] Main memory regions with both the coherence and
+  cacheability PMAs must provide AMOCASQ level PMA support.
 - <<zama16b,**Zama16b**>> Misaligned loads, stores, and AMOs to main memory
   regions that do not cross a naturally aligned 16-byte boundary are atomic.
 

--- a/src/unpriv/ziccamoa.adoc
+++ b/src/unpriv/ziccamoa.adoc
@@ -1,6 +1,6 @@
-[[ziccamoa]]
-=== Ziccamoa Extension for Main Memory Atomics, Version 1.0
+[[ext:ziccamoa]]
+=== ext:ziccamoa[] Extension for Main Memory Atomics
 
-If the Ziccamoa extension is implemented, then main memory regions with both
-the cacheability and coherence PMAs must support all atomics in the Zaamo
-extension.
+If the ext:ziccamoa[] extension is implemented, then main memory regions with
+both the coherence and cacheability PMAs must provide AMOArithmetic level PMA
+support as defined in <<sec:amo-pma>>.

--- a/src/unpriv/ziccamoc.adoc
+++ b/src/unpriv/ziccamoc.adoc
@@ -1,6 +1,6 @@
-[[ziccamoc]]
-=== Ziccamoc Extension for Main Memory Compare-and-Swap, Version 1.0
+[[ext:ziccamoc]]
+=== ext:ziccamoc[] Extension for Main Memory Compare-and-Swap
 
-If the Ziccamoc extension is implemented, then main memory regions with both
-the cacheability and coherence PMAs must provide ``AMOCASQ``-level PMA
-support.
+If the ext:ziccamoc[] extension is implemented, then main memory regions with
+both the coherence and cacheability PMAs must provide AMOCASQ level PMA support
+as defined in <<sec:amo-pma>>.


### PR DESCRIPTION
Fix https://github.com/riscv/riscv-isa-manual/issues/2908