### PR TITLE
profiles: Tweak section level

### DIFF
--- a/src/profiles/intro.adoc
+++ b/src/profiles/intro.adoc
@@ -249,7 +249,7 @@ that matches the profile naming convention.  This allows tools that
 process the RISC-V ISA naming string to parse and/or process a combined
 string.
 
-==== RVA Profiles Rationale
+=== RVA Profiles Rationale
 
 RISC-V was designed to provide a highly modular and extensible
 instruction set and includes a large and growing set of standard


### PR DESCRIPTION
RVA Profiles Rationale should not be a subsection of Components of a Profile IHMO.