### PR TITLE
Add Normative Rule on Ziccamoa

### DIFF
--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1316,8 +1316,10 @@ normative_rule_definitions:
     tag: "norm:pma_amo_zacas_req_arith"
   - name: pma_amo_zabha_req
     tag: "norm:pma_amo_zabha_req"
-  - name: pma_amo_ziccamoc_req
-    tag: "norm:pma_amo_ziccamoc_req"
+  - name: ziccamoa_pma_amo_req
+    tag: "norm:ziccamoa_pma_amo_req"
+  - name: ziccamoc_pma_amo_req
+    tag: "norm:ziccamoc_pma_amo_req"
   - name: pma_rsrv_levels
     tag: "norm:pma_rsrv_levels"
   - name: ziccrse_pma_rsrv_req
@@ -1346,8 +1348,8 @@ normative_rule_definitions:
     tag: "norm:pma_mag_op_vec"
   - name: pma_mag_op_implicit
     tag: "norm:pma_mag_op_implicit"
-  - name: pma_mag_zama16b_req
-    tag: "norm:pma_mag_zama16b_req"
+  - name: zama16b_pma_mag_req
+    tag: "norm:zama16b_pma_mag_req"
   - name: pma_mo_io_chan_0
     tags: [{name: "norm:pma_mo_io_chan_def", context: true}, "norm:pma_mo_io_chan_0"]
   - name: pma_mo_io_chan_1

--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -1975,10 +1975,11 @@
     "norm:pma_amo_sz_support": "For each level of support, naturally aligned AMOs of a given width\nare supported if the underlying memory region supports reads and writes of that width.",
     "norm:pma_amo_far_subset_proc": "Main memory and I/O regions may only support a subset or none of the processor-supported atomic operations.",
     "norm:pma_amo_zacas_levels1": "The Zacas extension defines three additional levels of support: AMOCASW,\nAMOCASD, and AMOCASQ.",
-    "norm:pma_amo_zacas_levels2": "AMOCASW indicates that in addition to instructions indicated by AMOArithmetic\nlevel support, the AMOCAS.W instruction is supported. AMOCASD indicates that\nin addition to instructions indicated by AMOCASW level support, the AMOCAS.D\ninstruction is supported. AMOCASQ indicates that in addition to instructions\nindicated by AMOCASD level support, the AMOCAS.Q instruction is supported.",
-    "norm:pma_amo_zacas_req_arith": "AMOCASW/D/Q require AMOArithmetic level support as the AMOCAS.W/D/Q\ninstructions require ability to perform an arithmetic comparison and a swap operation.",
+    "norm:pma_amo_zacas_levels2": "AMOCASW indicates that in addition to instructions indicated by AMOArithmetic-level support, the AMOCAS.W instruction is supported. AMOCASD indicates that\nin addition to instructions indicated by AMOCASW-level support, the AMOCAS.D\ninstruction is supported. AMOCASQ indicates that in addition to instructions\nindicated by AMOCASD-level support, the AMOCAS.Q instruction is supported.",
+    "norm:pma_amo_zacas_req_arith": "AMOCASW/D/Q require AMOArithmetic-level support as the AMOCAS.W/D/Q\ninstructions require ability to perform an arithmetic comparison and a swap operation.",
     "norm:pma_amo_zabha_req": "The AMOs specified by the Zabha extension require the same level of support as\nthe corresponding instructions in the Zaamo standard extension or the Zacas extension.",
-    "norm:pma_amo_ziccamoc_req": "The ext:ziccamoc[] extension requires AMOCASQ-level\nsupport to main memory regions with both the coherence and cacheability PMAs.",
+    "norm:ziccamoa_pma_amo_req": "The ext:ziccamoa[] extension requires\nAMOArithmetic-level support to main memory regions with both the coherence and\ncacheability PMAs.",
+    "norm:ziccamoc_pma_amo_req": "The ext:ziccamoc[] extension requires AMOCASQ-level\nsupport to main memory regions with both the coherence and cacheability PMAs.",
     "norm:pma_rsrv_levels": "For LR/SC, there are three levels of support indicating combinations\nof the reservability and eventuality properties: RsrvNone,\nRsrvNonEventual, and RsrvEventual. RsrvNone indicates that no LR/SC\noperations are supported (the location is non-reservable).\nRsrvNonEventual indicates that the operations are supported (the\nlocation is reservable), but without the eventual success guarantee\ndescribed in the unprivileged ISA specification. RsrvEventual indicates\nthat the operations are supported and provide the eventual success guarantee.",
     "norm:ziccrse_pma_rsrv_req": "The ext:ziccrse[] extension requires RsrvEventual\nsupport to main memory regions with both the coherence and cacheability PMAs.",
     "norm:pma_mag_def": "The misaligned atomicity granule PMA provides constrained support for misaligned AMOs. This PMA, if present, specifies the size of a misaligned atomicity granule, a naturally aligned power-of-two number of bytes. Specific supported values for this PMA are represented by MAGNN, e.g., MAG16 indicates the misaligned atomicity granule is at least 16 bytes.",
@@ -1990,7 +1991,7 @@
     "norm:pma_mag_op_rsrv": "LR/SC instructions are unaffected by this PMA and so always raise an\nexception when misaligned.",
     "norm:pma_mag_op_vec": "Vector memory accesses are also unaffected, so might execute non-atomically even\nwhen contained within a misaligned atomicity granule.",
     "norm:pma_mag_op_implicit": "Implicit accesses are similarly unaffected by this PMA.",
-    "norm:pma_mag_zama16b_req": "The Zama16b extension requires MAG16 support to main\nmemory regions.",
+    "norm:zama16b_pma_mag_req": "The Zama16b extension requires MAG16 support to main\nmemory regions.",
     "norm:pma_mo_io_chan_def": "Each strongly ordered I/O region specifies a numbered ordering channel,\nwhich is a mechanism by which ordering guarantees can be provided\nbetween different I/O regions.",
     "norm:pma_mo_io_chan_0": "Channel 0 is used to indicate\npoint-to-point strong ordering only, where only accesses by the hart to\nthe single associated I/O region are strongly ordered.",
     "norm:pma_mo_io_chan_1": "Channel 1 is used to provide global strong ordering across all I/O regions. Any accesses by a hart to any I/O region associated with channel 1 can only be observed to have occurred in program order by all other harts and I/O devices, including relative to accesses made by that hart to relaxed I/O regions or strongly ordered I/O regions with different channel numbers. In other words, any access to a region in channel 1 is equivalent to executing a fence io,io instruction before and after the instruction.",
@@ -10530,7 +10531,8 @@
                           "norm:pma_amo_zacas_levels2",
                           "norm:pma_amo_zacas_req_arith",
                           "norm:pma_amo_zabha_req",
-                          "norm:pma_amo_ziccamoc_req"
+                          "norm:ziccamoa_pma_amo_req",
+                          "norm:ziccamoc_pma_amo_req"
                         ]
                       },
                       {
@@ -10561,7 +10563,7 @@
                       "norm:pma_mag_op_rsrv",
                       "norm:pma_mag_op_vec",
                       "norm:pma_mag_op_implicit",
-                      "norm:pma_mag_zama16b_req"
+                      "norm:zama16b_pma_mag_req"
                     ]
                   },
                   {

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -3034,7 +3034,11 @@ instructions require ability to perform an arithmetic comparison and a swap oper
 [#norm:pma_amo_zabha_req]#The AMOs specified by the Zabha extension require the same level of support as
 the corresponding instructions in the Zaamo standard extension or the Zacas extension.#
 
-[#norm:pma_amo_ziccamoc_req]#The ext:ziccamoc[] extension requires AMOCASQ-level
+[#norm:ziccamoa_pma_amo_req]#The ext:ziccamoa[] extension requires
+AMOArithmetic-level support to main memory regions with both the coherence and
+cacheability PMAs.#
+
+[#norm:ziccamoc_pma_amo_req]#The ext:ziccamoc[] extension requires AMOCASQ-level
 support to main memory regions with both the coherence and cacheability PMAs.#
 
 ===== Reservability PMA
@@ -3100,7 +3104,7 @@ exception when misaligned.#
 when contained within a misaligned atomicity granule.#
 [#norm:pma_mag_op_implicit]#Implicit accesses are similarly unaffected by this PMA.#
 
-[#norm:pma_mag_zama16b_req]#The Zama16b extension requires MAG16 support to main
+[#norm:zama16b_pma_mag_req]#The Zama16b extension requires MAG16 support to main
 memory regions.#
 
 [[sec:memory-ordering-pmas]]


### PR DESCRIPTION
In addition to the Ziccamoa rule, this also fixed the naming of rules on Ziccamoc and Zama16b.

Fix https://github.com/riscv/riscv-isa-manual/issues/2908

cc @jordancarlin @mmhus