### PR TITLE
machine: Fix hyphenation in AMO PMAs

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -3020,15 +3020,14 @@ possible.
 [#norm:pma_amo_zacas_levels1]#The Zacas extension defines three additional levels of support: AMOCASW,
 AMOCASD, and AMOCASQ.#
 
-[#norm:pma_amo_zacas_levels2]#AMOCASW indicates that in addition to instructions indicated by AMOArithmetic
-level support, the `AMOCAS.W` instruction is supported. AMOCASD indicates that
-in addition to instructions indicated by AMOCASW level support, the `AMOCAS.D`
+[#norm:pma_amo_zacas_levels2]#AMOCASW indicates that in addition to instructions indicated by AMOArithmetic-level support, the `AMOCAS.W` instruction is supported. AMOCASD indicates that
+in addition to instructions indicated by AMOCASW-level support, the `AMOCAS.D`
 instruction is supported. AMOCASQ indicates that in addition to instructions
-indicated by AMOCASD level support, the `AMOCAS.Q` instruction is supported.#
+indicated by AMOCASD-level support, the `AMOCAS.Q` instruction is supported.#
 
 [NOTE]
 ====
-[#norm:pma_amo_zacas_req_arith]#`AMOCASW/D/Q` require AMOArithmetic level support as the `AMOCAS.W/D/Q`
+[#norm:pma_amo_zacas_req_arith]#`AMOCASW/D/Q` require AMOArithmetic-level support as the `AMOCAS.W/D/Q`
 instructions require ability to perform an arithmetic comparison and a swap operation.#
 ====
 


### PR DESCRIPTION
Note that this conflicts with <https://github.com/riscv/riscv-isa-manual/pull/2916> because they update the same section.