### PR TITLE
Tweak CMO

### DIFF
--- a/src/riscv-spec.adoc
+++ b/src/riscv-spec.adoc
@@ -38,7 +38,6 @@ endif::[]
 :data-uri:
 :hide-uri-scheme:
 :footnote:
-:csrname: envcfg
 :imagesdir: images
 
 include::symbols.adoc[]

--- a/src/unpriv/cmo.adoc
+++ b/src/unpriv/cmo.adoc
@@ -1,11 +1,6 @@
 [[cmo]]
 === Cache Management Operations (CMOs)
 
-==== Pseudocode for instruction semantics
-
-The semantics of each instruction in the <<#insns>> chapter is expressed in a
-SAIL-like syntax.
-
 [#intro-cmo,reftext="Introduction"]
 ==== Introduction
 
@@ -29,23 +24,24 @@ block; these are known as _cache-block operation_ (CBO) instructions. Each
 of the above classes of instructions represents an extension in this
 specification:
 
-* The ext:zicbom[] extension defines a set of cache-block management instructions:
+* The extlink:zicbom[] extension defines a set of cache-block management instructions:
   insn:cbo.inval[], insn:cbo.clean[],  and insn:cbo.flush[]
-* The ext:zicboz[] extension defines a cache-block zero instruction: insn:cbo.zero[]
-* The ext:zicbop[] extension defines a set of cache-block prefetch instructions:
+* The extlink:zicboz[] extension defines a cache-block zero instruction: insn:cbo.zero[]
+* The extlink:zicbop[] extension defines a set of cache-block prefetch instructions:
   insn:prefetch.r[], insn:prefetch.w[], and insn:prefetch.i[]
 
 The execution behavior of the above instructions is also modified by CSR state
 added by this specification.
 
 The remainder of this chapter provides general background information on CMO
-instructions and describes each of the above ISA extensions.
+instructions and describes each of the above ISA extensions. The semantics of
+instructions is expressed in a SAIL-like syntax.
 
 [NOTE]
 ====
-_The term CMO encompasses all operations on caches or resources related to
+The term CMO encompasses all operations on caches or resources related to
 caches. The term CBO represents a subset of CMOs that operate only on cache
-blocks. The first CMO extensions only define CBOs._
+blocks. The first CMO extensions only define CBOs.
 ====
 
 [#background,reftext="Background"]
@@ -62,9 +58,9 @@ accelerator, I/O device, etc., that can access a given memory location.
 
 [NOTE]
 ====
-_A given agent may not be able to access all memory locations in a system, and
+A given agent may not be able to access all memory locations in a system, and
 two different agents may or may not be able to access the same set of memory
-locations._
+locations.
 ====
 
 A _load operation_ (or _store operation_) is performed by an agent to consume
@@ -81,10 +77,10 @@ cache instead of the memory location.
 
 [NOTE]
 ====
-_Load and store operations are decoupled from read and write transfers by
+Load and store operations are decoupled from read and write transfers by
 caches. For example, a load operation may be satisfied by a cache without
 performing a read transfer from memory, or a store operation may be satisfied by
-a cache that first performs a read transfer from memory._
+a cache that first performs a read transfer from memory.
 ====
 
 Caches organize copies of data into _cache blocks_, each of which represents a
@@ -98,8 +94,8 @@ a cache block shall be uniform throughout the system.#
 
 [NOTE]
 ====
-_In future CMO extensions, the requirement for a uniform cache block size may be
-relaxed._
+In future CMO extensions, the requirement for a uniform cache block size may be
+relaxed.
 ====
 
 Implementation techniques such as speculative execution or hardware prefetching
@@ -181,11 +177,11 @@ accessed by the load and store operations from the coherent agents.
 
 [NOTE]
 ====
-_An operation from a CBO instruction is defined to operate only on the copies of
+An operation from a CBO instruction is defined to operate only on the copies of
 a cache block that are cached in the caches accessible by the explicit memory
 accesses performed by the set of coherent agents. This includes copies of a
 cache block in caches that are accessed only indirectly by load and store
-operations, e.g. coherent instruction caches._
+operations, e.g. coherent instruction caches.
 ====
 
 The set of caches subject to the above mechanism form a _set of coherent
@@ -212,10 +208,10 @@ operations are performed by the agents in a set of coherent agents:
 
 [NOTE]
 ====
-_The above restrictions ensure that a "clean" copy of a cache block, fetched by
+The above restrictions ensure that a "clean" copy of a cache block, fetched by
 a read transfer from memory and unmodified by a store operation, cannot later
 overwrite the copy of the cache block in memory updated by a write transfer to
-memory from a non-coherent agent._
+memory from a non-coherent agent.
 ====
 
 A non-coherent agent may initiate a cache-block operation that operates on the
@@ -289,10 +285,10 @@ load. In particular, an additional condition is added to the Load Value Axiom:
 
 [NOTE]
 ====
-_The first three bullets describe the possible load values at different points
+The first three bullets describe the possible load values at different points
 in the global memory order relative to clean or flush operations. The final
 bullet implies that the load value may be produced by a non-coherent agent at
-any time._
+any time.
 ====
 
 ===== Traps
@@ -333,8 +329,8 @@ UNSPECIFIED.#
 
 [NOTE]
 ====
-_This specification assumes that the above constraints will typically be met for
-main memory regions and may be met for certain I/O regions._
+This specification assumes that the above constraints will typically be met for
+main memory regions and may be met for certain I/O regions.
 ====
 
 [NOTE]
@@ -367,11 +363,11 @@ bit and may either raise an exception or set the bit as required.#
 
 [NOTE]
 ====
-_The interaction between cache-block management instructions and instruction
-fetches will be specified in a future extension._
+The interaction between cache-block management instructions and instruction
+fetches will be specified in a future extension.
 
-_As implied by omission, a cache-block management instruction does not check the
-dirty bit and neither raises an exception nor sets the bit._
+As implied by omission, a cache-block management instruction does not check the
+dirty bit and neither raises an exception nor sets the bit.
 ====
 
 [#norm:cbz_access]#A cache-block zero instruction is permitted to access the specified cache block
@@ -398,14 +394,14 @@ value of _rs1_).#
 
 [NOTE]
 ====
-_Like a load or store instruction, a CMO instruction may or may not be permitted
+Like a load or store instruction, a CMO instruction may or may not be permitted
 to access a cache block based on the states of the csr::[mprv], csr::[mpv] and csr::[mpp] bits
 in csr:mstatus[] and the csr::[sum] and csr::[mxr] bits in csr:mstatus[], csr:sstatus[], and
-csr:vsstatus[]._
+csr:vsstatus[].
 
-_This specification expects that implementations will process cache-block
+This specification expects that implementations will process cache-block
 management instructions like store/AMO instructions, so store/AMO exceptions are
-appropriate for these instructions, regardless of the permissions required._
+appropriate for these instructions, regardless of the permissions required.
 ====
 
 ====== Address-Misaligned Exceptions
@@ -420,8 +416,8 @@ of trigger modules with respect to CMO instructions is UNSPECIFIED.
 
 [NOTE]
 ====
-_For the ext:zicbom[], ext:zicboz[], and ext:zicbop[] extensions, this specification recommends
-the following common trigger module behaviors:_
+For the ext:zicbom[], ext:zicboz[], and ext:zicbop[] extensions, this specification recommends
+the following common trigger module behaviors:
 
 * Type 6 address match triggers, i.e. csr:tdata1[type]=6 and csr:mcontrol6[select]=0,
   should be supported
@@ -437,8 +433,8 @@ the following common trigger module behaviors:_
   an address trigger should only match a memory access from a CBO instruction if
   csr:mcontrol6[size]=0
 
-_If the ext:zicbom[] extension is implemented, this specification recommends the
-following additional trigger module behaviors:_
+If the ext:zicbom[] extension is implemented, this specification recommends the
+following additional trigger module behaviors:
 
 * Implementing address match triggers should be optional
 
@@ -448,8 +444,8 @@ following additional trigger module behaviors:_
 * Memory accesses are considered to be stores, i.e. an address trigger matches
   only if csr:mcontrol6[store]=1
 
-_If the ext:zicboz extension is implemented, this specification recommends the
-following additional trigger module behaviors:_
+If the ext:zicboz extension is implemented, this specification recommends the
+following additional trigger module behaviors:
 
 * Implementing address match triggers should be mandatory
 
@@ -459,8 +455,8 @@ following additional trigger module behaviors:_
 * Memory accesses are considered to be stores, i.e. an address trigger matches
   only if csr:mcontrol6[store]=1
 
-_If the ext:zicbop[] extension is implemented, this specification recommends the
-following additional trigger module behaviors:_
+If the ext:zicbop[] extension is implemented, this specification recommends the
+following additional trigger module behaviors:
 
 * Implementing address match triggers should be optional
 
@@ -471,10 +467,10 @@ following additional trigger module behaviors:_
   implementation, i.e. whether an address trigger matches on these instructions
   when csr:mcontrol6[load]=1 or csr:mcontrol6[store]=1 is _implementation-specific_
 
-_This specification also recommends that the behavior of trigger modules with
+This specification also recommends that the behavior of trigger modules with
 respect to the ext:zicboz[] extension should be defined in version 1.0 of the debug
 architecture specification. The behavior of trigger modules with respect to the
-ext:zicbom[] and ext:zicbop[] extensions is expected to be defined in future extensions._
+ext:zicbom[] and ext:zicbop[] extensions is expected to be defined in future extensions.
 ====
 
 ====== Hypervisor Extension
@@ -500,8 +496,8 @@ trapping instruction.
 
 [NOTE]
 ====
-_As described in the hypervisor extension, a zero may be written into csr:mtinst[]
-or csr:htinst[] instead of the standard transformation defined above._
+As described in the hypervisor extension, a zero may be written into csr:mtinst[]
+or csr:htinst[] instead of the standard transformation defined above.
 ====
 
 ===== Effects on Constrained LR/SC Loops
@@ -515,17 +511,17 @@ guarantee provided by constrained LR/SC loops, as defined in the ext:Zalrsc[] ex
 
 [NOTE]
 ====
-_The above event has been added to accommodate cache coherence protocols that
+The above event has been added to accommodate cache coherence protocols that
 cannot distinguish between invalidations for stores and invalidations for
-cache-block management operations._
+cache-block management operations.
 
-_Aside from the above event, CMO instructions neither change the properties of
+Aside from the above event, CMO instructions neither change the properties of
 constrained LR/SC loops nor modify the eventuality guarantee provided by them.
 For example, executing a CMO instruction may cause a constrained LR/SC loop on
 any hart to fail periodically or may cause a unconstrained LR/SC sequence on the
 same hart to fail always. Additionally, executing a cache-block prefetch
 instruction does not impact the eventuality guarantee provided by constrained
-LR/SC loops executed on any hart._
+LR/SC loops executed on any hart.
 ====
 
 ===== Software Discovery
@@ -535,7 +531,7 @@ discovered by software:
 
 * The size of the cache block for management and prefetch instructions
 * The size of the cache block for zero instructions
-* CBIE support at each privilege level
+* csr::[cbie] support at each privilege level
 
 Other general cache characteristics may also be specified in the discovery
 mechanism.
@@ -543,36 +539,36 @@ mechanism.
 [#csr_state,reftext="Control and Status Register State"]
 ==== CSR controls for CMO instructions
 
-The x{csrname} registers control CBO instruction execution based on the current
+The csr:envcfg[] registers control CBO instruction execution based on the current
 privilege mode and the state of the appropriate CSRs, as detailed below.
 
 [[norm:cbo-inval]]
 A insn:cbo.inval[] instruction executes or raises either an illegal-instruction
 exception or a virtual-instruction exception based on the state of the
-csr:x{csrname}[cbie] fields:
+csr:envcfg[cbie] fields:
 
 [source,sail,subs="attributes+"]
 --
 
 // illegal-instruction exceptions
-if (((priv_mode != M) && (m{csrname}.CBIE == 00)) ||
-    ((priv_mode == U) && (s{csrname}.CBIE == 00)))
+if (((priv_mode != M) && (menvcfg.CBIE == 00)) ||
+    ((priv_mode == U) && (senvcfg.CBIE == 00)))
 {
   <raise illegal-instruction exception>
 }
 // virtual-instruction exceptions
-else if (((priv_mode == VS) && (h{csrname}.CBIE == 00)) ||
-         ((priv_mode == VU) && ((h{csrname}.CBIE == 00) || (s{csrname}.CBIE == 00))))
+else if (((priv_mode == VS) && (henvcfg.CBIE == 00)) ||
+         ((priv_mode == VU) && ((henvcfg.CBIE == 00) || (senvcfg.CBIE == 00))))
 {
   <raise virtual-instruction exception>
 }
 // execute instruction
 else
 {
-  if (((priv_mode != M) && (m{csrname}.CBIE == 01)) ||
-      ((priv_mode == U) && (s{csrname}.CBIE == 01)) ||
-      ((priv_mode == VS) && (h{csrname}.CBIE == 01)) ||
-      ((priv_mode == VU) && ((h{csrname}.CBIE == 01) || (s{csrname}.CBIE == 01))))
+  if (((priv_mode != M) && (menvcfg.CBIE == 01)) ||
+      ((priv_mode == U) && (senvcfg.CBIE == 01)) ||
+      ((priv_mode == VS) && (henvcfg.CBIE == 01)) ||
+      ((priv_mode == VU) && ((henvcfg.CBIE == 01) || (senvcfg.CBIE == 01))))
   {
     <execute CBO.INVAL and perform flush operation>
   }
@@ -587,36 +583,36 @@ else
 
 [NOTE]
 ====
-_Until a modified cache block has updated memory, a insn:cbo.inval[] instruction may
+Until a modified cache block has updated memory, a insn:cbo.inval[] instruction may
 expose stale data values in memory if the CSRs are programmed to perform an
 invalidate operation. This behavior may result in a security hole if lower
 privileged level software performs an invalidate operation and accesses
-sensitive information in memory._
+sensitive information in memory.
 
-_To avoid such holes, higher privileged level software must perform either a
+To avoid such holes, higher privileged level software must perform either a
 clean or flush operation on the cache block before permitting lower privileged
 level software to perform an invalidate operation on the block. Alternatively,
 higher privileged level software may program the CSRs so that insn:cbo.inval[]
-either traps or performs a flush operation in a lower privileged level._
+either traps or performs a flush operation in a lower privileged level.
 ====
 
 [[norm:cbo-clean_cbo-flush]]
 A insn:cbo.clean[] or insn:cbo.flush[] instruction executes or raises an illegal-instruction
 or virtual-instruction exception based on the state of the
-csr:x{csrname}[cbcfe] bits:
+csr:envcfg[cbcfe] bits:
 
 [source,sail,subs="attributes+"]
 --
 
 // illegal-instruction exceptions
-if (((priv_mode != M) && !m{csrname}.CBCFE) ||
-    ((priv_mode == U) && !s{csrname}.CBCFE))
+if (((priv_mode != M) && !menvcfg.CBCFE) ||
+    ((priv_mode == U) && !senvcfg.CBCFE))
 {
   <raise illegal-instruction exception>
 }
 // virtual-instruction exceptions
-else if (((priv_mode == VS) && !h{csrname}.CBCFE) ||
-         ((priv_mode == VU) && !(h{csrname}.CBCFE && s{csrname}.CBCFE)))
+else if (((priv_mode == VS) && !henvcfg.CBCFE) ||
+         ((priv_mode == VU) && !(henvcfg.CBCFE && senvcfg.CBCFE)))
 {
   <raise virtual-instruction exception>
 }
@@ -630,20 +626,20 @@ else
 
 [[norm:cbo-zero_basedon_xenvcfg-CBZE]]
 Finally, a insn:cbo.zero[] instruction executes or raises an illegal-instruction or
-virtual-instruction exception based on the state of the csr:x{csrname}[cbze] bits:
+virtual-instruction exception based on the state of the csr:envcfg[cbze] bits:
 
 [source,sail,subs="attributes+"]
 --
 
 // illegal-instruction exceptions
-if (((priv_mode != M) && !m{csrname}.CBZE) ||
-    ((priv_mode == U) && !s{csrname}.CBZE))
+if (((priv_mode != M) && !menvcfg.CBZE) ||
+    ((priv_mode == U) && !senvcfg.CBZE))
 {
   <raise illegal-instruction exception>
 }
 // virtual-instruction exceptions
-else if (((priv_mode == VS) && !h{csrname}.CBZE) ||
-         ((priv_mode == VU) && !(h{csrname}.CBZE && s{csrname}.CBZE)))
+else if (((priv_mode == VS) && !henvcfg.CBZE) ||
+         ((priv_mode == VU) && !(henvcfg.CBZE && senvcfg.CBZE)))
 {
   <raise virtual-instruction exception>
 }
@@ -656,23 +652,14 @@ else
 --
 
 [[norm:cbxe_unaffected]]
-The csr::[cbie]/csr::[cbcfe]/csr::[cbze] fields in each `x{csrname}` register do not affect the
-read and write behavior of the same fields in the other `x{csrname}` registers.
+The csr::[cbie]/csr::[cbcfe]/csr::[cbze] fields in each csr:envcfg[] register do not affect the
+read and write behavior of the same fields in the other csr:envcfg[] registers.
 
-Each `x{csrname}` register is WARL; however, software should determine the legal
+Each csr:envcfg[] register is WARL; however, software should determine the legal
 values from the execution environment discovery mechanism.
 
-[#extensions,reftext="Extensions"]
-==== Extensions
-
-CMO instructions are defined in the following extensions:
-
-* extlink:zicbom[]
-* extlink:zicboz[]
-* extlink:zicbop[]
-
 [[ext:zicbom]]
-===== ext:zicbom[] Extension for Cache-Block Management
+==== ext:zicbom[] Extension for Cache-Block Management
 
 Cache-block management instructions enable software running on a set of coherent
 agents to communicate with a set of non-coherent agents by performing one of the
@@ -701,12 +688,12 @@ visible to all non-coherent agents.
 
 [NOTE]
 ====
-_The ext:zicbom[] extension does not prohibit agents that fall outside of the above
+The ext:zicbom[] extension does not prohibit agents that fall outside of the above
 architectural definition; however, software cannot rely on the defined cache
-operations to have the desired effects with respect to those agents._
+operations to have the desired effects with respect to those agents.
 
-_Future extensions may define different sets of agents for the purposes of
-performance optimization._
+Future extensions may define different sets of agents for the purposes of
+performance optimization.
 ====
 
 These instructions operate on the cache block whose effective address is
@@ -741,13 +728,13 @@ The following instructions comprise the ext:zicbom[] extension:
 
 [NOTE]
 ====
-_Cache-block management instructions ignore cacheability attributes and operate
+Cache-block management instructions ignore cacheability attributes and operate
 on the cache block irrespective of the PMA cacheable attribute and any Page-Based
-Memory Type (PBMT) downgrade from cacheable to non-cacheable._
+Memory Type (PBMT) downgrade from cacheable to non-cacheable.
 ====
 
 [[ext:zicboz]]
-===== ext:zicboz[] Extension for Cache-Block Zero
+==== ext:zicboz[] Extension for Cache-Block Zero
 
 Cache-block zero instructions store zeros to the set of bytes corresponding to a
 cache block. An implementation may update the bytes in any order and with any
@@ -755,9 +742,9 @@ granularity and atomicity, including individual bytes.
 
 [NOTE]
 ====
-_Cache-block zero instructions store zeros independently of whether data from
+Cache-block zero instructions store zeros independently of whether data from
 the underlying memory locations are cacheable. In addition, this specification
-does not constrain how the bytes are written._
+does not constrain how the bytes are written.
 ====
 
 [#norm:cbo-zero_specified_block]#These instructions operate on the cache block, or the memory locations
@@ -782,7 +769,7 @@ The following instructions comprise the ext:zicboz[] extension:
 |===
 
 [[ext:zicbop]]
-===== ext:zicbop[] Extension for Cache-Block Prefetch
+==== ext:zicbop[] Extension for Cache-Block Prefetch
 
 Cache-block prefetch instructions are HINTs to the hardware to indicate that
 software intends to perform a particular type of memory access in the near
@@ -797,9 +784,9 @@ mechanisms.
 
 [NOTE]
 ====
-_Cache-block prefetch instructions are encoded as ORI instructions with rd equal
+Cache-block prefetch instructions are encoded as ORI instructions with rd equal
 to `0b00000`; however, for the purposes of effective address calculation, this
-field is also interpreted as imm[4:0] like a store instruction._
+field is also interpreted as imm[4:0] like a store instruction.
 ====
 
 The following instructions comprise the Zicbop extension:
@@ -862,10 +849,10 @@ agent executing the instruction.
 
 [NOTE]
 ====
-_When executing a insn:cbo.clean[] instruction, an implementation may instead perform
+When executing a insn:cbo.clean[] instruction, an implementation may instead perform
 a flush operation, since the result of that operation is indistinguishable from
 the sequence of performing a clean operation just before deallocating all cached
-copies in the set of coherent caches._
+copies in the set of coherent caches.
 ====
 
 [#insns-cbo_flush,reftext="Cache Block Flush"]
@@ -939,10 +926,10 @@ that computes the offset shall evaluate to zero.
 
 [NOTE]
 ====
-_When executing a insn:cbo.inval[] instruction, an implementation may instead perform
+When executing a insn:cbo.inval[] instruction, an implementation may instead perform
 a flush operation, since the result of that operation is indistinguishable from
 the sequence of performing a write transfer to memory just before performing an
-invalidate operation._
+invalidate operation.
 ====
 
 [#insns-cbo_zero,reftext="Cache Block Zero"]
@@ -1012,9 +999,9 @@ is likely to be accessed by an instruction fetch in the near future.
 
 [NOTE]
 ====
-_An implementation may opt to cache a copy of the cache block in a cache
+An implementation may opt to cache a copy of the cache block in a cache
 accessed by an instruction fetch in order to improve memory access latency, but
-this behavior is not required._
+this behavior is not required.
 ====
 
 [#insns-prefetch_r,reftext="Cache Block Prefetch for Data Read"]
@@ -1050,9 +1037,9 @@ is likely to be accessed by a data read (i.e. load) in the near future.
 
 [NOTE]
 ====
-_An implementation may opt to cache a copy of the cache block in a cache
+An implementation may opt to cache a copy of the cache block in a cache
 accessed by a data read in order to improve memory access latency, but this
-behavior is not required._
+behavior is not required.
 ====
 
 [#insns-prefetch_w,reftext="Cache Block Prefetch for Data Write"]
@@ -1088,7 +1075,7 @@ is likely to be accessed by a data write (i.e. store) in the near future.
 
 [NOTE]
 ====
-_An implementation may opt to cache a copy of the cache block in a cache
+An implementation may opt to cache a copy of the cache block in a cache
 accessed by a data write in order to improve memory access latency, but this
-behavior is not required._
+behavior is not required.
 ====


### PR DESCRIPTION
- Reduced the number of sections and its levels
- Unified the style of notes
- Removed '{csrname}' that is defined globally but used only in CMO