### PR TITLE
Tweak

### DIFF
--- a/src/unpriv/a-st-ext.adoc
+++ b/src/unpriv/a-st-ext.adoc
@@ -3,3 +3,24 @@
 
 The ext:a[] extension comprises the extlink:zalrsc[] and extlink:zaamo[] extensions,
 which are defined in the following sections.
+
+[NOTE]
+====
+The instructions in the ext:a[] extension can be used to provide sequentially
+consistent loads and stores, but this constrains hardware reordering of memory
+accesses more than necessary.
+
+A {cpp} sequentially consistent load can be implemented as an insn:lr[] with
+_aq_ set. However, the insn:lr[]/insn:sc[] eventual success guarantee may slow
+down concurrent loads from the same effective address.
+
+A sequentially consistent store can be implemented as an insn:amoswap[] that
+writes the old value to `x0` and has _rl_ set. However the superfluous load may
+impose ordering constraints that are unnecessary for this use case.
+
+Specific compilation conventions may require both the _aq_ and _rl_ bits to be
+set in either or both the insn:lr[] and insn:amoswap[] instructions.
+
+The extlink:zalasr[] extension provides load-acquire and store-release
+instructions without the aforementioned drawbacks.
+====

--- a/src/unpriv/zaamo.adoc
+++ b/src/unpriv/zaamo.adoc
@@ -79,24 +79,3 @@ the _acquire_ operation and insn:fence[rw,w] suffices to implement _release_,
 both imply additional unnecessary ordering as compared to AMOs with the
 corresponding _aq_ or _rl_ bit set.
 ====
-
-[NOTE]
-====
-The instructions in the ext:a[] extension can be used to provide sequentially
-consistent loads and stores, but this constrains hardware reordering of memory
-accesses more than necessary.
-
-A {cpp} sequentially consistent load can be implemented as an insn:lr[] with
-_aq_ set. However, the insn:lr[]/insn:sc[] eventual success guarantee may slow
-down concurrent loads from the same effective address.
-
-A sequentially consistent store can be implemented as an insn:amoswap[] that
-writes the old value to `x0` and has _rl_ set. However the superfluous load may
-impose ordering constraints that are unnecessary for this use case.
-
-Specific compilation conventions may require both the _aq_ and _rl_ bits to be
-set in either or both the insn:lr[] and insn:amoswap[] instructions.
-
-The ext:zalasr[] extension provides load-acquire and store-release instructions
-without the aforementioned drawbacks.
-====


### PR DESCRIPTION
A note at the end of Zaamo is about the whole A extension. This PR moved the note to the A section.