### PR TITLE
Clarify `mip` and `mie` register implementation and WARL field requirements

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1369,7 +1369,7 @@ which these interrupt trap conditions expressly depend (including `mip`,
 [[norm:intr_M_mode_highest_pri]]
 Interrupts to M-mode take priority over any interrupts to lower privilege modes.
 
-[#norm:mip_bits_wr_or_rdonly]#The `mip` register must always be implemented, 
+[#norm:mip_bits_wr_or_rdonly]#The `mip` register must always be implemented,
 but can contain read-only zeros in any position, indicating that interrupt is
 can never become pending.
 Each individual bit in register `mip` may be writable or may be read-only.#

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1370,7 +1370,7 @@ which these interrupt trap conditions expressly depend (including `mip`,
 Interrupts to M-mode take priority over any interrupts to lower privilege modes.
 
 [#norm:mip_bits_wr_or_rdonly]#The `mip` register must always be implemented,
-but can contain read-only zeros in any position, indicating that interrupt is
+but can contain read-only zeros in any position, indicating that interrupt
 can never become pending.
 Each individual bit in register `mip` may be writable or may be read-only.#
 [#norm:mip_bits_wr_op]#When bit _i_ in `mip` is writable, a pending interrupt _i_

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1369,13 +1369,17 @@ which these interrupt trap conditions expressly depend (including `mip`,
 [[norm:intr_M_mode_highest_pri]]
 Interrupts to M-mode take priority over any interrupts to lower privilege modes.
 
-[#norm:mip_bits_wr_or_rdonly]#Each individual bit in register `mip` may be writable or may be read-only.#
+[#norm:mip_bits_wr_or_rdonly]#The `mip` register must always be implemented, 
+but can contain read-only zeros in any position, indicating that interrupt is
+can never become pending.
+Each individual bit in register `mip` may be writable or may be read-only.#
 [#norm:mip_bits_wr_op]#When bit _i_ in `mip` is writable, a pending interrupt _i_
 can be cleared by writing 0 to this bit.#
 [#norm:mip_bits_rdonly_op]#If interrupt _i_ can become pending but bit _i_ in `mip` is read-only, the implementation must
 provide some other mechanism for clearing the pending interrupt.#
 
-[#norm:mie_bits_wr]#A bit in `mie` must be writable if the corresponding interrupt can ever become pending.#
+[#norm:mie_bits_wr]#The `mie` register must always be implemented.
+A bit in `mie` must be writable if the corresponding interrupt can ever become pending.#
 [#norm:mie_bits_rdonly0]#Bits of `mie` that are not writable must be read-only zero.#
 
 [#norm:mip_mie_std_enc_txt]#The standard portions (bits 15:0) of the `mip` and `mie` registers are


### PR DESCRIPTION
Clarify the implementation requirements for the `mip` and `mie` registers, specifying that `mip` can contain read-only zeros and that `mie` must always be implemented.