### PR TITLE
Update documentation for mstatus and mstatush registers

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -352,6 +352,11 @@ include::images/wavedrom/mstatusreg.edn[]
 .Additional machine-mode status (`mstatush`) register  for RV32.
 include::images/wavedrom/mstatushreg.edn[]
 
+The `mstatus` (and RV32 `mstatush`) registers must be implemented.  
+The single bit fields must be writable with both 0 and 1 unless
+specified otherwise (e.g. many fields are read-only zero when
+an associated extension is not implemented.)
+
 [[privstack]]
 ===== Privilege and Global Interrupt-Enable Stack in `mstatus` register
 
@@ -635,8 +640,10 @@ whether access-fault exceptions are raised due to PMAs or PMP.
 
 ===== Endianness Control in `mstatus` and `mstatush` Registers
 
-[#norm:mstatus_mstatush_xbe_warl]#The MBE, SBE, and UBE bits in `mstatus` and `mstatush` are *WARL* fields# that
+[#norm:mstatus_mstatush_xbe_warl]#The MBE, SBE, and UBE bits in `mstatus` and `mstatush` are *WARL* fields that
 control the endianness of memory accesses other than instruction fetches.
+Each may be read/write or read-only.#
+
 [#norm:endianness_inst_fetch_little]#Instruction fetches are always little-endian.#
 
 [[norm:mstatus_mbe_op]]

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -377,7 +377,7 @@ Higher-privilege-level code can use separate per-interrupt enable bits
 to disable selected higher-privilege-mode interrupts before ceding
 control to a lower-privilege mode.
 [#norm:mstatus_sie_spie_rdonly0]#MIE and MPIE must be writable.
-If supervisor mode is not implemented, then SIE and SPIE are read-only 0.;
+If supervisor mode is not implemented, then SIE and SPIE are read-only 0;
 otherwise they must be writable.#
 
 [NOTE]

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -352,7 +352,7 @@ include::images/wavedrom/mstatusreg.edn[]
 .Additional machine-mode status (`mstatush`) register  for RV32.
 include::images/wavedrom/mstatushreg.edn[]
 
-The `mstatus` (and RV32 `mstatush`) registers must be implemented.  
+The `mstatus` (and RV32 `mstatush`) registers must be implemented.
 The single bit fields must be writable with both 0 and 1 unless
 specified otherwise (e.g. many fields are read-only zero when
 an associated extension is not implemented.)

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -737,7 +737,8 @@ supervisor virtual-memory management operations. When TVM=1, attempts to
 read or write the `satp` CSR or execute an SFENCE.VMA or SINVAL.VMA
 instruction while executing in S-mode will raise an illegal-instruction
 exception. When TVM=0, these operations are permitted in S-mode. TVM is
-read-only 0 when S-mode is not supported or ; otherwise it must be writable.
+read-only 0 when S-mode is not supported or if `satp`.MODE is read-only 0;
+otherwise it must be writable.
 
 [NOTE]
 ====

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -333,7 +333,7 @@ of the largest hart ID used in a system.
 ==== Machine Status (`mstatus` and `mstatush`) Registers
 
 [#norm:mstatus_sz_acc]#The `mstatus` register is an MXLEN-bit read/write register formatted as
-shown in <<mstatusreg-rv32>> for RV32 and <<mstatusreg>> for RV64.#
+shown in <<mstatusreg-rv32>> for RV32 and <<mstatusreg>> for RV64. It must be implemented.#
 The `mstatus` register keeps track of and controls the hart’s current operating state. A
 restricted view of `mstatus` appears as the `sstatus` register in the S-level ISA.
 
@@ -351,11 +351,6 @@ include::images/wavedrom/mstatusreg.edn[]
 [[mstatushreg]]
 .Additional machine-mode status (`mstatush`) register  for RV32.
 include::images/wavedrom/mstatushreg.edn[]
-
-The `mstatus` (and RV32 `mstatush`) registers must be implemented.
-The single bit fields must be writable with both 0 and 1 unless
-specified otherwise (e.g. many fields are read-only zero when
-an associated extension is not implemented.)
 
 [[privstack]]
 ===== Privilege and Global Interrupt-Enable Stack in `mstatus` register
@@ -381,7 +376,9 @@ setting of the global __y__IE bit for the higher-privilege mode.#
 Higher-privilege-level code can use separate per-interrupt enable bits
 to disable selected higher-privilege-mode interrupts before ceding
 control to a lower-privilege mode.
-[#norm:mstatus_sie_spie_rdonly0]#If supervisor mode is not implemented, then SIE and SPIE are read-only 0.#
+[#norm:mstatus_sie_spie_rdonly0]#MIE and MPIE must be writable.
+If supervisor mode is not implemented, then SIE and SPIE are read-only 0.;
+otherwise they must be writable.#
 
 [NOTE]
 ====
@@ -600,7 +597,7 @@ and store memory addresses are translated and protected, and endianness
 is applied, as though the current privilege mode were set to MPP.#
 [#norm:mstatus_mprv_inst_xlat_op]#Instruction address-translation and protection are unaffected by the
 setting of MPRV.#
-[#norm:mstatus_mprv_rdonly0_no_umode]#MPRV is read-only 0 if U-mode is not supported.#
+[#norm:mstatus_mprv_rdonly0_no_umode]#MPRV is read-only 0 if U-mode is not supported; otherwise it must be writable.#
 
 [#norm:mstatus_mprv_clr_mret_sret_less_priv]#An MRET or SRET instruction that changes the privilege mode to a mode
 less privileged than M also sets MPRV=0.#
@@ -609,7 +606,7 @@ The MXR (Make eXecutable Readable) bit modifies the privilege with which loads a
 [#norm:mstatus_mxr_op]#When MXR=0, only loads from pages marked readable (R=1 in <<sv32pte>>) will succeed.
 When MXR=1, loads from pages marked either readable or executable (R=1 or
 X=1) will succeed.  MXR has no effect when page-based virtual memory is not in effect.#
-[#norm:mstatus_mxr_rdonly0_no_smode]#MXR is read-only 0 if S-mode is not supported.#
+[#norm:mstatus_mxr_rdonly0_no_smode]#MXR is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise it must be writable.#
 
 [NOTE]
 ====
@@ -631,7 +628,7 @@ privilege with which S-mode loads and stores access virtual memory.
 [#norm:mstatus_sum_op_no-vm]#SUM has no effect when page-based virtual memory is not in effect.#
 Note that, [#norm:mstatus_sum_op_mprv_mpp]#while SUM is ordinarily ignored when not
 executing in S-mode, it _is_ in effect when MPRV=1 and MPP=S.#
-[#norm:mstatus_sum_rdonly0]#SUM is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0.#
+[#norm:mstatus_sum_rdonly0]#SUM is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise it must be writable.#
 
 [[norm:mstatus_mxr_sum_op_acc_fault]]
 The MXR and SUM mechanisms only affect the interpretation of permissions
@@ -740,7 +737,7 @@ supervisor virtual-memory management operations. When TVM=1, attempts to
 read or write the `satp` CSR or execute an SFENCE.VMA or SINVAL.VMA
 instruction while executing in S-mode will raise an illegal-instruction
 exception. When TVM=0, these operations are permitted in S-mode. TVM is
-read-only 0 when S-mode is not supported.
+read-only 0 when S-mode is not supported or ; otherwise it must be writable.
 
 [NOTE]
 ====
@@ -765,7 +762,8 @@ an illegal-instruction exception.#
 raise an illegal-instruction exception in modes less privileged than M when
 TW=1, even if there are pending globally-disabled interrupts when the
 instruction is executed.#
-[#norm:mstatus_tw_acc]#TW is read-only 0 when there are no modes less privileged than M.#
+[#norm:mstatus_tw_acc]#TW is read-only 0 when there are no modes less privileged than M;
+otherwise it must be writable.#
 
 [NOTE]
 ====
@@ -782,7 +780,8 @@ supervisor exception return instruction, SRET.#
 [#norm:mstatus_tsr_op]#When TSR=1, attempts to
 execute SRET while executing in S-mode will raise an illegal-instruction
 exception. When TSR=0, this operation is permitted in S-mode.#
-[#norm:mstatus_tsr_acc]#TSR is read-only 0 when S-mode is not supported.#
+[#norm:mstatus_tsr_acc]#TSR is read-only 0 when S-mode is not supported or if `satp`.MODE is read-only 0;
+otherwise it must be writable.#
 
 [NOTE]
 ====

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -781,7 +781,7 @@ supervisor exception return instruction, SRET.#
 [#norm:mstatus_tsr_op]#When TSR=1, attempts to
 execute SRET while executing in S-mode will raise an illegal-instruction
 exception. When TSR=0, this operation is permitted in S-mode.#
-[#norm:mstatus_tsr_acc]#TSR is read-only 0 when S-mode is not supported or if `satp`.MODE is read-only 0;
+[#norm:mstatus_tsr_acc]#TSR is read-only 0 when S-mode is not supported;
 otherwise it must be writable.#
 
 [NOTE]

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -333,7 +333,7 @@ of the largest hart ID used in a system.
 ==== Machine Status (`mstatus` and `mstatush`) Registers
 
 [#norm:mstatus_sz_acc]#The `mstatus` register is an MXLEN-bit read/write register formatted as
-shown in <<mstatusreg-rv32>> for RV32 and <<mstatusreg>> for RV64. It must be implemented.#
+shown in <<mstatusreg-rv32>> for RV32 and <<mstatusreg>> for RV64. `mstatus` must be implemented.#
 The `mstatus` register keeps track of and controls the hart’s current operating state. A
 restricted view of `mstatus` appears as the `sstatus` register in the S-level ISA.
 
@@ -378,7 +378,7 @@ to disable selected higher-privilege-mode interrupts before ceding
 control to a lower-privilege mode.
 [#norm:mstatus_sie_spie_rdonly0]#MIE and MPIE must be writable.
 If supervisor mode is not implemented, then SIE and SPIE are read-only 0;
-otherwise they must be writable.#
+otherwise, they must be writable.#
 
 [NOTE]
 ====
@@ -597,7 +597,7 @@ and store memory addresses are translated and protected, and endianness
 is applied, as though the current privilege mode were set to MPP.#
 [#norm:mstatus_mprv_inst_xlat_op]#Instruction address-translation and protection are unaffected by the
 setting of MPRV.#
-[#norm:mstatus_mprv_rdonly0_no_umode]#MPRV is read-only 0 if U-mode is not supported; otherwise it must be writable.#
+[#norm:mstatus_mprv_rdonly0_no_umode]#MPRV is read-only 0 if U-mode is not supported; otherwise, it must be writable.#
 
 [#norm:mstatus_mprv_clr_mret_sret_less_priv]#An MRET or SRET instruction that changes the privilege mode to a mode
 less privileged than M also sets MPRV=0.#
@@ -606,7 +606,7 @@ The MXR (Make eXecutable Readable) bit modifies the privilege with which loads a
 [#norm:mstatus_mxr_op]#When MXR=0, only loads from pages marked readable (R=1 in <<sv32pte>>) will succeed.
 When MXR=1, loads from pages marked either readable or executable (R=1 or
 X=1) will succeed.  MXR has no effect when page-based virtual memory is not in effect.#
-[#norm:mstatus_mxr_rdonly0_no_smode]#MXR is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise it must be writable.#
+[#norm:mstatus_mxr_rdonly0_no_smode]#MXR is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise, it must be writable.#
 
 [NOTE]
 ====
@@ -628,7 +628,7 @@ privilege with which S-mode loads and stores access virtual memory.
 [#norm:mstatus_sum_op_no-vm]#SUM has no effect when page-based virtual memory is not in effect.#
 Note that, [#norm:mstatus_sum_op_mprv_mpp]#while SUM is ordinarily ignored when not
 executing in S-mode, it _is_ in effect when MPRV=1 and MPP=S.#
-[#norm:mstatus_sum_rdonly0]#SUM is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise it must be writable.#
+[#norm:mstatus_sum_rdonly0]#SUM is read-only 0 if S-mode is not supported or if `satp`.MODE is read-only 0; otherwise, it must be writable.#
 
 [[norm:mstatus_mxr_sum_op_acc_fault]]
 The MXR and SUM mechanisms only affect the interpretation of permissions
@@ -738,7 +738,7 @@ read or write the `satp` CSR or execute an SFENCE.VMA or SINVAL.VMA
 instruction while executing in S-mode will raise an illegal-instruction
 exception. When TVM=0, these operations are permitted in S-mode. TVM is
 read-only 0 when S-mode is not supported or if `satp`.MODE is read-only 0;
-otherwise it must be writable.
+otherwise, it must be writable.
 
 [NOTE]
 ====
@@ -764,7 +764,7 @@ raise an illegal-instruction exception in modes less privileged than M when
 TW=1, even if there are pending globally-disabled interrupts when the
 instruction is executed.#
 [#norm:mstatus_tw_acc]#TW is read-only 0 when there are no modes less privileged than M;
-otherwise it must be writable.#
+otherwise, it must be writable.#
 
 [NOTE]
 ====
@@ -782,7 +782,7 @@ supervisor exception return instruction, SRET.#
 execute SRET while executing in S-mode will raise an illegal-instruction
 exception. When TSR=0, this operation is permitted in S-mode.#
 [#norm:mstatus_tsr_acc]#TSR is read-only 0 when S-mode is not supported;
-otherwise it must be writable.#
+otherwise, it must be writable.#
 
 [NOTE]
 ====


### PR DESCRIPTION
Clarify requirements for `mstatus` and `mstatush` registers regarding implementation and writable bit fields per #2975.

Aimed for concise summary rather than per-field specification.