### PR TITLE
Clarify that WRS interrupt interaction matches WFI

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2733,7 +2733,7 @@ the hart must resume if a locally enabled interrupt becomes pending,
 even if it has been delegated to a less-privileged mode), but should
 honor the individual interrupt enables (e.g, MTIE) (i.e.,
 implementations should avoid resuming the hart if the interrupt is
-pending but not individually enabled). WFI is also required to resume
+pending but not locally enabled). WFI is also required to resume
 execution for locally enabled interrupts pending at any privilege level,
 regardless of the global interrupt enable at each privilege level.#
 

--- a/src/unpriv/zawrs.adoc
+++ b/src/unpriv/zawrs.adoc
@@ -45,7 +45,9 @@ insn:lr[] instruction, which is provided by the ext:zalrsc[] component of the ex
 
 The insn:wrs.nto[] and insn:wrs.sto[] instructions cause the hart to temporarily stall
 execution in a low-power state as long as the reservation set is valid and no
-pending interrupts, even if disabled, are observed. For insn:wrs.sto[] the stall
+locally enabled interrupts at any privilege level are pending,
+regardless of the global interrupt enable at each privilege level.
+For insn:wrs.sto[] the stall
 duration is bounded by an implementation defined short timeout. These
 instructions are available in all privilege modes.
 
@@ -66,13 +68,13 @@ Hart execution may be stalled while the following conditions are all satisfied:
 [loweralpha]
     . The reservation set is valid
     . If insn:wrs.sto[], a "short" duration since start of stall has not elapsed
-    . No pending interrupt is observed (see the rules below)
+    . No locally enabled interrupt at any privilege level is pending (see the rules below)
 
 [#norm:Zawrs_stall_terminate]#While stalled, an implementation is permitted to occasionally terminate the
 stall and complete execution for any reason.#
 
 [#norm:Zawrs_exec_resume_rules]#insn:wrs.nto[] and insn:wrs.sto[] instructions follow the rules of the insn:wfi[] instruction
-for resuming execution on a pending  interrupt.#
+for resuming execution on a locally enabled pending interrupt.#
 
 [#norm:Zawrs_priv_illegal_instr_excp]#When the csr::[tw] (timeout wait) bit in csr:mstatus[] is set and insn:wrs.nto[] is executed
 in any privilege mode other than M-mode, and it does not complete within an


### PR DESCRIPTION
The Zawrs spec already says that the WRS instructions follow WFI's rules for resumption upon interrupts, but the surrounding language suggests something different (that they need only be pending, not locally enabled).  Resolve this contradiction by changing the language to match that of WFI.

Note that implementations that resolve this contradiction in the opposite direction are technically still correct, since it is valid to break out of the WRS stall for any reason.