### PR TITLE
Use {asterisk} in macros

### DIFF
--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -382,7 +382,7 @@ XLEN>32, insn:fcvt.w.s[] and insn:fcvt.wu.s[] sign-extend the 32-bit result to t
 [#norm:fcvt_unrepresentable_nv]#If the rounded result is not representable in the
 destination format, it is clipped to the nearest value and the invalid
 flag is set#. [#norm:fcvt_int_float_valid_input]#<<int_conv>> gives the range of valid inputs
-for insn:fcvt.*.s[] and the behavior for invalid inputs#.
+for insn:fcvt.{asterisk}.s[] in the ext:f[] extension and the behavior for invalid inputs#.
 (((floating-point, conversion)))
 
 [[norm:fcvt_round]]

--- a/src/unpriv/rationale.adoc
+++ b/src/unpriv/rationale.adoc
@@ -82,7 +82,7 @@ operation.
 The A-extension offers atomic memory operation (AMO) instructions for _words_,
 _doublewords_, and _quadwords_ (only for insn:amocas[]). The absence of atomic
 operations for subword data types necessitates emulation strategies. For bitwise
-operations, this emulation can be performed via word-sized bitwise insn:amo*[]
+operations, this emulation can be performed via word-sized bitwise insn:amo{asterisk}[]
 instructions. For non-bitwise operations, emulation is achievable using
 word-sized insn:lr[]/insn:sc[] instructions.
 
@@ -92,10 +92,10 @@ Several limitations arise from this emulation approach:
   configurations, emulation based on insn:lr[]/insn:sc[] introduces issues related to
   scalability and fairness, particularly under conditions of high contention.
 
-. Emulation of narrower AMOs through wider insn:amo*[] instructions on non-idempotent
+. Emulation of narrower AMOs through wider insn:amo{asterisk}[] instructions on non-idempotent
   IO memory regions may result in unintended side effects.
 
-. Utilizing wider insn:amo*[] instructions for emulating narrower AMOs risks activating
+. Utilizing wider insn:amo{asterisk}[] instructions for emulating narrower AMOs risks activating
   extraneous breakpoints or watchpoints.
 
 . In the absence of native support for subword atomics, compilers often resort

--- a/src/unpriv/zabha.adoc
+++ b/src/unpriv/zabha.adoc
@@ -5,7 +5,7 @@ The ext:zaamo[] and ext:zacas[] extensions offer atomic memory operation (AMO) i
 _doublewords_, and _quadwords_ (only for insn:amocas[]). The absence of atomic
 operations for subword data types necessitates emulation strategies. For bitwise
 operations, this emulation can be performed via word-sized bitwise
-insn:amo*[] instructions. For non-bitwise operations, emulation is achievable using
+insn:amo{asterisk}[] instructions. For non-bitwise operations, emulation is achievable using
 word-sized insn:lr[]/insn:sc[] instructions.
 
 Several limitations arise from this emulation approach:
@@ -14,10 +14,10 @@ Several limitations arise from this emulation approach:
   configurations, emulation based on insn:lr[]/insn:sc[] introduces issues related to
   scalability and fairness, particularly under conditions of high contention.
 
-. Emulation of narrower AMOs through wider insn:amo*[] instructions on non-idempotent
+. Emulation of narrower AMOs through wider insn:amo{asterisk}[] instructions on non-idempotent
   IO memory regions may result in unintended side effects.
 
-. Utilizing wider insn:amo*[] instructions for emulating narrower AMOs risks activating
+. Utilizing wider insn:amo{asterisk}[] instructions for emulating narrower AMOs risks activating
   extraneous breakpoints or watchpoints.
 
 . In the absence of native support for subword atomics, compilers often resort

--- a/src/unpriv/zc.adoc
+++ b/src/unpriv/zc.adoc
@@ -16,7 +16,7 @@ The extlink:zcd[] extension adds double-precision floating-point loads and
 stores.
 The extlink:c[] extension combines ext:zca[], ext:zcf[] if XLEN=32 and the F extension
 is present, and ext:zcd[] if the D extension is present.
-Various additional ext:Zc*[] extensions are also defined.
+Various additional ext:zc{asterisk}[] extensions are also defined.
 
 include::zca.adoc[]
 include::zcf.adoc[]

--- a/src/unpriv/zicclsm.adoc
+++ b/src/unpriv/zicclsm.adoc
@@ -7,7 +7,7 @@ to main memory regions with both the coherence and cacheability PMAs must be
 supported.
 
 NOTE: This definition includes vector memory accesses.
-It does not include any instructions in the various ext:Za*[] extensions.
+It does not include any instructions in the various ext:za{asterisk}[] extensions.
 
 NOTE: Even though mandated, misaligned loads and stores might execute
 extremely slowly.

--- a/src/unpriv/ztso.adoc
+++ b/src/unpriv/ztso.adoc
@@ -37,7 +37,7 @@ stores can be forwarded locally before they are visible to other harts.
 ====
 
 [#norm:ztso_vect_mem]#Additionally, if the ext:ztso[] extension is implemented, then vector memory
-instructions in the ext:v[] extension and ext:zve*[] family of extensions follow RVTSO at
+instructions in the ext:v[] extension and ext:zve{asterisk}[] family of extensions follow RVTSO at
 the instruction level.#
 The ext:ztso[] extension does not strengthen the ordering of intra-instruction
 element accesses.


### PR DESCRIPTION
The raw `*` may or may not be interpreted as `<strong>...</strong>`, `<li>...</li>` or the character itself, depending on context. For safety, instead of playing with asciidoctor and insert backslash where necessary, let's use `{asterisk}` where the character itself is needed. I did the conversion for macros since I did the markup so it was easy to me to spot where asterisks are used. There are other instances too, but no rush. Let's do it for the rest later.