### PR TITLE
Clarify norm:fcvt_int_float_valid_input

### DIFF
--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -398,7 +398,7 @@
     "norm:Zacas_amocas_mem_op_success_aq_rl": "The memory operation performed by an\ninsn:amocas.w/d/q[], when successful, has acquire semantics if aq bit is 1 and has\nrelease semantics if rl bit is 1.",
     "norm:Zacas_amocas_mem_op_fail_aq_rl": "The memory operation performed by an\ninsn:amocas.w/d/q[], when not successful, has acquire semantics if aq bit is 1 but\ndoes not have release semantics, regardless of rl.",
     "norm:Zacas_amocas_w_permission": "An insn:amocas.w/d/q[] instruction always requires write permissions.",
-    "norm:zama16b_mag": "If the ext:zama16b[] extension is implemented, then the\n&lt;&lt;sec:misaligned-atomicity-granule,misaligned atomicity granule&gt;&gt;\nin main memory regions with both the coherence and cacheability PMAs is 16 bytes.",
+    "norm:norm:zama16b_mag": "If the ext:zama16b[] extension is implemented, then the\n&lt;&lt;sec:misaligned-atomicity-granule,misaligned atomicity granule&gt;&gt;\nin main memory regions with both the coherence and cacheability PMAs is 16 bytes.",
     "norm:zama16b_atomic_ops": "Misaligned loads, stores and AMOs to those regions that do not cross a naturally\naligned 16-byte boundary are atomic.",
     "norm:f_ieee_compliance": "computational instructions\ncompliant with the IEEE 754-2008 arithmetic standard's binary32 format and\noperations.",
     "norm:f_depends_zicsr": "The ext:f[] extension depends on the\next:zicsr[] extension.",
@@ -440,7 +440,7 @@
     "norm:fcvt-wu-s_fcvt-lu-s_fcvt-s-wu_fcvt-s-lu_op": "insn:fcvt.wu.s[], insn:fcvt.lu.s[], insn:fcvt.s.wu[],\nand insn:fcvt.s.lu[] variants convert to or from unsigned integer values. For\nXLEN&gt;32, insn:fcvt.w.s[] and insn:fcvt.wu.s[] sign-extend the 32-bit result to the destination register width",
     "norm:fcvt_long_float_rv64_only": "insn:fcvt.l.s[], insn:fcvt.lu.s[], insn:fcvt.s.l[] and insn:fcvt.s.lu[] are RV64-only instructions",
     "norm:fcvt_unrepresentable_nv": "If the rounded result is not representable in the\ndestination format, it is clipped to the nearest value and the invalid\nflag is set",
-    "norm:fcvt_int_float_valid_input": "&lt;&lt;int_conv&gt;&gt; gives the range of valid inputs\nfor insn:fcvt.*.s[] and the behavior for invalid inputs",
+    "norm:fcvt_int_float_valid_input": "&lt;&lt;int_conv&gt;&gt; gives the range of valid inputs\nfor insn:fcvt.w.s[], insn:fcvt.wu.s[], insn:fcvt.l.s[] and insn:fcvt.lu.s[] and\nthe behavior of these instructions for invalid inputs",
     "norm:fcvt_round": "All floating-point to integer and integer to floating-point conversion instructions round according to the rm field. A floating-point register can be initialized to floating-point positive zero using insn:fcvt.s.w[rd,x0], which will never set any exception flags.",
     "norm:fcvt_nx": "All floating-point conversion instructions set the Inexact exception flag if the rounded result differs from the operand value and the Invalid exception flag is not set.",
     "norm:fsgnj-s_fsgnjn-s_fsgnjx-s_op": "Floating-point to floating-point sign-injection instructions, insn:fsgnj.s[],\ninsn:fsgnjn.s[] and insn:fsgnjx.s[], produce a result that takes all bits except the\nsign bit from rs1. For insn:fsgnj[], the result's sign bit is rs2's sign\nbit; for insn:fsgnjn[], the result's sign bit is the opposite of rs2's sign\nbit; and for insn:fsgnjx[], the sign bit is the XOR of the sign bits of rs1\nand rs2. Sign-injection instructions do not set floating-point\nexception flags, nor do they canonicalize NaNs",
@@ -796,7 +796,7 @@
     "norm:zip_enc": "Encoding",
     "norm:zip_op": "Operation",
     "norm:elen": "The maximum size in bits of a vector element that any operation can produce or consume, ELEN {ge} 8, which\nmust be a power of 2.",
-    "norm:vlen": "The number of bits in a single vector register, VLEN {ge} ELEN, which must be a power of 2, and must be no greater than 2^16^.",
+    "norm:vlen": "The number of bits in a single vector register, VLEN {ge} 8, which must be a power of 2, and must be no greater than 2^16^.",
     "norm:vreg_count": "The vector extension adds 32 architectural vector registers, v0-v31 to the base scalar RISC-V ISA.",
     "norm:mstatus_vs_sstatus_vs_op": "A vector context status field, VS, is added to mstatus[10:9] and shadowed in sstatus[10:9].  It is defined analogously to the floating-point context status field, FS.",
     "norm:mstatus_vs_op_off": "Attempts to execute any vector instruction, or to access the vector CSRs, raise an illegal-instruction exception when mstatus.VS is set to Off.",
@@ -816,9 +816,9 @@
     "norm:vtype_vsew_op": "The value in vsew sets the dynamic selected element width (SEW).  By default, a vector register is viewed as being divided into VLEN/SEW elements.",
     "norm:vtype_vsew_rsv": "While it is anticipated the larger vsew[2:0] encodings\n(100-111) will be used to encode larger SEW, the encodings are\nformally reserved at this point.",
     "norm:vtype_lmul_val": "Implementations must support LMUL integer values of\n1, 2, 4, and 8.",
-    "norm:vtype_lmul_fval": "Implementations must provide fractional LMUL settings that allow the narrowest supported type to occupy a fraction of a vector register corresponding to the ratio of the narrowest supported type&#8217;s width to that of the largest supported type&#8217;s width.  In general, the requirement is to support LMUL ≥ SEWMIN/ELEN, where SEWMIN is the narrowest supported SEW value and ELEN is the widest supported SEW value.  In the standard extensions, SEWMIN=8.  For standard vector extensions with ELEN=32, fractional LMULs of 1/2 and 1/4 must be supported.  For standard vector extensions with ELEN=64, fractional LMULs of 1/2, 1/4, and 1/8 must be supported.",
-    "norm:vtype_sew_val": "For a given supported fractional LMUL setting, implementations must support SEW settings between SEWMIN and LMUL * ELEN, inclusive.",
-    "norm:vtype_lmul_fval_rsv": "The use of vtype encodings with LMUL &lt; SEWMIN/ELEN is reserved, but implementations can set vill if they do not support these configurations.",
+    "norm:vtype_lmul_fval": "Implementations must provide fractional LMUL settings that allow the narrowest supported type to occupy a fraction of a vector register corresponding to the ratio of the narrowest supported type&#8217;s width to the smaller of VLEN and the largest supported type&#8217;s width. In general, the requirement is to support LMUL ≥ SEWMIN/min(ELEN, VLEN), where SEWMIN is the narrowest supported SEW value, ELEN is the widest supported SEW value and VLEN is the number of bits in a vector register. In the standard extensions, SEWMIN=8.  For vector extensions with ELEN=32, fractional LMULs of 1/2 and 1/4 must be supported.  For vector extensions with ELEN=64 and ELEN ≤ VLEN, fractional LMULs of 1/2, 1/4, and 1/8 must be supported. For vector extensions with SEWMIN=8, ELEN=64 and VLEN=32, fractional LMULs of 1/2 and 1/4 must be supported.",
+    "norm:vtype_sew_val": "For a given supported fractional LMUL setting, implementations must support SEW settings between SEWMIN and LMUL * min(ELEN, VLEN), inclusive.",
+    "norm:vtype_lmul_fval_rsv": "The use of vtype encodings with LMUL &lt; SEWMIN/min(ELEN, VLEN) is reserved, but implementations can set vill if they do not support these configurations.",
     "norm:lmul": "LMUL is set by the signed vlmul field in vtype (i.e., LMUL = 2vlmul[2:0]).",
     "norm:vlmax": "The derived value VLMAX = LMUL*VLEN/SEW represents the maximum number of elements that can be operated on with a single vector instruction given the current SEW and LMUL settings as shown in the table below.",
     "norm:vreg_offgroup_lmul2_rsv": "Instructions specifying an LMUL=2 vector register group\nwith an odd-numbered vector register are reserved.",
@@ -864,7 +864,7 @@
     "norm:vreg_overlap_rsv": "Any instruction encoding that violates the overlap constraints is reserved.",
     "norm:vreg_overlap_agn": "When source and destination registers overlap and have different EEW, the instruction is mask- and tail-agnostic, regardless of the setting of the vta and vma bits in vtype.",
     "norm:emul_rsv": "The largest vector register group used by an instruction can not be greater than 8 vector registers (i.e., EMUL≤8), and if a vector instruction would require greater than 8 vector registers in a group, the instruction encoding is reserved.  For example, a widening operation that produces a widened vector register group result when LMUL=8 is reserved as this would imply a result EMUL=16.",
-    "norm:vreg_scalar_emul": "Widened scalar values, e.g., input and output to a widening reduction operation, are held in the first element of a vector register and have EMUL=1.",
+    "norm:vreg_scalar_emul": "Widened scalar values, e.g., input and output to a widening reduction operation, are held in the first element of a vector register and have EMUL=1. If an implementation supports EEW &gt; VLEN, EEW-wide widened scalar values are held in a vector register group with EMUL = EEW/VLEN.",
     "norm:vmask_inactive_op": "Element operations\nthat are masked off (inactive) never generate exceptions.",
     "norm:vmask_agn_op": "The\ndestination vector register elements corresponding to masked-off\nelements are handled with either a mask-undisturbed or mask-agnostic\npolicy depending on the setting of the vma bit in vtype",
     "norm:vreg_vmask": "The mask value used to control execution of a masked vector instruction is always supplied by vector register v0.",
@@ -916,7 +916,7 @@
     "norm:vector_ls_ins_req": "Implementations must provide vector loads and stores with EEWs corresponding to all supported SEW settings.",
     "norm:vector_ls_ins_rsv": "Vector load/store encodings for unsupported EEW widths are reserved.",
     "norm:vector_ls_mew_rsv": "The mew bit (inst[28]) when set is expected to be used to encode expanded memory sizes of 128 bits and above, but these encodings are currently reserved.",
-    "norm:vector_ls_unit_stride_mask": "Additional unit-stride mask load and store instructions are provided to transfer mask values to/from memory.  These operate similarly to unmasked byte loads or stores (EEW=8), except that the effective vector length is evl=ceil(vl/8) (i.e. EMUL=1), and the destination register is always written with a tail-agnostic policy.",
+    "norm:vector_ls_unit_stride_mask": "Additional unit-stride mask load and store instructions are provided to transfer mask values to/from memory.  These operate similarly to unmasked byte loads or stores (EEW=8), except that the effective vector length is evl = ceil(vl/8) (i.e. EMUL=1), and the destination register is always written with a tail-agnostic policy.",
     "norm:vector_ls_neg_zero_stride": "Negative and zero strides are supported.",
     "norm:vector_ls_constant_stride_unordered": "Element accesses within a constant-stride instruction are unordered with respect to each other.",
     "norm:vector_ls_constant_stride_x0": "When rs2=x0, then an implementation is allowed, but not required, to perform fewer memory operations than the number of active elements, and may perform different numbers of memory operations across different dynamic executions of the same static instruction.",
@@ -946,7 +946,7 @@
     "norm:vector_ls_seg_indexed_eew_emul_op": "The data vector register group has EEW=SEW, EMUL=LMUL, while the index vector register group has EEW encoded in the instruction with EMUL=(EEW/SEW)*LMUL.",
     "norm:vector_ls_seg_indexed_emul_nfields_val": "The EMUL * NFIELDS ≤ 8 constraint applies to the data vector register group.",
     "norm:vector_ls_seg_indexed_vreg_rsv": "For vector indexed segment loads, the destination vector register groups cannot overlap the source vector register group (specified by vs2), else the instruction encoding is reserved.",
-    "norm:vector_ls_seg_wholereg_eew": "The load instructions have an EEW encoded in the mew and width fields following the pattern of regular unit-stride loads.",
+    "norm:vector_ls_seg_wholereg_eew": "The load instructions have the element width encoded in the mew and width fields following the pattern of regular unit-stride loads. EEW is computed as EEW=min(VLEN*NFIELDS, EEW_encoded).",
     "norm:vector_ls_seg_wholereg_op": "NFIELDS\nindicates the number of vector registers to transfer, numbered\nsuccessively after the base.",
     "norm:vector_ls_seg_wholereg_nf_rsv": "Only NFIELDS values of 1, 2, 4, 8 are\nsupported, with other values reserved.",
     "norm:vector_ls_seg_wholereg_op_cont": "When multiple registers are\ntransferred, the lowest-numbered vector register is held in the\nlowest-numbered memory addresses and successive vector register\nnumbers are placed contiguously in memory.",
@@ -1077,8 +1077,8 @@
     "norm:vfwcvt_vreg_constr": "These instructions have the same constraints on vector register overlap\nas other widening instructions (see &lt;&lt;sec-widening&gt;&gt;).",
     "norm:vfncvt_op": "A set of conversion instructions is provided to convert wider integer\nand floating-point datatypes to a type of half the width.",
     "norm:vfncvt_vreg_constr": "These instructions have the same constraints on vector register overlap\nas other narrowing instructions (see &lt;&lt;sec-narrowing&gt;&gt;).",
-    "norm:vreduction_scalar_def": "Vector reduction operations take a vector register group of elements\nand a scalar held in element 0 of a vector register, and perform a\nreduction using some binary operator, to produce a scalar result in\nelement 0 of a vector register.",
-    "norm:vreduction_scalar_disregard_LMUL": "The scalar input and output operands\nare held in element 0 of a single vector register, not a vector\nregister group, so any vector register can be the scalar source or\ndestination of a vector reduction regardless of LMUL setting.",
+    "norm:vreduction_scalar_def": "Vector reduction operations take a vector register group of elements\nand a scalar held in element 0 of a vector register group, and perform a\nreduction using some binary operator, to produce a scalar result in\nelement 0 of a vector register group.",
+    "norm:vreduction_scalar_disregard_LMUL": "The scalar input and output operands\nare held in element 0 of a group with EMUL = ceil(EEW/VLEN), regardless of LMUL setting.",
     "norm:vreduction_vd_overlap_vs": "The destination vector register can overlap the source operands,\nincluding the mask register.",
     "norm:vreduction_scalar_disregard_maskval": "Inactive elements from the source vector register group are excluded\nfrom the reduction, but the scalar operand is always included\nregardless of the mask values.",
     "norm:vreduction_tail_policy": "The other elements in the destination vector register ( 0 &lt; index &lt;\nVLEN/SEW) are considered the tail and are managed with the current\ntail agnostic/undisturbed policy.",
@@ -1145,13 +1145,13 @@
     "norm:vid_vs2_nv0_rsv": "The vs2 field of the instruction must be set to v0, otherwise the\nencoding is reserved.",
     "norm:vid_op_zext": "The result value is zero-extended to fill the destination element if\nSEW is wider than the result.",
     "norm:vid_op_overflow": "If the result value would overflow the\ndestination SEW, the least-significant SEW bits are retained.",
-    "norm:vmv-x-s_vmv-s-x_ignoreLMUL": "The instructions ignore LMUL and vector register groups.",
+    "norm:vmv-x-s_vmv-s-x_ignoreLMUL": "The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).",
     "norm:vmv-x-s_op": "The vmv.x.s instruction copies a single SEW-wide element from index 0 of the\nsource vector register to a destination integer register.  If SEW &gt; XLEN, the\nleast-significant XLEN bits are transferred and the upper SEW-XLEN bits are\nignored.  If SEW &lt; XLEN, the value is sign-extended to XLEN bits.",
     "norm:vmv-x-s_vstartgevl_vl0": "vmv.x.s performs its operation even if vstart {ge} vl or vl=0.",
-    "norm:vmv-s-x_op": "The vmv.s.x instruction copies the scalar integer register to element 0 of\nthe destination vector register.  If SEW &lt; XLEN, the least-significant bits\nare copied and the upper XLEN-SEW bits are ignored.  If SEW &gt; XLEN, the value\nis sign-extended to SEW bits.  The other elements in the destination vector\nregister ( 0 &lt; index &lt; VLEN/SEW) are treated as tail elements using the current tail agnostic/undisturbed policy.",
+    "norm:vmv-s-x_op": "The vmv.s.x instruction copies the scalar integer register to element 0 of\nthe destination vector register group with EMUL = ceil(EEW/VLEN).\nIf SEW &lt; XLEN, the least-significant bits\nare copied and the upper XLEN-SEW bits are ignored.  If SEW &gt; XLEN, the value\nis sign-extended to SEW bits.  The other elements in the destination vector\nregister ( 0 &lt; index &lt; VLEN/SEW) are treated as tail elements using the current tail agnostic/undisturbed policy.",
     "norm:vmv-s-x_vstart_ge_vl": "If vstart {ge} vl, no\noperation is performed and the destination register is not updated.",
     "norm:vmv-s-x_vmv-x-s_masked_rsv": "The encodings corresponding to the masked versions (vm=0) of vmv.x.s\nand vmv.s.x are reserved.",
-    "norm:vfmv-f-s_vfmv-s-f_ignoreLMUL": "The instructions ignore LMUL and vector register groups.",
+    "norm:vfmv-f-s_vfmv-s-f_ignoreLMUL": "#The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).",
     "norm:vfmv-f-s_op": "The vfmv.f.s instruction copies a single SEW-wide element from index\n0 of the source vector register to a destination scalar floating-point\nregister.",
     "norm:vfmv-s-f_op": "The vfmv.s.f instruction copies the scalar floating-point register\nto element 0 of the destination vector register.  The other elements\nin the destination vector register ( 0 &lt; index &lt; VLEN/SEW) are treated\nas tail elements using the current tail agnostic/undisturbed policy.",
     "norm:vfmv-s-f_vstart_ge_vl": "If vstart {ge} vl, no operation is performed and the destination\nregister is not updated.",
@@ -1188,7 +1188,7 @@
     "norm:vcompress_vreg_constr": "The destination vector register group cannot overlap the source vector\nregister group or the source mask register, otherwise the instruction\nencoding is reserved.",
     "norm:vcompress_trap": "A trap on a vcompress instruction is always reported with a\nvstart of 0.",
     "norm:vcompress_vstart_n0_ill": "Executing a vcompress instruction with a non-zero\nvstart raises an illegal-instruction exception.",
-    "norm:vmv-nr-r_op": "The vmv&lt;nr&gt;r.v instructions copy whole vector registers (i.e., all\nVLEN bits) and can copy whole vector register groups.  The nr value\nin the opcode is the number of individual vector registers, NREG, to\ncopy.  The instructions operate as if EEW=SEW, EMUL = NREG, effective\nlength evl= EMUL * VLEN/SEW.",
+    "norm:vmv-nr-r_op": "The vmv&lt;nr&gt;r.v instructions copy whole vector registers (i.e., all\nVLEN bits) and can copy whole vector register groups.  The nr value\nin the opcode is the number of individual vector registers, NREG, to\ncopy.  The instructions operate as if EMUL = NREG, EEW = min(VLEN*EMUL, SEW), and effective\nlength evl = EMUL * VLEN/EEW.",
     "norm:vmv-nr-r_enc": "The instruction is encoded as an OPIVI instruction.  The number of\nvector registers to copy is encoded in the low three bits of the\nsimm field (simm[2:0]) using the same encoding as the nf[2:0] field for memory\ninstructions (Figure &lt;&lt;fig-nf&gt;&gt;), i.e., simm[2:0] = NREG-1.",
     "norm:vmv-nr-r_nreg_rsv": "The value of NREG must be 1, 2, 4, or 8, and values of simm[4:0]\nother than 0, 1, 3, and 7 are reserved.",
     "norm:vmv-nr-r_vreg_constr": "The source and destination vector register numbers must be aligned\nappropriately for the vector register group size,",
@@ -2141,6 +2141,7 @@
     "norm:senvcfg_sse_Zicfilp": "The Zicfiss extension adds the SSE field in senvcfg. When the SSE field is set to 1, the Zicfiss extension is activated in VU/U-mode. When the SSE field is 0, the Zicfiss extension remains inactive in VU/U-mode, and the following rules apply:",
     "norm:satp": "The satp CSR is an SXLEN-bit read/write register, formatted as shown in  for SXLEN=32 and  for SXLEN=64, which controls supervisor-mode address translation and protection. This register holds the physical page number (PPN) of the root page table, i.e., its supervisor physical address divided by 4 KiB; an address space identifier (ASID), which facilitates address-translation fences on a per-address-space basis; and the MODE field, which selects the current address-translation scheme. Further details on the access to this register are described in .",
     "norm:satp_mode": "shows the encodings of the MODE field when SXLEN=32 and SXLEN=64. When MODE=Bare, supervisor virtual addresses are equal to supervisor physical addresses, and there is no additional memory protection beyond the physical memory protection scheme described in . To select MODE=Bare, software must write zero to the remaining fields of satp (bits 30–0 when SXLEN=32, or bits 59–0 when SXLEN=64). Attempting to select MODE=Bare with a nonzero pattern in the remaining fields has an UNSPECIFIED effect on the value that the remaining fields assume and an UNSPECIFIED effect on address translation and protection behavior.",
+    "norm:svbare_satp_mode_bare": "If an implementation supports the Svbare extension, then the satp\nregister's MODE field must be capable of holding the value Bare.",
     "norm:satp_mode_sxlen32": "When SXLEN=32, the only other valid setting for MODE is Sv32, a paged virtual-memory scheme described in .",
     "norm:satp_mode_sxlen64": "When SXLEN=64, three paged virtual-memory schemes are defined: Sv39, Sv48, and Sv57, described in , , and , respectively. One additional scheme, Sv64, will be defined in a later version of this specification. The remaining MODE settings are reserved for future use and may define different interpretations of the other fields in satp.",
     "norm:satp_mode_op_unsupported": "Implementations are not required to support all MODE settings, and if satp is written with an unsupported MODE, the entire write has no effect; no fields in satp are modified.",
@@ -2169,6 +2170,7 @@
     "norm:fetch_page_fault_no_x": "Attempting to fetch an instruction from a page that does not have\nexecute permissions raises a fetch page-fault exception.",
     "norm:load_page_fault_no_r": "Attempting to execute a load, load-reserved, or cache-block management\ninstruction whose effective address lies\nwithin a page without read permissions raises a load page-fault exception.",
     "norm:store_page_fault_no_w": "Attempting to execute a store, store-conditional, AMO, or cache-block zero instruction\ninstruction whose effective address lies within a page without write\npermissions raises a store page-fault exception.",
+    "norm:svade_access_ad_bit_clear": "The Svade extension: when a virtual page is accessed and the A bit is\nclear, or is written and the D bit is clear, a page-fault exception is\nraised.",
     "norm:Sv39_sxlen": "simple paged virtual-memory system for\nSXLEN=64",
     "norm:Sv39_va_sz": "supports 39-bit virtual address spaces",
     "norm:Sv39_va_signext": "must have bits 63–39 all equal to bit 38, or else\na page-fault exception will occur",
@@ -2872,6 +2874,15 @@
     "norm:Ssqosid_smstateen_srmcfg_requires_mstateen0": "If extension Smstateen is implemented together with Ssqosid, then Ssqosid also\nrequires the SRMCFG bit in mstateen0 to be implemented.",
     "norm:Ssqosid_srmcfg_access_illegal_instruction": "If mstateen0.SRMCFG is 0, attempts to access srmcfg in privilege modes\nless privileged than M-mode raise an illegal-instruction exception.",
     "norm:Ssqosid_srmcfg_access_virtual_instruction": "If mstateen0.SRMCFG is 1 or if extension Smstateen is not implemented,\nattempts to access srmcfg when V=1 raise a virtual-instruction exception.",
+    "norm:ssu64xl_uxl_sstatus": "If the Ssu64xl extension is implemented, then sstatus.UXL must be capable of holding the value 2 (i.e., UXLEN=64 must be supported).",
+    "norm:ssccptr_memory_pte_reads": "If the Ssccptr extension is implemented, then main memory regions with both the cacheability and coherence PMAs must support hardware page-table reads.",
+    "norm:sstvecd_stvec_mode_direct": "If the Sstvecd extension is implemented, then stvec.MODE must be capable of holding the value 0 (Direct).",
+    "norm:sstvecd_stvec_base_aligned_address": "Furthermore, when stvec.MODE=Direct, stvec.BASE must be capable of holding any valid four-byte-aligned address.",
+    "norm:sstvala_stval_faulting_vaddr": "If the Sstvala extension is implemented, then stval must be written with the faulting virtual address for load, store, and instruction page-fault, access-fault, and misaligned exceptions, and for breakpoint exceptions that are defined to write an address to stval, other than those caused by execution of the EBREAK or C.EBREAK instructions.",
+    "norm:sstvala_stval_faulting_instruction": "For virtual-instruction and illegal-instruction exceptions, stval must be written with the faulting instruction.",
+    "norm:sscounterenw_hpmcounter_scounteren": "If the Sscounterenw extension is implemented, then for any hpmcounter that is not read-only zero, the corresponding bit in scounteren must be writable.",
+    "norm:ssstrict_no_nonconforming_extensions": "If the Ssstrict extension is implemented, then no non-conforming extensions are present.",
+    "norm:ssstrict_unimplemented_opcodes_csr_exception": "Furthermore, attempts to execute unimplemented opcodes or access unimplemented CSRs in the standard or reserved encoding spaces raises an illegal instruction exception that results in a contained trap to the supervisor-mode trap handler.",
     "norm:sstc_purpose": "This extension serves to provide supervisor mode with its own CSR-based timer\ninterrupt facility that it can directly manage to provide its own timer service\n(in the form of having its own stimecmp register) - thus eliminating the large\noverheads for emulating S/HS-mode timers and timer interrupt generation up in\nM-mode.",
     "norm:sstc_vs_facility": "Further, this extension adds a similar facility to the Hypervisor\nextension for VS-mode.",
     "norm:stimecmp_exist": "This extension adds the S-level stimecmp\nCSR (&lt;&lt;stimecmp&gt;&gt;)",
@@ -2894,7 +2905,15 @@
     "norm:menvcfg_DTE": "The Ssdbltrp extension adds the menvcfg.DTE (See &lt;&lt;sec:menvcfg&gt;&gt;)",
     "norm:sstatus_SDT": "and the\nsstatus.SDT fields (See &lt;&lt;sstatus&gt;&gt;).",
     "norm:henvcfg_DTE": "If the hypervisor extension is\nadditionally implemented, then the extension adds the henvcfg.DTE (See\n&lt;&lt;sec:henvcfg&gt;&gt;)",
-    "norm:vsstatus_SDT": "and the vsstatus.SDT fields (See &lt;&lt;vsstatus&gt;&gt;)."
+    "norm:vsstatus_SDT": "and the vsstatus.SDT fields (See &lt;&lt;vsstatus&gt;&gt;).",
+    "norm:shvstvecd_vstvec_mode_direct": "If the Shvstvecd extension is implemented, then vstvec.MODE must be capable of holding the value 0 (Direct).",
+    "norm:shvstvecd_vstvec_base_aligned_address": "Furthermore, when vstvec.MODE=Direct, vstvec.BASE must be capable of holding any valid four-byte-aligned address.",
+    "norm:shcounterenw_hpmcounter_hcounteren": "If the Shcounterenw extension is implemented, then for any hpmcounter that is not read-only zero, the corresponding bit in hcounteren must be writable.",
+    "norm:shvstvala_vstval_written": "If the Shvstvala extension is implemented, vstval must be written in all cases described in  for stval.",
+    "norm:shtvala_htval_faulting_gpa": "If the Shtvala extension is implemented, htval must be written with the faulting guest physical address in all circumstances permitted by the ISA.",
+    "norm:shvsatpa_satp_vsatp_modes": "If the Shvsatpa extension is implemented, all translation modes supported in satp must be supported in vsatp.",
+    "norm:shgatpa_satp_hgatp_mode_support": "If the Shgatpa extension is implemented, then for each supported virtual memory scheme SvNN supported in satp, the corresponding hgatp SvNNx4 mode must be supported.",
+    "norm:shgatpa_hgatp_bare_mode": "Furthermore, the hgatp mode Bare must also be supported."
   },
   "sections": {
     "title": "",
@@ -4246,7 +4265,7 @@
                 "id": "ext:zama16b",
                 "children": [],
                 "tags": [
-                  "norm:zama16b_mag",
+                  "norm:norm:zama16b_mag",
                   "norm:zama16b_atomic_ops"
                 ]
               }
@@ -9035,6 +9054,12 @@
             "tags": []
           },
           {
+            "title": "Matrix Extensions",
+            "id": "matrix",
+            "children": [],
+            "tags": []
+          },
+          {
             "title": "ISA Extension Naming Conventions",
             "id": "naming",
             "children": [
@@ -10956,6 +10981,7 @@
                     "tags": [
                       "norm:satp",
                       "norm:satp_mode",
+                      "norm:svbare_satp_mode_bare",
                       "norm:satp_mode_sxlen32",
                       "norm:satp_mode_sxlen64",
                       "norm:satp_mode_op_unsupported",
@@ -11018,7 +11044,8 @@
                       "norm:satp_ppn_sv32_sz",
                       "norm:fetch_page_fault_no_x",
                       "norm:load_page_fault_no_r",
-                      "norm:store_page_fault_no_w"
+                      "norm:store_page_fault_no_w",
+                      "norm:svade_access_ad_bit_clear"
                     ]
                   },
                   {
@@ -12659,37 +12686,52 @@
                 "title": "Ssu64xl Extension for UXLEN=64 Support, Version 1.0",
                 "id": "ssu64xl",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:ssu64xl_uxl_sstatus"
+                ]
               },
               {
                 "title": "Ssccptr Extension for Main Memory Page-Table Reads, Version 1.0",
                 "id": "ssccptr",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:ssccptr_memory_pte_reads"
+                ]
               },
               {
                 "title": "Sstvecd Extension for Direct Trap Vectoring, Version 1.0",
                 "id": "sstvecd",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:sstvecd_stvec_mode_direct",
+                  "norm:sstvecd_stvec_base_aligned_address"
+                ]
               },
               {
                 "title": "Sstvala Extension for Trap Value Reporting, Version 1.0",
                 "id": "sstvala",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:sstvala_stval_faulting_vaddr",
+                  "norm:sstvala_stval_faulting_instruction"
+                ]
               },
               {
                 "title": "Sscounterenw Extension for Counter-Enable Writability, Version 1.0",
                 "id": "sscounterenw",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:sscounterenw_hpmcounter_scounteren"
+                ]
               },
               {
                 "title": "Ssstrict Extension for Extension Conformance, Version 1.0",
                 "id": "ssstrict",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:ssstrict_no_nonconforming_extensions",
+                  "norm:ssstrict_unimplemented_opcodes_csr_exception"
+                ]
               },
               {
                 "title": "\"Sstc\" Extension for Supervisor-mode Timer Interrupts, Version 1.0",
@@ -12760,37 +12802,51 @@
                 "title": "Shvstvecd Extension for Direct Trap Vectoring, Version 1.0",
                 "id": "shvstvecd",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shvstvecd_vstvec_mode_direct",
+                  "norm:shvstvecd_vstvec_base_aligned_address"
+                ]
               },
               {
                 "title": "Shcounterenw Extension for Counter-Enable Writability, Version 1.0",
                 "id": "shcounterenw",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shcounterenw_hpmcounter_hcounteren"
+                ]
               },
               {
                 "title": "Shvstvala Extension for Trap Value Reporting, Version 1.0",
                 "id": "shvstvala",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shvstvala_vstval_written"
+                ]
               },
               {
                 "title": "Shtvala Extension for Trap Value Reporting, Version 1.0",
                 "id": "shtvala",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shtvala_htval_faulting_gpa"
+                ]
               },
               {
                 "title": "Shvsatpa Extension for Translation Mode Support, Version 1.0",
                 "id": "shvsatpa",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shvsatpa_satp_vsatp_modes"
+                ]
               },
               {
                 "title": "Shgatpa Extension for Translation Mode Support, Version 1.0",
                 "id": "shgatpa",
                 "children": [],
-                "tags": []
+                "tags": [
+                  "norm:shgatpa_satp_hgatp_mode_support",
+                  "norm:shgatpa_hgatp_bare_mode"
+                ]
               },
               {
                 "title": "Sha Augmented Hypervisor Extension",

--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -381,8 +381,10 @@ XLEN>32, insn:fcvt.w.s[] and insn:fcvt.wu.s[] sign-extend the 32-bit result to t
 [#norm:fcvt_long_float_rv64_only]#insn:fcvt.l.s[], insn:fcvt.lu.s[], insn:fcvt.s.l[] and insn:fcvt.s.lu[] are RV64-only instructions#.
 [#norm:fcvt_unrepresentable_nv]#If the rounded result is not representable in the
 destination format, it is clipped to the nearest value and the invalid
-flag is set#. [#norm:fcvt_int_float_valid_input]#<<int_conv>> gives the range of valid inputs
-for insn:fcvt.*.s[] and the behavior for invalid inputs#.
+flag is set#.
+[#norm:fcvt_int_float_valid_input]#<<int_conv>> gives the range of valid inputs
+for insn:fcvt.w.s[], insn:fcvt.wu.s[], insn:fcvt.l.s[] and insn:fcvt.lu.s[] and
+the behavior of these instructions for invalid inputs#.
 (((floating-point, conversion)))
 
 [[norm:fcvt_round]]


### PR DESCRIPTION
The current sentence edited by me accidentally introduce the ambiguity that FCVT.D.S might be affected by norm:fcvt_int_float_valid_input. This PR clarifies that FCVT.W[U].S and FCVT.L[U].S are affected by the rule.

By the way, the `<<int_conv>>` table itself is not in any Normative Rules if I understand correctly. Is it OK for certification documents?