### PR TITLE
Reorganize NormRules of PMA-related extensions from profiles

### DIFF
--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1316,14 +1316,8 @@ normative_rule_definitions:
     tag: "norm:pma_amo_zacas_req_arith"
   - name: pma_amo_zabha_req
     tag: "norm:pma_amo_zabha_req"
-  - name: ziccamoa_pma_amo_req
-    tags: ["norm:ziccamoa_pma_amo_req", "norm:ziccamoa_amo_pma"]
-  - name: ziccamoc_pma_amo_req
-    tags: ["norm:ziccamoc_pma_amo_req", "norm:ziccamoc_casq_pma"]
   - name: pma_rsrv_levels
     tag: "norm:pma_rsrv_levels"
-  - name: ziccrse_pma_rsrv_req
-    tags: ["norm:ziccrse_pma_rsrv_req", "norm:ziccrse_rsrv_eventual"]
   - name: pma_mag_def
     tag: "norm:pma_mag_def"
   - name: pma_mag_insts
@@ -1348,8 +1342,6 @@ normative_rule_definitions:
     tag: "norm:pma_mag_op_vec"
   - name: pma_mag_op_implicit
     tag: "norm:pma_mag_op_implicit"
-  - name: zama16b_pma_mag_req
-    tags: ["norm:zama16b_pma_mag_req", "norm:norm:zama16b_mag"]
   - name: pma_mo_io_chan_0
     tags: [{name: "norm:pma_mo_io_chan_def", context: true}, "norm:pma_mo_io_chan_0"]
   - name: pma_mo_io_chan_1

--- a/normative_rule_defs/zama.yaml
+++ b/normative_rule_defs/zama.yaml
@@ -7,5 +7,8 @@ chapter_name: Zama16b Extension for 16-byte Misaligned Atomicity
 
 normative_rule_definitions:
 
+  - name: zama16b_pma_mag_req
+    tags: ["norm:zama16b_pma_mag_req", "norm:zama16b_mag"]
+
   - name: zama16b_atomic_ops
     tags: ["norm:zama16b_atomic_ops"]

--- a/normative_rule_defs/ziccamoa.yaml
+++ b/normative_rule_defs/ziccamoa.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=../docs-resources/schemas/defs-schema.json
+
+$schema: "../docs-resources/schemas/defs-schema.json#"
+
+chapter_name: Ziccamoa Extension for Main Memory Atomics
+
+normative_rule_definitions:
+
+  - name: ziccamoa_pma_amo_req
+    tags: ["norm:ziccamoa_pma_amo_req", "norm:ziccamoa_amo_pma"]

--- a/normative_rule_defs/ziccamoc.yaml
+++ b/normative_rule_defs/ziccamoc.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=../docs-resources/schemas/defs-schema.json
+
+$schema: "../docs-resources/schemas/defs-schema.json#"
+
+chapter_name: Ziccamoc Extension for Main Memory Compare-and-Swap
+
+normative_rule_definitions:
+
+  - name: ziccamoc_pma_amo_req
+    tags: ["norm:ziccamoc_pma_amo_req", "norm:ziccamoc_casq_pma"]

--- a/normative_rule_defs/ziccrse.yaml
+++ b/normative_rule_defs/ziccrse.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=../docs-resources/schemas/defs-schema.json
+
+$schema: "../docs-resources/schemas/defs-schema.json#"
+
+chapter_name: Ziccrse Extension for Main Memory Reservability
+
+normative_rule_definitions:
+
+  - name: ziccrse_pma_rsrv_req
+    tags: ["norm:ziccrse_pma_rsrv_req", "norm:ziccrse_rsrv_eventual"]

--- a/src/unpriv/zama.adoc
+++ b/src/unpriv/zama.adoc
@@ -1,7 +1,7 @@
 [[ext:zama16b]]
 === ext:zama16b[] Extension for 16-byte Misaligned Atomicity
 
-[#norm:norm:zama16b_mag]#If the ext:zama16b[] extension is implemented, then the
+[#norm:zama16b_mag]#If the ext:zama16b[] extension is implemented, then the
 <<sec:misaligned-atomicity-granule,misaligned atomicity granule>>
 in main memory regions with both the coherence and cacheability PMAs is 16 bytes.#
 [#norm:zama16b_atomic_ops]#Misaligned loads, stores and AMOs to those regions that do not cross a naturally


### PR DESCRIPTION
I had added some rules in machine.yaml but after reviewing <https://github.com/riscv/riscv-isa-manual/pull/2991> I thought they should have been placed on dedicated files. This PR did so.

Personally I think these NormRules are redundant but they stay as-is in this PR.

cc @jordancarlin @mmhus