### PR TITLE
Add symbols for em and en dashes

### DIFF
--- a/src/symbols.adoc
+++ b/src/symbols.adoc
@@ -16,3 +16,9 @@
 :pm: ±
 :rightarrow: →
 :asterisk: &#42;
+// https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
+// https://github.com/asciidoctor/asciidoctor/issues/1578
+:emdash: &#8212;&#8203;
+// https://en.wikipedia.org/wiki/Template:Non_breaking_en_dash
+// https://github.com/asciidoctor/asciidoctor/issues/1174
+:endash: &#8205;&#8211;&#8205;


### PR DESCRIPTION
On AsciiDoc, in some context, `--` is replaced with an em dash (—) as specified in <https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/>. However, currently asciidoctor has caveats as described in <https://github.com/asciidoctor/asciidoctor/issues/1578>. AsciiDoc has no similar replacement substitutions for en dash (–). This PR adds `{emdash}` and `{endash}` for convenience.