### PR TITLE
Rearrange the description of floating-point register state

### DIFF
--- a/src/unpriv/d-st-ext.adoc
+++ b/src/unpriv/d-st-ext.adoc
@@ -14,13 +14,6 @@ depends on the ext:f[] extension.
 either 32-bit or 64-bit floating-point values as described below in
 <<nanboxing>>.
 
-(((floating-point, supported precisions)))
-[NOTE]
-====
-FLEN can be 32, 64, or 128 depending on which of the ext:f[], ext:d[], and
-ext:q[] extensions are supported. There can be up to four different
-floating-point precisions supported, including H, F, D, and Q.
-====
 [[nanboxing]]
 ==== NaN Boxing of Narrower Values
 [[norm:fp_nan-boxing]]

--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -6,77 +6,10 @@ floating-point, which adds [#norm:f_ieee_compliance]#computational instructions
 compliant with the IEEE 754-2008 arithmetic standard's binary32 format and
 operations.# [#norm:f_depends_zicsr]#The ext:f[] extension depends on the
 ext:zicsr[] extension.#
+[#norm:flen]#The ext:f[] extension adds 32 floating-point registers, `f0`-`f31`,
+each 32 bits wide (FLEN=32 in <<fprs>>)#.
 
-==== ext:f[] Register State
-
-[#norm:flen]#The ext:f[] extension adds 32 floating-point registers, `f0`-`f31`, each 32
-bits wide#, and a floating-point control and status register csr:fcsr[],
-which contains the operating mode and exception status of the
-floating-point unit. This additional state is shown in
-<<fprs>>. We use the term FLEN to describe the width of
-the floating-point registers in the RISC-V ISA, and FLEN=32 for the
-ext:f[] single-precision floating-point extension. Most floating-point
-instructions operate on values in the floating-point register file.
-Floating-point load and store instructions transfer floating-point
-values between registers and memory. Instructions to transfer values to and from the integer register file are also provided.
-
-[NOTE]
-====
-We considered a unified register file for both integer and
-floating-point values as this simplifies software register allocation
-and calling conventions, and reduces total user state. However, a split
-organization increases the total number of registers accessible with a
-given instruction width, simplifies provision of enough register file ports
-for wide superscalar issue, supports decoupled floating-point-unit
-architectures, and simplifies use of internal floating-point encoding
-techniques. Compiler support and calling conventions for split register
-file architectures are well understood, and using dirty bits on
-floating-point register file state can reduce context-switch overhead.
-====
-
-[[fprs]]
-.RISC-V standard ext:f[] extension single-precision floating-point state
-[cols="<,^,>",options="header",width="50%",align="center",grid="rows"]
-|===
-| [.small]#FLEN-1#| >| [.small]#0#
-3+^| [.small]#f0#
-3+^| [.small]#f1#
-3+^| [.small]#f2#
-3+^| [.small]#f3#
-3+^| [.small]#f4#
-3+^| [.small]#f5#
-3+^| [.small]#f6#
-3+^| [.small]#f7#
-3+^| [.small]#f8#
-3+^| [.small]#f9#
-3+^| [.small]#f10#
-3+^| [.small]#f11#
-3+^| [.small]#f12#
-3+^| [.small]#f13#
-3+^| [.small]#f14#
-3+^| [.small]#f15#
-3+^| [.small]#f16#
-3+^| [.small]#f17#
-3+^| [.small]#f18#
-3+^| [.small]#f19#
-3+^| [.small]#f20#
-3+^| [.small]#f21#
-3+^| [.small]#f22#
-3+^| [.small]#f23#
-3+^| [.small]#f24#
-3+^| [.small]#f25#
-3+^| [.small]#f26#
-3+^| [.small]#f27#
-3+^| [.small]#f28#
-3+^| [.small]#f29#
-3+^| [.small]#f30#
-3+^| [.small]#f31#
-3+^| [.small]#FLEN#
-| [.small]#31#| >| [.small]#0#
-3+^|  [.small]#fcsr#
-3+^| [.small]#32#
-|===
-
+[[sec:fcsr]]
 ==== Floating-Point Control and Status Register
 
 [[norm:fcsr_op_sz_acc]]

--- a/src/unpriv/rationale.adoc
+++ b/src/unpriv/rationale.adoc
@@ -12,6 +12,18 @@ the rationale will be added over time.
 In cases where the rationale was not recorded, the authors and editors will
 synthesize it from the historical record.
 
+=== ext:f[], ext:d[], and ext:q[] Extensions for Floating-Point
+
+We considered a unified register file for both integer and floating-point values
+as this simplifies software register allocation and calling conventions, and
+reduces total user state. However, a split organization increases the total
+number of registers accessible with a given instruction width, simplifies
+provision of enough register file ports for wide superscalar issue, supports
+decoupled floating-point-unit architectures, and simplifies use of internal
+floating-point encoding techniques. Compiler support and calling conventions for
+split register file architectures are well understood, and using dirty bits on
+floating-point register file state can reduce context-switch overhead.
+
 === ext:zihintpause[] Extension for Pause Hint
 
 The insn:pause[] instruction hints to a hart that it should temporarily reduce its

--- a/src/unpriv/zf.adoc
+++ b/src/unpriv/zf.adoc
@@ -10,14 +10,14 @@ instructions for computation on single-precision floating-point values.
 The extlink:d[] and extlink:q[] extensions widen those registers to
 hold double- and quad-precision floating-point values, respectively, and add
 instructions for computation on those formats.
-Several additional extensions with the ext:zf[] and ext:zd[] prefixes provide
+Several additional extensions with the ext:zf[] prefix provide
 additional computational instructions.
 
-The extlink:zfinx[] and extlink:zdinx[] extensions add
-computational instructions analogous to those in the ext:f[] and ext:d[] extensions,
-but they instead operate on floating-point numbers in the `x` registers.
-These extensions, intended for lower-cost systems, are incompatible with the
-ext:f[] and ext:d[] extensions.
+The extlink:zfinx[] and extlink:zdinx[] extensions add computational
+instructions analogous to those in the ext:f[] and ext:d[] extensions, but they
+instead operate on floating-point numbers in the `x` registers. These extensions,
+intended for lower-cost systems, are incompatible with the ext:f[] and ext:d[]
+extensions.
 
 :sectnums!:
 [discrete]
@@ -47,6 +47,77 @@ While the BF16 cite:[bfloat16], E4M3, and E5M2 formats are not defined in IEEE
 754-2008, the structure and operations of these formats are compatible with the
 standard. E4M3 and E5M2 are specified by the Open Compute Project (OCP) as the
 OCP FP8 (OFP8) formats cite:[ocp-fp8].
+
+:sectnums!:
+[discrete]
+=== Floating-Point Register State
+:sectnums:
+
+The ext:f[], ext:d[], and ext:q[] standard extensions use 32 floating-point
+registers, `f0`-`f31`, and a floating-point CSR, csr:fcsr[], that contains the
+operating mode and exception status of the floating-point unit. The
+floating-point register state is shown in <<fprs>>.
+We use the term FLEN to describe the width of the floating-point registers. FLEN
+can be 32, 64, or 128 depending on which of the ext:f[], ext:d[], and ext:q[]
+extensions are supported.
+
+[[fprs]]
+.RISC-V floating-point register state.
+[cols="<,^,>",options="header",width="50%",align="center",grid="rows"]
+|===
+| [.small]#FLEN-1#| >| [.small]#0#
+3+^| [.small]#f0#
+3+^| [.small]#f1#
+3+^| [.small]#f2#
+3+^| [.small]#f3#
+3+^| [.small]#f4#
+3+^| [.small]#f5#
+3+^| [.small]#f6#
+3+^| [.small]#f7#
+3+^| [.small]#f8#
+3+^| [.small]#f9#
+3+^| [.small]#f10#
+3+^| [.small]#f11#
+3+^| [.small]#f12#
+3+^| [.small]#f13#
+3+^| [.small]#f14#
+3+^| [.small]#f15#
+3+^| [.small]#f16#
+3+^| [.small]#f17#
+3+^| [.small]#f18#
+3+^| [.small]#f19#
+3+^| [.small]#f20#
+3+^| [.small]#f21#
+3+^| [.small]#f22#
+3+^| [.small]#f23#
+3+^| [.small]#f24#
+3+^| [.small]#f25#
+3+^| [.small]#f26#
+3+^| [.small]#f27#
+3+^| [.small]#f28#
+3+^| [.small]#f29#
+3+^| [.small]#f30#
+3+^| [.small]#f31#
+3+^| [.small]#FLEN#
+| [.small]#31#| >| [.small]#0#
+3+^|  [.small]#fcsr#
+3+^| [.small]#32#
+|===
+
+Most floating-point instructions operate on values in the floating-point
+register file. Floating-point load and store instructions transfer
+floating-point values between registers and memory. Instructions to transfer
+floating-point values to and from the integer register file are also provided.
+
+[NOTE]
+====
+For simple and low-cost implementations, the ext:zfinx[], ext:zdinx[], and
+ext:zhinx[] extensions provide computational instructions analogous to those in
+the ext:f[], ext:d[], and ext:zfh[] extensions that operate on the `x` registers
+instead.
+====
+
+The details of csr:fcsr[] are described in <<sec:fcsr>>.
 
 include::f-st-ext.adoc[]
 include::d-st-ext.adoc[]


### PR DESCRIPTION
This moves the description of `f` registers, `fcsr` and FLEN to the introduction of the scalar floating-point chapter and leave the actual value of FLEN in F/D/Q sections, as I think it is more natural. Does it make sense?