### PR TITLE
smstateen: clarify CTR state-enable bit behavior (#2672)

### DIFF
--- a/src/priv/smstateen.adoc
+++ b/src/priv/smstateen.adoc
@@ -263,6 +263,10 @@ whether they really do.#
 [[norm:stateen0_jvt_op]]
 The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
 
+[#norm:mstateen0_ctr_op]#The CTR bit in `mstateen0` controls access to the CTR
+state introduced by the Smctr/Ssctr extension.# [#norm:hstateen0_ctr_op]#The
+CTR bit in `hstateen0` controls access to that state for a virtual machine.#
+
 [#norm:mstateen0_se0_op]#The SE0 bit in `mstateen0` controls access to the `hstateen0`, `hstateen0h`,
 and the `sstateen0` CSRs.# [#norm:hstateen0_SE0_op]#The SE0 bit in `hstateen0` controls access to the
 `sstateen0` CSR.#

--- a/src/priv/smstateen.adoc
+++ b/src/priv/smstateen.adoc
@@ -263,9 +263,8 @@ whether they really do.#
 [[norm:stateen0_jvt_op]]
 The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
 
-[#norm:mstateen0_ctr_op]#The CTR bit in `mstateen0` controls access to the CTR
-state introduced by the Smctr/Ssctr extension.# [#norm:hstateen0_ctr_op]#The
-CTR bit in `hstateen0` controls access to that state for a virtual machine.#
+See <<smctr>> for the definition of the `CTR` bits in `mstateen0` and
+`hstateen0`.
 
 [#norm:mstateen0_se0_op]#The SE0 bit in `mstateen0` controls access to the `hstateen0`, `hstateen0h`,
 and the `sstateen0` CSRs.# [#norm:hstateen0_SE0_op]#The SE0 bit in `hstateen0` controls access to the


### PR DESCRIPTION
Fixes #2672.

Add the missing description of the `CTR` bit in `mstateen0` and `hstateen0` in `src/priv/smstateen.adoc`.

The detailed behavior is already defined in `src/priv/smctr.adoc`; this change just fills the missing explanation in `smstateen.adoc`.
