### PR TITLE
Fix misformatted em dashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ MONTHYEAR := $(shell date -j -f "%Y%m%d" "$(DATE)" +"%B %Y" 2>/dev/null || date 
 CITATION_DESCRIPTION := $(DATE)-$(RELEASE_TYPE)
 ifeq ($(RELEASE_TYPE), draft)
   WATERMARK_OPT := -a draft-watermark
-  RELEASE_DESCRIPTION := DRAFT---NOT AN OFFICIAL RELEASE
+  RELEASE_DESCRIPTION := DRAFT—NOT AN OFFICIAL RELEASE
 else ifeq ($(RELEASE_TYPE), intermediate)
   WATERMARK_OPT :=
   RELEASE_DESCRIPTION := Intermediate Release

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1205,15 +1205,9 @@ hand, we wish to allow flexibility for larger systems.
 [%autowidth,float="center",align="center",cols=">,^,<",options="header"]
 |===
 |Value |Name |Description
-|0 +
-1 +
-{ge}2
-|Direct +
-Vectored +
----
-|All traps set `pc` to BASE. +
-Asynchronous interrupts set `pc` to BASE+4{times}cause. +
-_Reserved_
+|0 |Direct |All traps set `pc` to BASE.
+|1 |Vectored |Asynchronous interrupts set `pc` to BASE+4{times}cause.
+|{ge}2 |-- |_Reserved_
 |===
 
 The encoding of the MODE field is shown in <<norm:mtvec_mode_enc>>.

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -886,7 +886,7 @@ instruction an option.
 ====
 
 [#norm:fence_unused_flds_rsv]#The unused fields in the FENCE
-instructions--_rs1_ and _rd_--are reserved
+instructions, _rs1_ and _rd_, are reserved
 for finer-grain fences in future extensions. For forward compatibility,
 base implementations shall ignore these fields#, and standard software
 shall zero these fields. Likewise, many _fm_ and predecessor/successor

--- a/src/unpriv/zalrsc.adoc
+++ b/src/unpriv/zalrsc.adoc
@@ -6,7 +6,7 @@ include::images/wavedrom/load-reserve-st-conditional.edn[]
 Complex atomic memory operations on a single memory word or doubleword
 are performed with the load-reserved (insn:lr[]) and store-conditional (insn:sc[])
 instructions. [#norm:lr_w_op]#insn:lr.w[] loads a word from the address in _rs1_, places the
-sign-extended value in _rd_, and registers a _reservation set_--a set of
+sign-extended value in _rd_, and registers a _reservation set:_ a set of
 bytes that subsumes the bytes in the addressed word.# [#norm:sc_w_success]#insn:sc.w[] conditionally
 writes a word in _rs2_ to the address in _rs1_: the insn:sc.w[] succeeds only
 if the reservation is still valid and the reservation set contains the

--- a/src/unpriv/zcmop.adoc
+++ b/src/unpriv/zcmop.adoc
@@ -17,7 +17,7 @@ include::images/wavedrom/c-mop.edn[]
 
 NOTE: Very few suitable 16-bit encoding spaces exist.  This space was chosen
 because it already has unusual behavior with respect to the `rd`/`rs1`
-field--it encodes insn:c.addi16sp[] when the field contains `x2`--and is
+field--it encodes insn:c.addi16sp[] when the field contains `x2`{emdash}and is
 therefore of lower value for most purposes.
 
 [[norm:c-mop_enc]]

--- a/src/unpriv/zihintntl.adoc
+++ b/src/unpriv/zihintntl.adoc
@@ -123,12 +123,12 @@ explicit cache management
 |P1 |PALL |S1 |ALL
 |L1 |L2 |L3 |L4/L5
  9+^| Common Scenarios
-| No caches 4+|--- 4+|none
-|Private L1 only |L1 |L1 |L1 |L1| ALL |--- |--- |---
-|Private L1; shared L2 |L1  |L1  |L2  |L2 |P1|ALL|---|---
-|Private L1; shared L2/L3 |L1 | L1 | L2 | L3 |P1  |S1   |ALL |---
-|Private L1/L2 |L1  |L2  |L2  |L2 | P1  |ALL  |--- |---
-|Private L1/L2; shared L3 |L1 | L2 | L3 | L3 | P1 | PALL| ALL |---
+| No caches 4+|-- 4+|none
+|Private L1 only |L1 |L1 |L1 |L1| ALL |-- |-- |--
+|Private L1; shared L2 |L1  |L1  |L2  |L2 |P1|ALL|--|--
+|Private L1; shared L2/L3 |L1 | L1 | L2 | L3 |P1  |S1   |ALL |--
+|Private L1/L2 |L1  |L2  |L2  |L2 | P1  |ALL  |-- |--
+|Private L1/L2; shared L3 |L1 | L2 | L3 | L3 | P1 | PALL| ALL |--
 |Private L1/L2; shared L3/L4 | L1 | L2|  L3 | L4 | P1 | PALL | S1 | ALL
  9+^| Uncommon Scenarios
 |Private L1/L2/L3; shared L4 | L1 | L3 |L4 |L4 |P1 |P1 |PALL |ALL

--- a/src/unpriv/zv.adoc
+++ b/src/unpriv/zv.adoc
@@ -2323,7 +2323,7 @@ All standard vector floating-point arithmetic operations follow the
 IEEE 754-2008 arithmetic standard.  [#norm:V_fp_frm]#All vector floating-point operations use the dynamic rounding mode in the `frm` register.#  [#norm:V_inv_frm_rsv]#Use of the `frm` field
 when it contains an invalid rounding mode by any vector floating-point
 instruction--even those that do not depend on the rounding mode, or
-when `vl`=0, or when `vstart` {ge} `vl`--is reserved.#
+when `vl`=0, or when `vstart` {ge} `vl`{emdash}is reserved.#
 
 NOTE: All vector floating-point code will rely on a valid value in
 `frm`.  Implementations can make all vector FP instructions report
@@ -4049,7 +4049,7 @@ NOTE: Older assembler mnemonic `vfredsum` is retained as alias for `vfredusum`.
 ====== Vector Ordered Single-Width Floating-Point Sum Reduction
 
 [#norm:vfredosum_op]#The `vfredosum` instruction must sum the floating-point values in
-element order, starting with the scalar in `vs1[0]`#--that is, it
+element order, starting with the scalar in `vs1[0]`#{emdash}that is, it
 performs the computation:
 
 ----

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -476,9 +476,7 @@ likely be too burdensome for `VLEN`=64 implementations.
 The section introduces all of the  extensions in the Vector Cryptography
 Instruction Set Extension Specification.
 
-[#norm:Zvknhb_Zvbc_Zvkn_Zvknc_Zvkng_depZve64x]#The <<zvknh,Zvknhb>> and <<zvbc>> Vector Crypto Extensions
---and accordingly the composite extensions <<Zvkn>>, <<Zvknc>>, <<Zvkng>>, and <<Zvksc>>--
-depend on Zve64x.#
+[#norm:Zvknhb_Zvbc_Zvkn_Zvknc_Zvkng_depZve64x]#The <<zvknh,Zvknhb>> and <<zvbc>> Vector Crypto Extensions--and accordingly the composite extensions <<Zvkn>>, <<Zvknc>>, <<Zvkng>>, and <<Zvksc>>{emdash}depend on Zve64x.#
 
 [#norm:Zvbb_Zvkb_Zvkg_Zvkned_Zvknha_Zvksed_Zvksh_Zvks_Zvksc_Zvksg_Zvkt_depZve32x]#All of the other Vector Crypto Extensions depend on `Zve32x`.#
 
@@ -1021,8 +1019,7 @@ instruction encoding such as the use of the zero register (`x0`), and, in the
 case of immediate forms of an instruction, the values in the immediate
 fields (i.e., imm, and uimm).
 
-In some cases --- which are explicitly specified in the lists below
---- operands that are used as control rather than data
+In some cases--which are explicitly specified in the lists below--operands that are used as control rather than data
 are exempt from DIEL.
 
 [NOTE]


### PR DESCRIPTION
I have checked the whole specification for em dash and fixed where the conversion did not work correctly. Some dashes are eliminated by tweaking the wording.

Reference: https://github.com/asciidoctor/asciidoctor/issues/1578