### PR TITLE
Bring back Oxford commas

### DIFF
--- a/src/unpriv/cmo.adoc
+++ b/src/unpriv/cmo.adoc
@@ -25,7 +25,7 @@ of the above classes of instructions represents an extension in this
 specification:
 
 * The extlink:zicbom[] extension defines a set of cache-block management instructions:
-  insn:cbo.inval[], insn:cbo.clean[],  and insn:cbo.flush[]
+  insn:cbo.inval[], insn:cbo.clean[], and insn:cbo.flush[]
 * The extlink:zicboz[] extension defines a cache-block zero instruction: insn:cbo.zero[]
 * The extlink:zicbop[] extension defines a set of cache-block prefetch instructions:
   insn:prefetch.r[], insn:prefetch.w[], and insn:prefetch.i[]

--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -378,12 +378,12 @@ integer, respectively, in integer register _rs1_ into a floating-point
 number in floating-point register _rd_#. [#norm:fcvt-wu-s_fcvt-lu-s_fcvt-s-wu_fcvt-s-lu_op]#insn:fcvt.wu.s[], insn:fcvt.lu.s[], insn:fcvt.s.wu[],
 and insn:fcvt.s.lu[] variants convert to or from unsigned integer values. For
 XLEN>32, insn:fcvt.w.s[] and insn:fcvt.wu.s[] sign-extend the 32-bit result to the destination register width#.
-[#norm:fcvt_long_float_rv64_only]#insn:fcvt.l.s[], insn:fcvt.lu.s[], insn:fcvt.s.l[] and insn:fcvt.s.lu[] are RV64-only instructions#.
+[#norm:fcvt_long_float_rv64_only]#insn:fcvt.l.s[], insn:fcvt.lu.s[], insn:fcvt.s.l[], and insn:fcvt.s.lu[] are RV64-only instructions#.
 [#norm:fcvt_unrepresentable_nv]#If the rounded result is not representable in the
 destination format, it is clipped to the nearest value and the invalid
 flag is set#.
 [#norm:fcvt_int_float_valid_input]#<<int_conv>> gives the range of valid inputs
-for insn:fcvt.w.s[], insn:fcvt.wu.s[], insn:fcvt.l.s[] and insn:fcvt.lu.s[] and
+for insn:fcvt.w.s[], insn:fcvt.wu.s[], insn:fcvt.l.s[], and insn:fcvt.lu.s[] and
 the behavior of these instructions for invalid inputs#.
 (((floating-point, conversion)))
 
@@ -421,8 +421,9 @@ include::images/wavedrom/spfloat-cn-cmp.edn[]
 [[fcvt]]
 //.SP float convert and move
 
-[#norm:fsgnj-s_fsgnjn-s_fsgnjx-s_op]#Floating-point to floating-point sign-injection instructions, insn:fsgnj.s[],
-insn:fsgnjn.s[] and insn:fsgnjx.s[], produce a result that takes all bits except the
+[#norm:fsgnj-s_fsgnjn-s_fsgnjx-s_op]#insn:fsgnj.s[], insn:fsgnjn.s[], and
+insn:fsgnjx.s[] are floating-point to floating-point sign-injection instructions
+that produce a result that takes all bits except the
 sign bit from _rs1_. For insn:fsgnj[], the result's sign bit is _rs2_'s sign
 bit; for insn:fsgnjn[], the result's sign bit is the opposite of _rs2_'s sign
 bit; and for insn:fsgnjx[], the sign bit is the XOR of the sign bits of _rs1_

--- a/src/unpriv/m-st-ext.adoc
+++ b/src/unpriv/m-st-ext.adoc
@@ -102,7 +102,7 @@ equal to the dividend, and the remainder is zero.# Unsigned division
 overflow cannot occur.
 
 [[divby0]]
-.Semantics for division by zero and division overflow. L is the width of the operation in bits: XLEN for insn:div[], insn:divu[], insn:rem[] and insn:remu[], or 32 for insn:divw[], insn:divuw[], insn:remw[] and insn:remuw[].
+.Semantics for division by zero and division overflow. L is the width of the operation in bits: XLEN for insn:div[], insn:divu[], insn:rem[], and insn:remu[], or 32 for insn:divw[], insn:divuw[], insn:remw[], and insn:remuw[].
 [cols="<2,^,^,^,^,^,^",options="header",]
 |===
 |Condition |Dividend |Divisor |insn:divu[]/insn:divuw[] |insn:remu[]/insn:remuw[] |insn:div[]/insn:divw[] |insn:rem[]/insn:remw[]

--- a/src/unpriv/mm-formal.adoc
+++ b/src/unpriv/mm-formal.adoc
@@ -430,7 +430,7 @@ The operational model, together with a fragment of the RISC-V ISA
 semantics (RV64I and A), are integrated into the `rmem` exploration tool
 (https://github.com/rems-project/rmem). `rmem` can explore litmus tests
 (see <<litmustests>>) and small ELF binaries
-exhaustively, pseudorandomly and interactively. In `rmem`, the ISA
+exhaustively, pseudorandomly, and interactively. In `rmem`, the ISA
 semantics is expressed explicitly in Sail (see
 https://github.com/rems-project/sail for the Sail language, and
 https://github.com/rems-project/sail-riscv for the RISC-V ISA model),

--- a/src/unpriv/zabha.adoc
+++ b/src/unpriv/zabha.adoc
@@ -33,7 +33,7 @@ extension depends upon the ext:zaamo[] standard extension.
 
 ext:zabha[] extension provides the insn:amoadd.b/h[], insn:amoand.b/h[],
 insn:amoor.b/h[], insn:amoxor.b/h[], insn:amoswap.b/h[], insn:amomin.b/h[],
-insn:amominu.b/h[], insn:amomax.b/h[] and insn:amomaxu.b/h[] instructions.
+insn:amominu.b/h[], insn:amomax.b/h[], and insn:amomaxu.b/h[] instructions.
 If ext:zacas[] extension is also implemented, ext:zabha[] further provides the
 insn:amocas.b/h[] instructions.
 

--- a/src/unpriv/zalasr.adoc
+++ b/src/unpriv/zalasr.adoc
@@ -6,7 +6,7 @@ These can be important for high performance designs by enabling finer-grained sy
 Load-acquire and store-release are widely used in language-level memory models:
 both the Java and {cpp} memory models make use of acquire-release semantics, and {cpp}'s `atomic` provides primitives that are meant to map directly to load-acquire and store-release instructions.
 
-[#norm:zalasr_builds_on_amo]#The ext:zalasr[] extension builds on the atomic support provided by the ext:zaamo[], ext:zalrsc[] and ext:zabha[] extensions by providing additional atomic operations, although it can be implemented independently of them.#
+[#norm:zalasr_builds_on_amo]#The ext:zalasr[] extension builds on the atomic support provided by the ext:zaamo[], ext:zalrsc[], and ext:zabha[] extensions by providing additional atomic operations, although it can be implemented independently of them.#
 All of the AMO operations in ext:zaamo[] and ext:zabha[] are read-modify-write operations that both load and store.
 The ext:zalrsc[] extension provides operations that are only loads or stores.
 However, since it is designed to perform an atomic operation on a single memory word or doubleword, the loads and stores provided by ext:zalrsc[] are designed to be paired.
@@ -15,7 +15,7 @@ Therefore, the ext:zalrsc[] extension does not provide a general atomic and orde
 
 ext:zalasr[] fills this gap by offering truly standalone atomic and ordered loads and stores.
 [#norm:zalasr_atomic_ordered]#The ext:zalasr[] instructions are atomic loads and stores that support ordering annotations.#
-With the combination of ext:zaamo[], ext:zabha[], ext:zacas[] and ext:zalasr[], all {cpp} atomic operations can be supported with single instructions.
+All {cpp} atomic operations can be supported with single instructions with the combination of ext:zaamo[], ext:zabha[], ext:zacas[], and ext:zalasr[].
 
 ==== Load-Acquire and Store-Release Instructions
 

--- a/src/unpriv/zclsd.adoc
+++ b/src/unpriv/zclsd.adoc
@@ -16,9 +16,9 @@ insn:c.ld[] and insn:c.sd[] instructions can only use `x8`-`x15`.
 
 ==== Exception Handling
 
-For the purposes of RVWMO and exception handling, insn:c.ld[], insn:c.ldsp[], insn:c.sd[] and insn:c.sdsp[] instructions are
+For the purposes of RVWMO and exception handling, insn:c.ld[], insn:c.ldsp[], insn:c.sd[], and insn:c.sdsp[] instructions are
 considered to be misaligned loads and stores, with one additional constraint:
-a insn:c.ld[], insn:c.ldsp[], insn:c.sd[] or insn:c.sdsp[] instruction whose effective address is a multiple of 4 gives rise
+a insn:c.ld[], insn:c.ldsp[], insn:c.sd[], or insn:c.sdsp[] instruction whose effective address is a multiple of 4 gives rise
 to two 4-byte memory operations.
 
 ext:zclsd[] adds the following RV32-only instructions:

--- a/src/unpriv/zf.adoc
+++ b/src/unpriv/zf.adoc
@@ -43,7 +43,7 @@ specification.
 |E5M2 |_not applicable_ | |8 bits
 |===
 
-While the BF16 cite:[bfloat16], E4M3 and E5M2 formats are not defined in IEEE
+While the BF16 cite:[bfloat16], E4M3, and E5M2 formats are not defined in IEEE
 754-2008, the structure and operations of these formats are compatible with the
 standard. E4M3 and E5M2 are specified by the Open Compute Project (OCP) as the
 OCP FP8 (OFP8) formats cite:[ocp-fp8].

--- a/src/unpriv/zfh.adoc
+++ b/src/unpriv/zfh.adoc
@@ -64,7 +64,7 @@ conversion instructions.
 [#norm:fcvt-w-h_fcvt-l-h_op]#insn:fcvt.w.h[] or insn:fcvt.l.h[] converts a half-precision floating-point number to a signed 32-bit or 64-bit integer, respectively#.
 [#norm:fcvt-h-w_fcvt-h-l_op]#insn:fcvt.h.w[] or insn:fcvt.h.l[] converts a 32-bit or 64-bit signed integer, respectively, into a half-precision floating-point number#.
 [#norm:fcvt-wu-h_fcvt-lu-h_fcvt-h-wu_fcvt-h-lu_op]#insn:fcvt.wu.h[], insn:fcvt.lu.h[], insn:fcvt.h.wu[], and insn:fcvt.h.lu[] variants convert to or from unsigned integer values#.
-[#norm:fcvt_long_half_rv64_only]#insn:fcvt.l.h[], insn:fcvt.lu.h[], insn:fcvt.h.l[] and insn:fcvt.h.lu[] are RV64-only instructions.#
+[#norm:fcvt_long_half_rv64_only]#insn:fcvt.l.h[], insn:fcvt.lu.h[], insn:fcvt.h.l[], and insn:fcvt.h.lu[] are RV64-only instructions.#
 
 include::images/wavedrom/half-prec-conv-and-mv.edn[]
 [[half-prec-conv-and-mv]]

--- a/src/unpriv/zfinx.adoc
+++ b/src/unpriv/zfinx.adoc
@@ -27,7 +27,7 @@ ext:zfinx[] extension, and vice versa.
 [[norm:Zfinx_F_instrs]]
 The ext:zfinx[] extension adds all of the instructions that the ext:f[] extension
 adds, _except_ for the transfer instructions insn:flw[], insn:fsw[],
-insn:fmv.w.x[], insn:fmv.x.w[], insn:c.flw[], insn:c.flwsp[], insn:c.fsw[] and
+insn:fmv.w.x[], insn:fmv.x.w[], insn:c.flw[], insn:c.flwsp[], insn:c.fsw[], and
 insn:c.fswsp[].
 
 [NOTE]
@@ -76,7 +76,7 @@ instructions. The ext:zdinx[] extension depends upon the ext:zfinx[] extension.
 [[norm:Zdinx_D_instrs]]
 The ext:zdinx[] extension adds all of the instructions that the ext:d[] extension
 adds, _except_ for the transfer instructions insn:fld[], insn:fsd[],
-insn:fmv.d.x[], insn:fmv.x.d[], c.fld[], c.fldsp[], c.fsd[] and c.fsdsp[].
+insn:fmv.d.x[], insn:fmv.x.d[], c.fld[], c.fldsp[], c.fsd[], and c.fsdsp[].
 
 [[norm:Zdinx_x_regs]]
 The ext:zdinx[] variants of these ext:d[]-extension instructions have the same

--- a/src/unpriv/zicsr.adoc
+++ b/src/unpriv/zicsr.adoc
@@ -125,7 +125,7 @@ instructions with respect to whether they read and/or write the CSR.
 In addition to side effects that occur as a consequence of reading or
 writing a CSR, individual fields within a CSR might have side effects
 when written.  insn:csrrw[] and insn:csrrwi[] action side effects for all
-such fields within the written CSR.  [#norm:csr_rs1_uimm_side_effect]#insn:csrrs[], insn:csrrsi[], insn:csrrc[] and insn:csrrci[]
+such fields within the written CSR.  [#norm:csr_rs1_uimm_side_effect]#insn:csrrs[], insn:csrrsi[], insn:csrrc[], and insn:csrrci[]
 only action side effects for fields for which the _rs1_ or _uimm_ argument
 has at least one bit set corresponding to that field.#
 [NOTE]


### PR DESCRIPTION
I have omitted some Oxford commas when I was not aware that the RISC-V specifications has the Oxford comma rule. My fault. This change bring (back) Oxford comma.