### PR TITLE
Remove list of explicit memory accesses from pointer masking section

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -1,3 +1,4 @@
+---
 name: DCO Check
 
 on:

--- a/.github/workflows/signing_check.yml
+++ b/.github/workflows/signing_check.yml
@@ -1,3 +1,4 @@
+---
 name: Commit Signing Check
 
 on:

--- a/src/priv/zpm.adoc
+++ b/src/priv/zpm.adoc
@@ -125,28 +125,11 @@ Linux places kernel addresses in the upper half of the address space and user ad
 
 ===== Memory Accesses Subject to Pointer Masking
 
-Pointer masking applies to all explicit memory accesses. Currently, in the Base and Privileged ISAs, these are:
-
-* **Base Instruction Set**: LB, LH, LW, LBU, LHU, LWU, LD, SB, SH, SW, SD.
-* **Atomics**: All instructions in RV32A and RV64A.
-* **Floating Point**: FLW, FLD, FLQ, FSW, FSD, FSQ.
-* **Compressed**: All instructions mapping to any of the above, and C.LWSP, C.LDSP, C.FLWSP, C.FLDSP, C.SWSP, C.SDSP, C.FSWSP, C.FSDSP.
-* **Hypervisor Extension**: HLV.\*, HSV.* (in some cases; see <<sec:hstatus>>).
-* **Cache Management Operations**: All instructions in Zicbom, Zicbop and Zicboz.
-* **Vector Extension**: All vector load and store instructions in the ratified RVV 1.0 spec.
-* **Zicfiss Extension**: SSPUSH, C.SSPUSH, SSPOPCHK, C.SSPOPCHK, SSAMOSWAP.W/D.
-* **Assorted**: FENCE, FENCE.I (if the currently unused address fields become enabled in the future).
+Unless otherwise specified, pointer masking applies to all explicit memory accesses.
 
 [NOTE]
 ====
-This list will grow over time as new extensions introduce new instructions that perform explicit memory accesses.
-====
-
-For other extensions, pointer masking applies to all explicit memory accesses by default. Future extensions may add specific language to indicate whether particular accesses are or are not included in pointer masking.
-
-[NOTE]
-====
-It is worth noting that pointer masking is not applied to `SFENCE.\*`, `HFENCE.*`, `SINVAL.\*`, or `HINVAL.*`. When such an operation is invoked, it is the responsibility of the software to provide the correct address.
+Pointer masking is not applied to `SFENCE.\*`, `HFENCE.*`, `SINVAL.\*`, or `HINVAL.*`. When such an operation is invoked, it is the responsibility of the software to provide the correct address.
 ====
 
 [#norm:pm_mprv_spvp]#MPRV and SPVP affect pointer masking as well, causing the pointer masking settings of the effective privilege mode to be applied.# [#norm:pm_mxr_exception]#When MXR is in effect at the effective privilege mode where explicit memory access is performed, pointer masking does not apply.#


### PR DESCRIPTION
The list is a maintenance burden.  Relying on the definition of "explicit memory access" instead of listing them all out avoids this pitfall.

See discussion on #3015.