### PR TITLE
Tweak Zfbfmin canonical NaN definition

### DIFF
--- a/normative_rule_defs/zfbfmin.yaml
+++ b/normative_rule_defs/zfbfmin.yaml
@@ -7,5 +7,5 @@ chapter_name: Zfbfmin Extension for Scalar BF16 Conversion
 
 normative_rule_definitions:
 
-  - name: Zfbfmin_canonical_NaN
-    tags: ["norm:canonical_NaN", "norm:Zfbfmin_canonical_NaN"]
+  - name: bf16_canonical_NaN
+    tags: ["norm:canonical_NaN", "norm:bf16_canonical_NaN"]

--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -538,8 +538,8 @@
     "norm:fleq-d_fltq-d_op": "If the ext:d[] extension is implemented, insn:fleq.d[] and insn:fltq.d[] instructions are analogously defined to operate on double-precision numbers.",
     "norm:fleq-q_fltq-q_op": "If the ext:q[] extension is implemented, insn:fleq.q[] and insn:fltq.q[] instructions are analogously defined to operate on quad-precision numbers.",
     "norm:fleq-h_fltq-h_op": "If the ext:zfh[] extension is implemented, insn:fleq.h[] and insn:fltq.h[] instructions are analogously defined to operate on half-precision numbers.",
-    "norm:Zfbfmin_canonical_NaN": "For BF16, the canonical NaN corresponds to the pattern 0x7fc0.",
     "norm:bf16_subnorm": "BF16 computational instructions defined in this chapter support all IEEE 754-2008 features, including all rounding modes, subnormal inputs and outputs, overflow and underflow, and default exception handling. Tininess is detected after rounding.",
+    "norm:bf16_canonical_NaN": "For BF16, the canonical NaN corresponds to the pattern 0x7fc0.",
     "norm:fcvt-bf16-s_op": "Narrowing convert FP32 value to a BF16 value. Round according to the RM field.",
     "norm:fcvt-s-bf16_op": "Converts a BF16 value to an FP32 value. The conversion is exact.",
     "norm:Zfinx_F_instrs": "The ext:zfinx[] extension adds all of the instructions that the ext:f[] extension adds, except for the transfer instructions insn:flw[], insn:fsw[], insn:fmv.w.x[], insn:fmv.x.w[], insn:c.flw[], insn:c.flwsp[], insn:c.fsw[], and insn:c.fswsp[].",
@@ -4698,7 +4698,8 @@
                     "id": "_bf16_number_format",
                     "children": [],
                     "tags": [
-                      "norm:bf16_subnorm"
+                      "norm:bf16_subnorm",
+                      "norm:bf16_canonical_NaN"
                     ]
                   },
                   {
@@ -4718,9 +4719,7 @@
                     ]
                   }
                 ],
-                "tags": [
-                  "norm:Zfbfmin_canonical_NaN"
-                ]
+                "tags": []
               },
               {
                 "title": "ext:zfinx[], ext:zdinx[], ext:zhinx[], ext:zhinxmin[] Extensions for Floating-Point in Integer Registers",

--- a/src/unpriv/zfbfmin.adoc
+++ b/src/unpriv/zfbfmin.adoc
@@ -7,10 +7,6 @@ between BF16 values and FP32 values.
 
 This extension depends upon the ext:f[] extension.
 
-[[norm:Zfbfmin_canonical_NaN]]
-(((NaN, canonical, bfloat16)))
-For BF16, the canonical NaN corresponds to the pattern `0x7fc0`.
-
 This extension includes six instructions: the insn:fcvt.bf16.s[] and
 insn:fcvt.s.bf16[] instructions, defined below, and the insn:flh[], insn:fsh[],
 insn:fmv.x.h[], and insn:fmv.h.x[] instructions, defined in extlink:zfh[].
@@ -76,7 +72,9 @@ BF16 computational instructions defined in this chapter support all IEEE
 overflow and underflow, and default exception handling.
 Tininess is detected after rounding.
 
-The BF16 canonical NaN is `0x7fc0`.
+[[norm:bf16_canonical_NaN]]
+(((NaN, canonical, bfloat16)))
+For BF16, the canonical NaN corresponds to the pattern `0x7fc0`.
 
 BF16 values are NaN-boxed when held in `f` registers, as described in <<nanboxing>>.
 


### PR DESCRIPTION
I overlooked that there is a paragraph specifying the BF16 canonical NaN before the modification I recently made. The original place seems better than the newly added one, so I moved the NormRule there.