### PR TITLE
Zv, vector-common: Use macros

### DIFF
--- a/src/unpriv/vector-common.adoc
+++ b/src/unpriv/vector-common.adoc
@@ -6,10 +6,10 @@ features, are defined in the subsequent sections.
 
 [NOTE]
 ====
-_The base vector extension is intended to provide general support for
+The base vector extension is intended to provide general support for
 data-parallel execution within the 32-bit instruction encoding space,
 with later vector extensions supporting richer functionality for certain
-domains._
+domains.
 ====
 
 ==== Implementation-defined Constant Parameters
@@ -21,9 +21,9 @@ must be a power of 2.#
 . [#norm:vlen]#The number of bits in a single vector register, _VLEN_ {ge} 8, which must be a power of 2, and must be no greater than 2^16^.#
 
 Standard vector extensions (<<sec-vector-extensions>>) and
-architecture profiles may set further constraints on _ELEN_ and _VLEN_.
+architecture profiles may set further constraints on ELEN and VLEN.
 
-NOTE: Following the ratification of the V extension, this specification
+NOTE: Following the ratification of the ext:v[] extension, this specification
 has been revised to admit the possibility of future extensions that
 allow ELEN > VLEN, wherein one element is held using bits from
 multiple vector registers.
@@ -52,7 +52,7 @@ VLEN or ELEN parameters.
 ==== Vector Extension Programmer's Model
 
 The vector extension adds 32 vector registers, and seven unprivileged
-CSRs (`vstart`, `vxsat`, `vxrm`, `vcsr`, `vtype`, `vl`, `vlenb`) to a
+CSRs (csr:vstart[], csr:vxsat[], csr:vxrm[], csr:vcsr[], csr:vtype[], csr:vl[], csr:vlenb[]) to a
 base scalar RISC-V ISA.
 
 .New vector CSRs
@@ -61,17 +61,17 @@ base scalar RISC-V ISA.
 |===
 | Address | Privilege | Name   | Description
 
-| 0x008 | URW | vstart | Vector start element index
-| 0x009 | URW | vxsat  | Fixed-Point Saturate Flag
-| 0x00A | URW | vxrm   | Fixed-Point Rounding Mode
-| 0x00F | URW | vcsr   | Vector control and status register
-| 0xC20 | URO | vl     | Vector length
-| 0xC21 | URO | vtype  | Vector data type register
-| 0xC22 | URO | vlenb  | VLEN/8 (vector register length in bytes)
+| 0x008 | URW | csr:vstart[] | Vector start element index
+| 0x009 | URW | csr:vxsat[]  | Fixed-Point Saturate Flag
+| 0x00A | URW | csr:vxrm[]   | Fixed-Point Rounding Mode
+| 0x00F | URW | csr:vcsr[]   | Vector control and status register
+| 0xC20 | URO | csr:vl[]     | Vector length
+| 0xC21 | URO | csr:vtype[]  | Vector data type register
+| 0xC22 | URO | csr:vlenb[]  | VLEN/8 (vector register length in bytes)
 |===
 
 NOTE: The four CSR numbers `0x00B`-`0x00E` are tentatively reserved
-for future vector CSRs, some of which may be mirrored into `vcsr`.
+for future vector CSRs, some of which may be mirrored into csr:vcsr[].
 
 ===== Vector Registers
 
@@ -81,120 +81,119 @@ The vector extension adds 32 architectural vector registers,
 
 Each vector register has a fixed VLEN bits of state.
 
-===== Vector Context Status in `mstatus`
+===== Vector Context Status in csr:mstatus[]
 
 [[norm:mstatus_vs_sstatus_vs_op]]
-A vector context status field, `VS`, is added to `mstatus[10:9]` and shadowed
-in `sstatus[10:9]`.  It is defined analogously to the floating-point context
-status field, `FS`.
+A vector context status field, csr:[vs], is added to csr:mstatus[][10:9] and shadowed
+in csr:sstatus[][10:9].  It is defined analogously to the floating-point context
+status field, csr::[fs].
 
 [[norm:mstatus_vs_op_off]]
 Attempts to execute any vector instruction, or to access the vector
-CSRs, raise an illegal-instruction exception when `mstatus.VS` is
+CSRs, raise an illegal-instruction exception when csr:mstatus[vs] is
 set to Off.
 
 [[norm:mstatus_vs_op_initial_clean]]
-When `mstatus.VS` is set to Initial or Clean, executing any
+When csr:mstatus[vs] is set to Initial or Clean, executing any
 instruction that changes vector state, including the vector CSRs, will
-change `mstatus.VS` to Dirty.
-Implementations may also change `mstatus.VS` from Initial or Clean to Dirty
+change csr:mstatus[vs] to Dirty.
+Implementations may also change csr:mstatus[vs] from Initial or Clean to Dirty
 at any time, even when there is no change in vector state.
 
-NOTE: Accurate setting of `mstatus.VS` is an optimization.  Software
-will typically use VS to reduce context-swap overhead.
+NOTE: Accurate setting of csr:mstatus[vs] is an optimization.  Software
+will typically use csr::[vs] to reduce context-swap overhead.
 
 [[norm:mstatus_sd_op2]]
-If `mstatus.VS` is Dirty, `mstatus.SD` is 1;
-otherwise, `mstatus.SD` is set in accordance with existing specifications.
+If csr:mstatus[vs] is Dirty, csr:mstatus[sd] is 1;
+otherwise, csr:mstatus[sd] is set in accordance with existing specifications.
 
-[#norm:mutable_misa_v]#Implementations may have a writable `misa.V` field.#  [#norm:mstatus_vs_exists]#Analogous to the
-way in which the floating-point unit is handled, the `mstatus.VS`
-field may exist even if `misa.V` is clear.#
+[#norm:mutable_misa_v]#Implementations may have a writable csr:misa[v] field.#  [#norm:mstatus_vs_exists]#Analogous to the
+way in which the floating-point unit is handled, the csr:mstatus[vs]
+field may exist even if csr:misa[v] is clear.#
 
-NOTE: Allowing `mstatus.VS` to exist when `misa.V` is clear, enables
-vector emulation and simplifies handling of `mstatus.VS` in systems
-with writable `misa.V`.
+NOTE: Allowing csr:mstatus[vs] to exist when csr:misa[v] is clear enables
+vector emulation and simplifies handling of csr:mstatus[vs] in systems
+with writable csr:misa[v].
 
-===== Vector Context Status in `vsstatus`
+===== Vector Context Status in csr:vsstatus[]
 
 [[norm:vsstatus_vs_sz_acc]]
-When the hypervisor extension is present, a vector context status field, `VS`,
-is added to `vsstatus[10:9]`.
-It is defined analogously to the floating-point context status field, `FS`.
+When the hypervisor extension is present, a vector context status field, csr::[vs],
+is added to csr:vsstatus[][10:9].
+It is defined analogously to the floating-point context status field, csr::[fs].
 
 [[norm:vsstatus_vs_mstatus_vs_op_off]]
-When V=1, both `vsstatus.VS` and `mstatus.VS` are in effect: attempts to
+When V=1, both csr:vsstatus[vs] and csr:mstatus[vs] are in effect: attempts to
 execute any vector instruction, or to access the vector CSRs, raise an
 illegal-instruction exception when either field is set to Off.
 
-[#norm:vsstatus_vs_mstatus_vs_op_active]#When V=1 and neither `vsstatus.VS` nor `mstatus.VS` is set to Off, executing
+[#norm:vsstatus_vs_mstatus_vs_op_active]#When V=1 and neither csr:vsstatus[vs] nor csr:mstatus[vs] is set to Off, executing
 any instruction that changes vector state, including the vector CSRs, will
-change both `mstatus.VS` and `vsstatus.VS` to Dirty.#
-[#norm:hw_mstatus_vs_dirty_update]#Implementations may also change `mstatus.VS` or `vsstatus.VS` from Initial or
+change both csr:mstatus[vs] and csr:vsstatus[vs] to Dirty.#
+[#norm:hw_mstatus_vs_dirty_update]#Implementations may also change csr:mstatus[vs] or csr:vsstatus[vs] from Initial or
 Clean to Dirty at any time, even when there is no change in vector state.#
 
 [[norm:vsstatus_sd_op_vs]]
-If `vsstatus.VS` is Dirty, `vsstatus.SD` is 1;
-otherwise, `vsstatus.SD` is set in accordance with existing specifications.
+If csr:vsstatus[vs] is Dirty, csr:vsstatus[sd] is 1;
+otherwise, csr:vsstatus[sd] is set in accordance with existing specifications.
 
 [[norm:mstatus_sd_op_vs]]
-If `mstatus.VS` is Dirty, `mstatus.SD` is 1;
-otherwise, `mstatus.SD` is set in accordance with existing specifications.
+If csr:mstatus[vs] is Dirty, csr:mstatus[sd] is 1;
+otherwise, csr:mstatus[sd] is set in accordance with existing specifications.
 
 [[norm:vsstatus_vs_exists]]
-For implementations with a writable `misa.V` field,
-the `vsstatus.VS` field may exist even if `misa.V` is clear.
+For implementations with a writable csr:misa[v] field,
+the csr:vsstatus[vs] field may exist even if csr:misa[v] is clear.
 
-===== Vector Type (`vtype`) Register
+===== Vector Type (csr:vtype[]) Register
 
-[#norm:vtype_sz_acc_op]#The read-only XLEN-wide _vector_ _type_ CSR, `vtype` provides the
+[#norm:vtype_sz_acc_op]#The read-only XLEN-wide _vector_ _type_ CSR, csr:vtype[] provides the
 default type used to interpret the contents of the vector register
-file, and can only be updated by `vset{i}vl{i}` instructions.# The
+file, and can only be updated by insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions.# The
 vector type determines the organization of elements in each
 vector register, and how multiple vector registers are grouped. The
-`vtype` register also indicates how masked-off elements and elements
+csr:vtype[] register also indicates how masked-off elements and elements
 past the current vector length in a vector result are handled.
 
-NOTE: Allowing updates only via the `vset{i}vl{i}` instructions
-simplifies maintenance of the `vtype` register state.
+NOTE: Allowing updates only via the insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions
+simplifies maintenance of the csr:vtype[] register state.
 
 [[norm:vtype_fields_sz]]
-The `vtype` register has five fields, `vill`, `vma`, `vta`,
-`vsew[2:0]`, and `vlmul[2:0]`.  Bits `vtype[XLEN-2:8]` should be
+The csr:vtype[] register has five fields, csr::[vill], csr::[vma], csr::[vta],
+csr::[vsew], and csr::[vlmul].  Bits csr:vtype[][XLEN-2:8] should be
 written with zero, and non-zero values in this field are reserved.
 
 include::images/wavedrom/vtype-format.edn[]
 
-
-NOTE: A small implementation supporting ELEN=32 requires only seven bits of state in `vtype`: two bits for `ma` and `ta`, two bits for `vsew[1:0]` and three bits for `vlmul[2:0]`.  The illegal value represented by `vill` can be internally encoded using the illegal 64-bit combination in `vsew[1:0]` without requiring an additional storage
-bit to hold `vill`.
+NOTE: A small implementation supporting ELEN=32 requires only seven bits of state in csr:vtype[]: two bits for csr::[vma] and csr::[vta], two bits for csr::[vsew] and three bits for csr::[vlmul].  The illegal value represented by csr::[vill] can be internally encoded using the illegal 64-bit combination in csr::[vsew] without requiring an additional storage
+bit to hold csr::[vill].
 
 NOTE: Further standard and custom vector extensions may extend these
 fields to support a greater variety of data types.
 
-NOTE: The primary motivation for the `vtype` CSR is to allow the
+NOTE: The primary motivation for the csr:vtype[] CSR is to allow the
 vector instruction set to fit into a 32-bit instruction encoding
-space.  A separate `vset{i}vl{i}` instruction can be used to set `vl`
-and/or `vtype` fields before execution of a vector instruction, and
+space.  A separate insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[] instruction can be used to set csr:vl[]
+and/or csr:vtype[] fields before execution of a vector instruction, and
 implementations may choose to fuse these two instructions into a single
-internal vector microop.  In many cases, the `vl` and `vtype` values
+internal vector microop.  In many cases, the csr:vl[] and csr:vtype[] values
 can be reused across multiple instructions, reducing the static and
-dynamic instruction overhead from the `vset{i}vl{i}` instructions.  It
+dynamic instruction overhead from the insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions.  It
 is anticipated that a future extended 64-bit instruction encoding
 would allow these fields to be specified statically in the instruction
 encoding.
 
-====== Vector Selected Element Width (`vsew[2:0]`)
+====== Vector Selected Element Width (csr::[vsew])
 [[norm:vtype_vsew_op]]
-The value in `vsew` sets the dynamic _selected_ _element_ _width_
+The value in csr::[vsew] sets the dynamic _selected element width_
 (SEW).  By default, a vector register is viewed as being divided into
 VLEN/SEW elements.
 
-.vsew[2:0] (selected element width) encoding
+.csr::[vsew] encoding
 [cols="1,1,1,1"]
 [%autowidth,float="center",align="center",options="header"]
 |===
-3+| vsew[2:0] | SEW
+3+| csr::[vsew] | SEW
 
 | 0 | 0 | 0 |    8
 | 0 | 0 | 1 |   16
@@ -203,7 +202,7 @@ VLEN/SEW elements.
 | 1 | X | X |   Reserved
 |===
 
-NOTE: [#norm:vtype_vsew_rsv]#While it is anticipated the larger `vsew[2:0]` encodings
+NOTE: [#norm:vtype_vsew_rsv]#While it is anticipated the larger csr::[vsew] encodings
 (`100`-`111`) will be used to encode larger SEW, the encodings are
 formally _reserved_ at this point.#
 
@@ -227,17 +226,17 @@ larger SEWs only when bits from multiple vector registers are combined
 using LMUL.  In this case, software that relies on large SEW should
 attempt to use the largest LMUL, and hence the fewest vector register
 groups, to increase the number of implementations on which the code
-will run. The `vill` bit in `vtype` should be checked after setting
-`vtype` to see if the configuration is supported, and an alternate
+will run. The csr::[vill] bit in csr:vtype[] should be checked after setting
+csr:vtype[] to see if the configuration is supported, and an alternate
 code path should be provided if it is not. Alternatively, a profile
 can mandate the minimum SEW at each LMUL setting.
 
 [[vector-register-grouping]]
-====== Vector Register Grouping (`vlmul[2:0]`)
+====== Vector Register Grouping (csr::[vlmul])
 
 Multiple vector registers can be grouped together, so that a single
 vector instruction can operate on multiple vector registers.  The term
-_vector_ _register_ _group_ is used herein to refer to one or more
+_vector register group_ is used herein to refer to one or more
 vector registers used as a single operand to a vector instruction.
 Vector register groups can be used to provide greater execution
 efficiency for longer application vectors, but the main reason for
@@ -303,21 +302,21 @@ For a given supported fractional LMUL setting, implementations must support
 SEW settings between SEW~MIN~ and LMUL * min(ELEN, VLEN), inclusive.
 
 [[norm:vtype_lmul_fval_rsv]]
-The use of `vtype` encodings with LMUL < SEW~MIN~/min(ELEN, VLEN) is
-__reserved__, but implementations can set `vill` if they do not
+The use of csr:vtype[] encodings with LMUL < SEW~MIN~/min(ELEN, VLEN) is
+__reserved__, but implementations can set csr::[vill] if they do not
 support these configurations.
 
-NOTE: Requiring all implementations to set `vill` in this case would
+NOTE: Requiring all implementations to set csr::[vill] in this case would
 prohibit future use of this case in an extension, so to allow for a
 future definition of LMUL<SEW~MIN~/min(ELEN, VLEN) behavior, we
 consider the use of this case to be __reserved__.
 
 NOTE: It is recommended that assemblers provide a warning (not an
-error) if a `vsetvli` instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
+error) if a insn:vsetvli[] instruction attempts to write an LMUL < SEW~MIN~/min(ELEN, VLEN).
 
 [[norm:lmul]]
-LMUL is set by the signed `vlmul` field in `vtype` (i.e., LMUL =
-2^`vlmul[2:0]`^).
+LMUL is set by the signed csr::[vlmul] field in csr:vtype[] (i.e., LMUL =
+2^csr::[vlmul]^).
 
 [[norm:vlmax]]
 The derived value VLMAX = LMUL*VLEN/SEW represents the maximum number
@@ -327,7 +326,7 @@ given the current SEW and LMUL settings as shown in the table below.
 [cols="1,1,1,2,2,5,5"]
 [%autowidth,float="center",align="center",options="header"]
 |===
-  3+| vlmul[2:0] | LMUL | #groups | VLMAX      | Registers grouped with register __n__
+  3+| csr::[vlmul] | LMUL | #groups | VLMAX      | Registers grouped with register __n__
 
 | 1 | 0 | 0 |   -  |     -   |     -      | reserved
 | 1 | 0 | 1 |   1/8|     32  | VLEN/SEW/8 | `v` __n__ (single register in group)
@@ -357,7 +356,7 @@ Mask registers are always contained in a single vector register,
 regardless of LMUL.
 
 [[sec-agnostic]]
-====== Vector Tail Agnostic and Vector Mask Agnostic `vta` and `vma`
+====== Vector Tail Agnostic and Vector Mask Agnostic csr::[vta] and csr::[vma]
 
 [[norm:vtype_vta-vma_op]]
 These two bits modify the behavior of destination tail elements and
@@ -372,7 +371,7 @@ All systems must support all four options:
 [cols="1,1,3,3"]
 [%autowidth,float="center",align="center",options="header"]
 |===
-| `vta` | `vma` | Tail Elements | Inactive Elements
+| csr::[vta] | csr::[vma] | Tail Elements | Inactive Elements
 
 |   0   |   0   | undisturbed   | undisturbed
 |   0   |   1   | undisturbed   | agnostic
@@ -382,7 +381,7 @@ All systems must support all four options:
 
 [[norm:vreg_mask_tail_agn]]
 Mask destination tail elements are always treated as tail-agnostic,
-regardless of the setting of `vta`.
+regardless of the setting of csr::[vta].
 
 [[norm:vreg_mask_op]]
 When a set is marked undisturbed, the corresponding set of destination
@@ -411,8 +410,8 @@ the value written.
 
 NOTE: A simple in-order implementation can ignore the settings and
 simply execute all vector instructions using the undisturbed
-policy. The `vta` and `vma` state bits must still be provided in
-`vtype` for compatibility and to support thread migration.
+policy. The csr::[vta] and csr::[vma] state bits must still be provided in
+csr:vtype[] for compatibility and to support thread migration.
 
 NOTE: An out-of-order implementation can choose to implement
 tail-agnostic + mask-agnostic using tail-agnostic + mask-undisturbed
@@ -433,11 +432,11 @@ renaming to all 1s for granules in the tail.
 [[norm:vreg_mask_tail_op]]
 In addition, except for mask load instructions, any element in the
 tail of a mask result can also be written with the value the
-mask-producing operation would have calculated with `vl`=VLMAX.
-Furthermore, for mask-logical instructions and `vmsbf.m`, `vmsif.m`,
-`vmsof.m` mask-manipulation instructions, any element in the tail of
+mask-producing operation would have calculated with csr:vl[]=VLMAX.
+Furthermore, for mask-logical instructions and insn:vmsbf.m[], insn:vmsif.m[],
+insn:vmsof.m[] mask-manipulation instructions, any element in the tail of
 the result can be written with the value the mask-producing operation
-would have calculated with `vl`=VLEN, SEW=8, and LMUL=8 (i.e., all
+would have calculated with csr:vl[]=VLEN, SEW=8, and LMUL=8 (i.e., all
 bits of the mask register can be overwritten).
 
 NOTE: Mask tails are always treated as agnostic to reduce complexity
@@ -449,7 +448,7 @@ out the tail, except mask loads cannot write memory values to
 destination mask tails as this would imply accessing memory past
 software intent.
 
-The assembly syntax adds two mandatory flags to the `vsetvli` instruction:
+The assembly syntax adds two mandatory flags to the insn:vsetvli[] instruction:
 
 ----
  ta   # Tail agnostic
@@ -464,148 +463,148 @@ The assembly syntax adds two mandatory flags to the `vsetvli` instruction:
 ----
 
 NOTE: Prior to v0.9, when these flags were not specified on a
-`vsetvli`, they defaulted to mask-undisturbed/tail-undisturbed.  The
-use of `vsetvli` without these flags is deprecated, however, and
+insn:vsetvli[], they defaulted to mask-undisturbed/tail-undisturbed.  The
+use of insn:vsetvli[] without these flags is deprecated, however, and
 specifying a flag setting is now mandatory.  The default should
 perhaps be tail-agnostic/mask-agnostic, so software has to specify
 when it cares about the non-participating elements, but given the
 historical meaning of the instruction prior to introduction of these
 flags, it was decided to always require them in future assembly code.
 
-====== Vector Type Illegal (`vill`)
+====== Vector Type Illegal (csr::[vill])
 
-The `vill` bit is used to encode that a previous `vset{i}vl{i}`
-instruction attempted to write an unsupported value to `vtype`.
+The csr::[vill] bit is used to encode that a previous insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[]
+instruction attempted to write an unsupported value to csr:vtype[].
 
-NOTE: The `vill` bit is held in bit XLEN-1 of the CSR to support
+NOTE: The csr::[vill] bit is held in bit XLEN-1 of the CSR to support
 checking for illegal values with a branch on the sign bit.
 
 [[norm:vtype_vill_op]]
-If the `vill` bit is set, then any attempt to execute a vector instruction
-that depends upon `vtype` will raise an illegal-instruction exception.
+If the csr::[vill] bit is set, then any attempt to execute a vector instruction
+that depends upon csr:vtype[] will raise an illegal-instruction exception.
 
-NOTE: `vset{i}vl{i}` and whole register loads and stores do not depend
-upon `vtype`.
+NOTE: insn:vsetvli[], insn:vsetivli[], insn:vsetvl[], and whole register loads and stores do not depend
+upon csr:vtype[].
 
-When the `vill` bit is set, the other XLEN-1 bits in `vtype` shall be
+When the csr::[vill] bit is set, the other XLEN-1 bits in csr:vtype[] shall be
 zero.
 
-===== Vector Length (`vl`) Register
+===== Vector Length (csr:vl[]) Register
 
 [[norm:vl_acc]]
-The _XLEN_-bit-wide read-only `vl` CSR can only be updated by the
-`vset{i}vl{i}` instructions, and the _fault-only-first_ vector load
+The _XLEN_-bit-wide read-only csr:vl[] CSR can only be updated by the
+insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions, and the _fault-only-first_ vector load
 instruction variants.
 
 [[norm:vl_op]]
-The `vl` register holds an unsigned integer specifying the number of
+The csr:vl[] register holds an unsigned integer specifying the number of
 elements to be updated with results from a vector instruction, as
 further detailed in <<sec-inactive-defs>>.
 
-NOTE: The number of bits implemented in `vl` depends on the
+NOTE: The number of bits implemented in csr:vl[] depends on the
 implementation's maximum vector length of the smallest supported
 type. The smallest vector implementation with VLEN=32 and supporting
-SEW=8 would need at least six bits in `vl` to hold the values 0-32
+SEW=8 would need at least six bits in csr:vl[] to hold the values 0-32
 (VLEN=32, with LMUL=8 and SEW=8, yields VLMAX=32).
 
-===== Vector Byte Length (`vlenb`) Register
+===== Vector Byte Length (csr:vlenb[]) Register
 
 [[norm:vlenb_acc_op]]
-The _XLEN_-bit-wide read-only CSR `vlenb` holds the value VLEN/8,
+The _XLEN_-bit-wide read-only CSR csr:vlenb[] holds the value VLEN/8,
 i.e., the vector register length in bytes.
 
-NOTE: The value in `vlenb` is a design-time constant in any
+NOTE: The value in csr:vlenb[] is a design-time constant in any
 implementation.
 
 NOTE: Without this CSR, several instructions are needed to calculate
-VLEN in bytes, and the code has to disturb current `vl` and `vtype`
+VLEN in bytes, and the code has to disturb current csr:vl[] and csr:vtype[]
 settings which require them to be saved and restored.
 
-===== Vector Start Index (`vstart`) Register
+===== Vector Start Index (csr:vstart[]) Register
 [[norm:vstart_acc_sz]]
-The _XLEN_-bit-wide read-write `vstart` CSR specifies the index of the
+The _XLEN_-bit-wide read-write csr:vstart[] CSR specifies the index of the
 first element to be executed by a vector instruction, as described in
 <<sec-inactive-defs>>.
 
-Normally, `vstart` is only written by hardware on a trap on a vector
-instruction, with the `vstart` value representing the element on which
+Normally, csr:vstart[] is only written by hardware on a trap on a vector
+instruction, with the csr:vstart[] value representing the element on which
 the trap was taken (either a synchronous exception or an asynchronous
 interrupt), and at which execution should resume after a resumable
 trap is handled.
 
 [#norm:vstart_op]#All vector instructions are defined to begin execution with the
-element number given in the `vstart` CSR, leaving earlier elements in
-the destination vector undisturbed#, and to [#norm:vstart_update]#reset the `vstart` CSR to
+element number given in the csr:vstart[] CSR, leaving earlier elements in
+the destination vector undisturbed#, and to [#norm:vstart_update]#reset the csr:vstart[] CSR to
 zero at the end of execution.#
 
-NOTE: All vector instructions, including `vset{i}vl{i}`, reset the `vstart`
+NOTE: All vector instructions, including insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[], reset the csr:vstart[]
 CSR to zero.
 
 [[norm:vstart_unmodified]]
-`vstart` is not modified by vector instructions that raise illegal-instruction
+csr:vstart[] is not modified by vector instructions that raise illegal-instruction
 exceptions.
 
 [[norm:vstart_sz_writable]]
-The `vstart` CSR is defined to have only enough writable bits to hold
+The csr:vstart[] CSR is defined to have only enough writable bits to hold
 the largest element index (one less than the maximum VLMAX).
 
 NOTE: The maximum vector length is obtained with the largest LMUL
-setting (8) and the smallest SEW setting (8), so VLMAX_max = 8*VLEN/8 = VLEN.  For example, for VLEN=256, `vstart` would have 8 bits to
+setting (8) and the smallest SEW setting (8), so VLMAX_max = 8*VLEN/8 = VLEN.  For example, for VLEN=256, csr:vstart[] would have 8 bits to
 represent indices from 0 through 255.
 
 [[norm:vstart_val_rsv]]
-The use of `vstart` values greater than the largest element index for
-the current `vtype` setting is reserved.
+The use of csr:vstart[] values greater than the largest element index for
+the current csr:vtype[] setting is reserved.
 
-NOTE: It is recommended that implementations trap if `vstart` is out
+NOTE: It is recommended that implementations trap if csr:vstart[] is out
 of bounds.  It is not required to trap, as a possible future use of
-upper `vstart` bits is to store imprecise trap information.
+upper csr:vstart[] bits is to store imprecise trap information.
 
-The `vstart` CSR is writable by unprivileged code, but non-zero
-`vstart` values may cause vector instructions to run substantially
-slower on some implementations, so `vstart` should not be used by
+The csr:vstart[] CSR is writable by unprivileged code, but non-zero
+csr:vstart[] values may cause vector instructions to run substantially
+slower on some implementations, so csr:vstart[] should not be used by
 application programmers.  A few vector instructions cannot be
-executed with a non-zero `vstart` value and will raise an
+executed with a non-zero csr:vstart[] value and will raise an
 illegal-instruction exception as defined below.
 
-NOTE: Making `vstart` visible to unprivileged code supports user-level
+NOTE: Making csr:vstart[] visible to unprivileged code supports user-level
 threading libraries.
 
 [[norm:vstart_vtype_dep]]
 Implementations are permitted to raise illegal-instruction exceptions when
-attempting to execute a vector instruction with a value of `vstart` that the
+attempting to execute a vector instruction with a value of csr:vstart[] that the
 implementation can never produce when executing that same instruction with
-the same `vtype` setting.
+the same csr:vtype[] setting.
 
 NOTE: For example, some implementations will never take interrupts during
 execution of a vector arithmetic instruction, instead waiting until the
 instruction completes to take the interrupt.  Such implementations are
 permitted to raise an illegal-instruction exception when attempting to execute
-a vector arithmetic instruction when `vstart` is nonzero.
+a vector arithmetic instruction when csr:vstart[] is nonzero.
 
 NOTE: When migrating a software thread between two harts with
-different microarchitectures, the `vstart` value might not be
+different microarchitectures, the csr:vstart[] value might not be
 supported by the new hart microarchitecture.  The runtime on the
 receiving hart might then have to emulate instruction execution up to the
-next supported `vstart` element position.  Alternatively, migration events
-can be constrained to only occur at mutually supported `vstart`
+next supported csr:vstart[] element position.  Alternatively, migration events
+can be constrained to only occur at mutually supported csr:vstart[]
 locations.
 
-===== Vector Fixed-Point Rounding Mode (`vxrm`) Register
+===== Vector Fixed-Point Rounding Mode (csr:vxrm[]) Register
 
 [[norm:vxrm_val_sz_acc]]
 The vector fixed-point rounding-mode register holds a two-bit
 read-write rounding-mode field in the least-significant bits
-(`vxrm[1:0]`).  The upper bits, `vxrm[XLEN-1:2]`, should be written as
+(csr::[vxrm][1:0]).  The upper bits, csr::[vxrm][XLEN-1:2], should be written as
 zeros.
 
 [[norm:vcsr_vxrm_op]]
 The vector fixed-point rounding-mode is given a separate CSR address
 to allow independent access, but is also reflected as a field in
-`vcsr`.
+cse:vcsr[].
 
 NOTE: A new rounding mode can be set while saving the original
-rounding mode using a single `csrwi` instruction.
+rounding mode using a single insn:csrwi[] instruction.
 
 [[norm:vxrm_op]]
 The fixed-point rounding algorithm is specified as follows.
@@ -618,7 +617,7 @@ mode as specified in the following table.
 //[cols="1,1,4,10,5"]
 [%autowidth,float="center",align="center",cols="<,<,<,<,<",options="header"]
 |===
-2+| `vxrm[1:0]` | Abbreviation | Rounding Mode | Rounding increment, `r`
+2+| csr::[vxrm][1:0] | Abbreviation | Rounding Mode | Rounding increment, `r`
 
 | 0 | 0 | rnu | round-to-nearest-up (add +0.5 LSB)          | `v[d-1]`
 | 0 | 1 | rne | round-to-nearest-even                       | `v[d-1] & (v[d-2:0]{ne}0 \| v[d])`
@@ -633,22 +632,22 @@ roundoff_signed(v, d) = (signed(v) >> d) + r
 ----
 are used to represent this operation in the instruction descriptions below.
 
-===== Vector Fixed-Point Saturation Flag (`vxsat`)
+===== Vector Fixed-Point Saturation Flag (csr:vxsat[])
 
 [[norm:vxsat_op_acc_sz]]
-The `vxsat` CSR has a single read-write least-significant bit
-(`vxsat[0]`) that indicates if a fixed-point instruction has had to
+The csr:vxsat[] CSR has a single read-write least-significant bit
+(csr:vxsat[][0]) that indicates if a fixed-point instruction has had to
 saturate an output value to fit into a destination format.
-Bits `vxsat[XLEN-1:1]` should be written as zeros.
+The remaining bits, csr:vxsat[][XLEN-1:1], should be written as zeros.
 
 [[norm:vcsr_vxsat_op]]
-The `vxsat` bit is mirrored in `vcsr`.
+The csr:vxsat[] bit is mirrored in csr:vcsr[].
 
-===== Vector Control and Status (`vcsr`) Register
+===== Vector Control and Status (csr:vcsr[]) Register
 
 [[norm:vcsr_vxrm-vxsat_acc]]
-The `vxrm` and `vxsat` separate CSRs can also be accessed via fields
-in the _XLEN_-bit-wide vector control and status CSR, `vcsr`.
+The csr:vxrm[] and csr:vxsat[] separate CSRs can also be accessed via fields
+in the _XLEN_-bit-wide vector control and status CSR, csr:vcsr[].
 
 .vcsr layout
 [cols=">2,4,10"]
@@ -657,23 +656,23 @@ in the _XLEN_-bit-wide vector control and status CSR, `vcsr`.
 | Bits | Name   | Description
 
 | XLEN-1:3 |       | Reserved
-|  2:1 | vxrm[1:0] | Fixed-point rounding mode
-|    0 | vxsat     | Fixed-point accrued saturation flag
+|  2:1 | csr:vxrm[][1:0] | Fixed-point rounding mode
+|    0 | csr:vxsat[][0]  | Fixed-point accrued saturation flag
 |===
 
 ===== State of Vector Extension at Reset
 
 The vector extension must have a consistent state at reset.  In
-particular, `vtype` and `vl` must have values that can be read and
-then restored with a single `vsetvl` instruction.
+particular, csr:vtype[] and csr:vl[] must have values that can be read and
+then restored with a single csr:vsetvl[] instruction.
 
-NOTE: It is recommended that at reset, `vtype.vill` is set, the
-remaining bits in `vtype` are zero, and `vl` is set to zero.
+NOTE: It is recommended that at reset, csr:vtype[vill] is set, the
+remaining bits in csr:vtype[] are zero, and csr:vl[] is set to zero.
 
-The `vstart`, `vxrm`, `vxsat` CSRs can have arbitrary values at reset.
+The csr:vstart[], csr:vxrm[], csr:vxsat[] CSRs can have arbitrary values at reset.
 
-NOTE: Most uses of the vector unit will require an initial `vset{i}vl{i}`,
-which will reset `vstart`.  The `vxrm` and `vxsat` fields should be
+NOTE: Most uses of the vector unit will require an initial insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[],
+which will reset csr:vstart[].  The csr:vxrm[] and csr:vxsat[] fields should be
 reset explicitly in software before use.
 
 The vector registers can have arbitrary values at reset.
@@ -859,7 +858,7 @@ reserved.
 The vector ISA is designed to support mixed-width operations without
 requiring additional explicit rearrangement instructions.  The
 recommended software strategy when operating on multiple vectors with
-different precision values is to modify `vtype` dynamically to keep
+different precision values is to modify csr:vtype[] dynamically to keep
 SEW/LMUL constant (and hence VLMAX constant).
 
 The following example shows four different packed element widths (8b,
@@ -953,26 +952,26 @@ are written to an `x` or `f` register or to element 0 of a vector
 register.  [#norm:vreg_scalar_lmul_indp]#Any vector register can be used to hold a scalar regardless
 of the current LMUL setting.#
 
-NOTE: Zfinx ("F in X") is a new ISA extension where
+NOTE: ext:zfinx[] is an ISA extension where
 floating-point instructions take their arguments from the integer
-register file.  The vector extension is also compatible with Zfinx,
-where the Zfinx vector extension has vector-scalar floating-point
+register file.  The vector extension is also compatible with ext:zfinx[],
+where the ext:zfinx[] vector extension has vector-scalar floating-point
 instructions taking their scalar argument from the `x` registers.
 
 NOTE: We considered but did not pursue overlaying the `f` registers on
 `v` registers.  The adopted approach reduces vector register pressure,
 avoids interactions with the standard calling convention, simplifies
 high-performance scalar floating-point design, and provides
-compatibility with the Zfinx ISA option.  Overlaying `f` with `v`
+compatibility with the ext:zfinx[] ISA option.  Overlaying `f` with `v`
 would provide the advantage of lowering the number of state bits in
 some implementations, but complicates high-performance designs and
-would prevent compatibility with the Zfinx ISA option.
+would prevent compatibility with the ext:zfinx[] ISA option.
 
 [[sec-vec-operands]]
 ===== Vector Operands
 
 [[norm:eew_emul]]
-Each vector operand has an _effective_ _element_ _width_ (EEW) and an
+Each vector operand has an _effective element width_ (EEW) and an
 _effective_ LMUL (EMUL) that is used to determine the size and
 location of all the elements within a vector register group.  By
 default, for most operands of most instructions, EEW=SEW and
@@ -1015,12 +1014,12 @@ group only if one of the following holds:
   register in the destination vector register group is the same as the
   lowest-numbered register in the source vector register group.
   (For example, when LMUL=1,
-  `vnsrl.wi v0, v0, 3` is legal, but a destination of `v1` is not).
+  insn:vnsrl.wi[v0,v0,3] is legal, but a destination of `v1` is not).
 - The destination EEW is greater than the source EEW, the source EMUL is
   at least 1, and the highest-numbered register in the destination
   vector register group is the same as the highest-numbered register in
   the source vector register group.
-  (For example, when LMUL=8, `vzext.vf4 v0, v6` is legal,
+  (For example, when LMUL=8, insn:vzext.vf4[v0,v6] is legal,
   but a source of `v0`, `v2`, or `v4` is not).
 
 [[norm:vreg_mask_overlap]]
@@ -1036,7 +1035,7 @@ Any instruction encoding that violates the overlap constraints is reserved.
 [[norm:vreg_overlap_agn]]
 When source and destination registers overlap and have different EEW, the
 instruction is mask- and tail-agnostic, regardless of the setting of the
-`vta` and `vma` bits in `vtype`.
+csr::[vta] and csr::[vma] bits in csr:vtype[].
 
 [[norm:emul_rsv]]
 The largest vector register group used by an instruction can not be
@@ -1059,7 +1058,7 @@ Masking is supported on many vector instructions.  [#norm:vmask_inactive_op]#Ele
 that are masked off (inactive) never generate exceptions.#  [#norm:vmask_agn_op]#The
 destination vector register elements corresponding to masked-off
 elements are handled with either a mask-undisturbed or mask-agnostic
-policy depending on the setting of the `vma` bit in `vtype`#
+policy depending on the setting of the csr::[vma] bit in csr:vtype[]#
 (<<sec-agnostic>>).
 
 [[norm:vreg_vmask]]
@@ -1079,11 +1078,12 @@ vector register is being written with a mask value (e.g., compares)
 or the scalar result of a reduction.  These instruction encodings are
 reserved.
 
-NOTE: This constraint supports restart with a non-zero `vstart` value.
+NOTE: This constraint supports restart with a non-zero csr:vstart[] value.
 
+[[sec-mask-vector-logical]]
 Other vector registers can be used to hold working mask values, and
 mask vector logical operations are provided to perform predicate
-calculations. [[sec-mask-vector-logical]]
+calculations.
 
 As specified in <<sec-agnostic>>, mask destination tail elements are
 always treated as tail-agnostic, regardless of the setting of `vta`.
@@ -1092,7 +1092,7 @@ always treated as tail-agnostic, regardless of the setting of `vta`.
 ====== Mask Encoding
 
 [[norm:vmask_vm_enc]]
-Where available, masking is encoded in a single-bit `vm` field in the
+Where available, masking is encoded in a single-bit _vm_ field in the
  instruction (`inst[25]`).
 
 [cols="1,15"]
@@ -1131,10 +1131,10 @@ The destination element indices operated on during a vector
 instruction's execution can be divided into three disjoint subsets.
 
 * The _prestart_ elements are those whose element index is less than the
-initial value in the `vstart` register.  [#norm:vector_prestart_element]#The prestart elements do not raise exceptions and do not update the destination vector register.#
+initial value in the csr:vstart[] register.  [#norm:vector_prestart_element]#The prestart elements do not raise exceptions and do not update the destination vector register.#
 
 * The _body_ elements are those whose element index is greater than or equal
-to the initial value in the `vstart` register, and less than the current
+to the initial value in the csr:vstart[] register, and less than the current
 vector length setting in `vl`. The body can be split into two disjoint subsets:
 
 ** The _active_ elements during a vector instruction's execution are the
@@ -1143,11 +1143,11 @@ position.  [#norm:vector_active_element]#The active elements can raise exception
 
 ** The _inactive_ elements are the elements within the body
 but where the current mask is disabled at that element
-position.  [#norm:vector_inactive_element]#The inactive elements do not raise exceptions and do not update any destination vector register group unless masked agnostic is specified (`vtype.vma`=1), in which case inactive elements may be overwritten with 1s.#
+position.  [#norm:vector_inactive_element]#The inactive elements do not raise exceptions and do not update any destination vector register group unless masked agnostic is specified (csr:vtype[vma]=1), in which case inactive elements may be overwritten with 1s.#
 
 * The _tail_ elements during a vector instruction's execution are the
 elements past the current vector length setting specified in `vl`.
-[#norm:vector_tail_element]#The tail elements do not raise exceptions, and do not update any destination vector register group unless tail agnostic is specified (`vtype.vta`=1), in which case tail elements may be overwritten with 1s, or with the result of the instruction in the case of mask-producing instructions except for mask loads.  When LMUL < 1, the tail includes the elements past VLMAX that are held in the same vector register.#
+[#norm:vector_tail_element]#The tail elements do not raise exceptions, and do not update any destination vector register group unless tail agnostic is specified (csr:vtype[vta]=1), in which case tail elements may be overwritten with 1s, or with the result of the instruction in the case of mask-producing instructions except for mask loads.  When LMUL < 1, the tail includes the elements past VLMAX that are held in the same vector register.#
 
 ----
     for element index x
@@ -1160,43 +1160,43 @@ elements past the current vector length setting specified in `vl`.
 ----
 
 [[norm:vstart_vl_dep]]
-When `vstart` {ge} `vl`, there are no body elements, and no elements
+When csr:vstart[] {ge} csr:vl[], there are no body elements, and no elements
 are updated in any destination vector register group, including that
 no tail elements are updated with agnostic values.
 
-NOTE: As a consequence, when `vl`=0, no elements, including agnostic
+NOTE: As a consequence, when csr:vl[]=0, no elements, including agnostic
 elements, are updated in the destination vector register group
-regardless of `vstart`.
+regardless of csr:vstart[].
 
 [[norm:vstart_vl_scalar_indp]]
 Instructions that write an `x` register or `f` register
-do so even when `vstart` {ge} `vl`, including when `vl`=0.
+do so even when csr:vstart[] {ge} csr:vl[], including when csr:vl[]=0.
 
-NOTE: Some instructions such as `vslidedown` and `vrgather` may read
-indices past `vl` or even VLMAX in source vector register groups.  The
+NOTE: Some instructions such as insn:vslidedown[] and insn:vrgather[] may read
+indices past csr:vl[] or even VLMAX in source vector register groups.  The
 general policy is to return the value 0 when the index is greater than
 VLMAX in the source vector register group.
 
 [[sec-vector-config]]
-==== Configuration-Setting Instructions (`vsetvli`/`vsetivli`/`vsetvl`)
+==== Configuration-Setting Instructions
 
 One of the common approaches to handling a large number of elements is
 "strip mining" where each iteration of a loop handles some number of elements,
 and the iterations continue until all elements have been processed. The RISC-V
 vector specification provides direct, portable support for this approach.
 The application specifies the total number of elements to be processed (the application vector length or AVL) as a
-candidate value for `vl`, and the hardware responds via a general-purpose
+candidate value for csr:vl[], and the hardware responds via a general-purpose
 register with the (frequently smaller) number of elements that the hardware
-will handle per iteration (stored in `vl`), based on the microarchitectural
-implementation and the `vtype` setting. A straightforward loop structure,
+will handle per iteration (stored in csr:vl[]), based on the microarchitectural
+implementation and the csr:vtype[] setting. A straightforward loop structure,
 shown in <<example-stripmine-sew>>, depicts the ease with which the code keeps
 track of the remaining number of elements and the amount per iteration handled
 by hardware.
 
 A set of instructions is provided to allow rapid configuration of the
-values in `vl` and `vtype` to match application needs.  [#norm:vset_op]#The
-`vset{i}vl{i}` instructions set the `vtype` and `vl` CSRs based on
-their arguments, and write the new value of `vl` into `rd`.#
+values in csr:vl[] and csr:vtype[] to match application needs.  [#norm:vset_op]#The
+insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions set the csr:vtype[] and csr:vl[] CSRs based on
+their arguments, and write the new value of csr:vl[] into _rd_.#
 
 ----
  vsetvli rd, rs1, vtypei   # rd = new vl, rs1 = AVL, vtypei = new vtype setting
@@ -1206,13 +1206,13 @@ their arguments, and write the new value of `vl` into `rd`.#
 
 include::images/wavedrom/vcfg-format.edn[]
 
-===== `vtype` encoding
+===== csr:vtype[] encoding
 
 include::images/wavedrom/vtype-format.edn[]
 
 [[norm:vtype_acc]]
-The new `vtype` value is encoded in the immediate fields of `vsetvli`
-and `vsetivli`, and in the `rs2` register for `vsetvl`.
+The new csr:vtype[] value is encoded in the immediate fields of insn:vsetvli[] and
+insn:vsetivli[], and in the _rs2_ register for insn:vsetvl[].
 
 ----
  Suggested assembler names used for vset{i}vli vtypei immediate
@@ -1236,58 +1236,58 @@ Examples:
     vsetvli t0, a0, e32, mf2, ta, ma    # SEW=32, LMUL=1/2
 ----
 
-The `vsetvl` variant operates similarly to `vsetvli` except that it
-takes a `vtype` value from `rs2` and can be used for context restore.
+The insn:vsetvl[] variant operates similarly to insn:vsetvli[] except that it
+takes a csr:vtype[] value from _rs2_ and can be used for context restore.
 
-====== Unsupported `vtype` Values
+====== Unsupported csr:vtype[] Values
 
-[#norm:vtype_vill_val]#If the `vtype` value is not supported by the implementation, then
-the `vill` bit is set in `vtype`, the remaining bits in `vtype` are
-set to zero#, and [#norm:vtype_vstart_op]#the `vl` register is also set to zero.#
+[#norm:vtype_vill_val]#If the csr:vtype[] value is not supported by the implementation, then
+the csr::[vill] bit is set in csr:vtype[], the remaining bits in csr:vtype[] are
+set to zero#, and [#norm:vtype_vstart_op]#the csr:vl[] register is also set to zero.#
 
-NOTE: Earlier drafts required a trap when setting `vtype` to an
+NOTE: Earlier drafts required a trap when setting csr:vtype[] to an
 illegal value.  However, this would have added the first
 data-dependent trap on a CSR write to the ISA.  Implementations could
-choose to trap when illegal values are written to `vtype` instead of
-setting `vill`, to allow emulation to support new configurations for
+choose to trap when illegal values are written to csr:vtype[] instead of
+setting csr::[vill], to allow emulation to support new configurations for
 forward-compatibility.  The current scheme supports light-weight
 runtime interrogation of the supported vector unit configurations by
-checking if `vill` is clear for a given setting.
+checking if csr::[vill] is clear for a given setting.
 
 [[norm:vtype_vill_val_vill]]
-A `vtype` value with `vill` set is treated as an unsupported
+A csr:vtype[] value with csr::[vill] set is treated as an unsupported
 configuration.
 
 [[norm:vtype_vill_all_bits]]
-Implementations must consider all bits of the `vtype` value to
+Implementations must consider all bits of the csr:vtype[] value to
 determine if the configuration is supported.  An unsupported value in
-any location within the `vtype` value must result in `vill` being set.
+any location within the csr:vtype[] value must result in csr::[vill] being set.
 
-NOTE: In particular, all XLEN bits of the register `vtype` argument to
-the `vsetvl` instruction must be checked.  Implementations cannot
+NOTE: In particular, all XLEN bits of the register csr:vtype[] argument to
+the insn:vsetvl[] instruction must be checked.  Implementations cannot
 ignore fields they do not implement. All bits must be checked to
-ensure that new code assuming unsupported vector features in `vtype`
+ensure that new code assuming unsupported vector features in csr:vtype[]
 traps instead of executing incorrectly on an older implementation.
 
 ===== AVL encoding
 
 The new vector
-length setting is based on AVL, which for `vsetvli` and `vsetvl` is encoded in the `rs1` and `rd`
+length setting is based on AVL, which for insn:vsetvli[] and insn:vsetvl[] is encoded in the _rs1_ and _rd_
 fields as follows:
 
-.AVL used in `vsetvli` and `vsetvl` instructions
+.AVL used in insn:vsetvli[] and insn:vsetvl[] instructions
 [cols="2,2,10,10"]
 [%autowidth,float="center",align="center",options="header"]
 |===
-|  `rd`  | `rs1`  | AVL value         | Effect on `vl`
+|  _rd_  | _rs1_  | AVL value         | Effect on csr:vl[]
 |  -     | !x0    | Value in `x[rs1]` | Normal strip mining
-| !x0    |  x0    | ~0                | Set `vl` to VLMAX
-|  x0    |  x0    | Value in `vl` register | Keep existing `vl` (of course, `vtype` may change)
+| !x0    |  x0    | ~0                | Set csr:vl[] to VLMAX
+|  x0    |  x0    | Value in csr:vl[] register | Keep existing csr:vl[] (of course, csr:vtype[] may change)
 |===
 
 [[norm:vsetvl_op]]
 When _rs1_ is not `x0`, the AVL is an unsigned integer held in the `x`
-register specified by _rs1_, and the new `vl` value is also written to
+register specified by _rs1_, and the new csr:vl[] value is also written to
 the `x` register specified by _rd_.
 
 [[norm:vsetvl_op_rs1_x0_rd_nx0]]
@@ -1295,57 +1295,57 @@ When _rs1_=`x0` but _rd_≠`x0`, the maximum unsigned integer value (`~0`)
 is used as the AVL, and the resulting VLMAX is written to `vl` and
 also to the `x` register specified by `rd`.
 
-[#norm:vsetvl_op_rs1_x0_rd_x0]#When _rs1_=`x0` and _rd_=`x0`, the instructions operate as if the current vector length in `vl` is used as the AVL, and the resulting value is written to `vl`, but not to a destination register.  This form can only be used when VLMAX and hence `vl` is not actually changed by the new SEW/LMUL ratio.#  [#norm:vtype_vset_rsv]#Use of the instructions with a new SEW/LMUL ratio that would result in a change of VLMAX is reserved. Use of the instructions is also reserved if `vill` was 1 beforehand.# [#norm:reserved_vill_set]#Implementations may set `vill` in either case.#
+[#norm:vsetvl_op_rs1_x0_rd_x0]#When _rs1_=`x0` and _rd_=`x0`, the instructions operate as if the current vector length in csr:vl[] is used as the AVL, and the resulting value is written to csr:vl[], but not to a destination register.  This form can only be used when VLMAX and hence csr:vl[] is not actually changed by the new SEW/LMUL ratio.#  [#norm:vtype_vset_rsv]#Use of the instructions with a new SEW/LMUL ratio that would result in a change of VLMAX is reserved. Use of the instructions is also reserved if csr::[vill] was 1 beforehand.# [#norm:reserved_vill_set]#Implementations may set csr::[vill] in either case.#
 
-NOTE: This last form of the instructions allows the `vtype` register to
-be changed while maintaining the current `vl`, provided VLMAX is not
-reduced.  This design was chosen to ensure `vl` would always hold a
-legal value for current `vtype` setting.  The current `vl` value can
-be read from the `vl` CSR.  The `vl` value could be reduced by these
+NOTE: This last form of the instructions allows the csr:vtype[] register to
+be changed while maintaining the current csr:vl[], provided VLMAX is not
+reduced.  This design was chosen to ensure csr:vl[] would always hold a
+legal value for current csr:vtype[] setting.  The current csr:vl[] value can
+be read from the csr:vl[] CSR.  The csr:vl[] value could be reduced by these
 instructions if the new SEW/LMUL ratio causes VLMAX to shrink, and so
 this case has been reserved as it is not clear this is a generally
-useful operation, and implementations can otherwise assume `vl` is not
+useful operation, and implementations can otherwise assume csr:vl[] is not
 changed by these instructions to optimize their microarchitecture.
 
 [[norm:vsetivli_op]]
-For the `vsetivli` instruction, the AVL is encoded as a 5-bit
-zero-extended immediate (0--31) in the `rs1` field.
+For the insn:vsetivli[] instruction, the AVL is encoded as a 5-bit
+zero-extended immediate (0--31) in the _rs1_ field.
 
-NOTE: The encoding of AVL for `vsetivli` is the same as for regular
+NOTE: The encoding of AVL for insn:vsetivli[] is the same as for regular
 CSR immediate values.
 
-NOTE: The `vsetivli` instruction provides more compact code when the
+NOTE: The insn:vsetivli[] instruction provides more compact code when the
 dimensions of vectors are small and known to fit inside the vector
 registers, in which case there is no strip-mining overhead.
 
 [[constraints-on-setting-vl]]
-===== Constraints on Setting `vl`
+===== Constraints on Setting csr:vl[]
 
 [[norm:vl_val_lead-in]]
-The `vset{i}vl{i}` instructions first set VLMAX according to their `vtype`
-argument, then set `vl` obeying the following constraints:
+The insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions first set VLMAX according to their csr:vtype[]
+argument, then set csr:vl[] obeying the following constraints:
 
 [[norm:vl_val_list]]
-. `vl = AVL` if `AVL {le} VLMAX`
+. csr:vl[] = AVL if `AVL {le} VLMAX`
 . `ceil(AVL / 2) {le} vl {le} VLMAX` if `AVL < (2 * VLMAX)`
-. `vl = VLMAX` if `AVL {ge} (2 * VLMAX)`
+. csr:vl[] = VLMAX if `AVL {ge} (2 * VLMAX)`
 . Deterministic on any given implementation for same input AVL and VLMAX values
 . These specific properties follow from the prior rules:
-.. `vl = 0` if  `AVL = 0`
-.. `vl > 0` if `AVL > 0`
-.. `vl {le} VLMAX`
-.. `vl {le} AVL`
-.. a value read from `vl` when used as the AVL argument to `vset{i}vl{i}` results in the same
-value in `vl`, provided the resultant VLMAX equals the value of VLMAX at the time that `vl` was read
+.. csr:vl[] = 0 if  `AVL = 0`
+.. csr:vl[] > 0 if `AVL > 0`
+.. csr:vl[] {le} VLMAX
+.. csr:vl[] {le} AVL
+.. a value read from csr:vl[] when used as the AVL argument to insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[] results in the same
+value in csr:vl[], provided the resultant VLMAX equals the value of VLMAX at the time that csr:vl[] was read
 
 [NOTE]
 --
-The `vl` setting rules are designed to be sufficiently strict to
-preserve `vl` behavior across register spills and context swaps for
+The csr:vl[] setting rules are designed to be sufficiently strict to
+preserve csr:vl[] behavior across register spills and context swaps for
 `AVL {le} VLMAX`, yet flexible enough to enable implementations to improve
 vector lane utilization for `AVL > VLMAX`.
 
-For example, this permits an implementation to set `vl = ceil(AVL / 2)`
+For example, this permits an implementation to set csr:vl[] = ceil(AVL / 2)
 for `VLMAX < AVL < 2*VLMAX` in order to evenly distribute work over the
 last two iterations of a strip-mine loop.
 Requirement 2 ensures that the first strip-mine iteration of reduction
@@ -1353,7 +1353,7 @@ loops uses the largest vector length of all iterations, even in the case
 of `AVL < 2*VLMAX`.
 This allows software to avoid needing to explicitly calculate a running
 maximum of vector lengths observed during a strip-mined loop.
-Requirement 2 also allows an implementation to set vl to VLMAX for `VLMAX < AVL < 2*VLMAX`
+Requirement 2 also allows an implementation to set csr:vl[] to VLMAX for `VLMAX < AVL < 2*VLMAX`
 --
 
 [[example-stripmine-sew]]
@@ -1394,10 +1394,10 @@ memory.#
 [#norm:vector_masked_memory_access]#Vector loads and stores can be masked, and they only access memory or raise
 exceptions for active elements.#
 [#norm:vector_masked_inactive_behavior]#Masked vector loads do not update inactive elements in the destination vector
-register group, unless masked agnostic is specified (`vtype.vma`=1).#
+register group, unless masked agnostic is specified (csr:vtype[vma]=1).#
 [[norm:vector_ls_vstart]]
 All vector loads and stores may
-generate and accept a non-zero `vstart` value.
+generate and accept a non-zero csr:vstart[] value.
 
 ===== Vector Load/Store Instruction Encoding
 
@@ -1427,13 +1427,13 @@ include::images/wavedrom/vmem-format.edn[]
 | lumop[4:0]/sumop[4:0] | are additional fields encoding variants of unit-stride instructions
 |===
 
-[#norm:vector_ls_strided_eew]#Vector memory unit-stride and constant-stride operations directly encode EEW of the data to be transferred statically in the instruction to reduce the number of `vtype` changes when accessing memory in a mixed-width routine.# [#norm:vector_ls_indexed_eew]#Indexed operations use the explicit EEW encoding in the instruction to set the size of the indices used, and use SEW/LMUL to specify the data width.#
+[#norm:vector_ls_strided_eew]#Vector memory unit-stride and constant-stride operations directly encode EEW of the data to be transferred statically in the instruction to reduce the number of csr:vtype[] changes when accessing memory in a mixed-width routine.# [#norm:vector_ls_indexed_eew]#Indexed operations use the explicit EEW encoding in the instruction to set the size of the indices used, and use SEW/LMUL to specify the data width.#
 
 ===== Vector Load/Store Addressing Modes
 
 The vector extension supports unit-stride, constant-stride, and
 indexed (scatter/gather) addressing modes.  [#norm:vector_ls_base_stride_regtype]#Vector load/store base
-registers and strides are taken from the GPR `x` registers.#
+registers and strides are taken from the `x` registers.#
 
 [[norm:vector_ls_base]]
 The base effective address for all vector accesses is given by the
@@ -1577,7 +1577,7 @@ otherwise the instruction encoding is reserved.#
 Vector unit-stride and constant-stride use the EEW/EMUL encoded in the
 instruction for the data values, while vector indexed loads and stores
 use the EEW/EMUL encoded in the instruction for the index values and
-the SEW/LMUL encoded in `vtype` for the data values.
+the SEW/LMUL encoded in csr:vtype[] for the data values.
 
 Vector loads and stores are encoded using width values that are not
 claimed by the standard scalar floating-point loads and stores.
@@ -1637,7 +1637,7 @@ vse64.v   vs3, (rs1), vm  #   64-bit unit-stride store
 Additional unit-stride mask load and store instructions are
 provided to transfer mask values to/from memory.  These
 operate similarly to unmasked byte loads or stores (EEW=8), except that
-the effective vector length is ``evl`` = ceil(``vl``/8) (i.e. EMUL=1),
+the effective vector length is ``evl`` = ceil(csr:vl[]/8) (i.e. EMUL=1),
 and the destination register is always written with a tail-agnostic
 policy.
 
@@ -1649,15 +1649,15 @@ vlm.v vd, (rs1)   #  Load byte vector of length ceil(vl/8)
 vsm.v vs3, (rs1)  #  Store byte vector of length ceil(vl/8)
 ----
 
-`vlm.v` and `vsm.v` are encoded with the same `width[2:0]`=0 encoding as
-`vle8.v` and `vse8.v`, but are distinguished by different
-`lumop` and `sumop` encodings.  Since `vlm.v` and `vsm.v` operate as byte loads and stores,
-`vstart` is in units of bytes for these instructions.
+insn:vlm.v[] and insn:vsm.v[] are encoded with the same `width[2:0]`=0 encoding as
+insn:vle8.v[] and insn:vse8.v[], but are distinguished by different
+`lumop` and `sumop` encodings.  Since insn:vlm.v[] and insn:vsm.v[] operate as byte loads and stores,
+csr:vstart[] is in units of bytes for these instructions.
 
-NOTE: `vlm.v` and `vsm.v` respect the `vill` field in `vtype`, as
-they depend on `vtype` indirectly through its constraints on `vl`.
+NOTE: insn:vlm.v[] and insn:vsm.v[] respect the csr::[vill] field in csr:vtype[], as
+they depend on csr:vtype[] indirectly through its constraints on csr:vl[].
 
-NOTE: The previous assembler mnemonics `vle1.v` and `vse1.v` were
+NOTE: The previous assembler mnemonics insn:vle1.v[] and insn:vse1.v[] were
 confusing as length was handled differently for these instructions
 versus other element load/store instructions.  To avoid software
 churn, these older assembly mnemonics are being retained as aliases.
@@ -1667,7 +1667,7 @@ support machines that internally rearrange data to reduce
 cross-datapath wiring.  However, these instructions also provide a convenient
 mechanism to use packed bit vectors in memory as mask values,
 and also reduce the cost of mask spill/fill by reducing need to change
-`vl`.
+csr:vl[].
 
 ===== Vector Constant-Stride Instructions
 
@@ -1695,7 +1695,7 @@ Element accesses within a constant-stride instruction are unordered with
 respect to each other.
 
 [[norm:vector_ls_constant_stride_x0]]
-When `rs2`=`x0`, then an implementation is allowed, but not required,
+When _rs2_=`x0`, then an implementation is allowed, but not required,
 to perform fewer memory operations than the number of active elements,
 and may perform different numbers of memory operations across
 different dynamic executions of the same static instruction.
@@ -1768,7 +1768,7 @@ retained as an alias during transition to help reduce software churn.
 [#norm:vector_ff_trigger]#The unit-stride fault-only-first load instructions are used to
 vectorize loops with data-dependent exit conditions ("while" loops).
 These instructions execute as a regular load except that they will
-only take a trap caused by a synchronous exception on element 0.# [#norm:vector_ff_op]#If element 0 raises an exception, `vl` is not modified, and the trap is taken.  If an element > 0 raises an exception, the corresponding trap is not taken, and the vector length `vl` is reduced to the index of the element that would have raised an exception.#
+only take a trap caused by a synchronous exception on element 0.# [#norm:vector_ff_op]#If element 0 raises an exception, csr:vl[] is not modified, and the trap is taken.  If an element > 0 raises an exception, the corresponding trap is not taken, and the vector length csr:vl[] is reduced to the index of the element that would have raised an exception.#
 
 [#norm:vector_ls_overwrite_past_trap]#Load instructions may overwrite active destination vector register
 group elements past the element index at which the trap is reported.#
@@ -1805,17 +1805,17 @@ security mitigations for fault-only-first instructions.
 
 [[norm:vector_ff_no_exception]]
 Even when an exception is not raised, implementations are permitted to process
-fewer than `vl` elements and reduce `vl` accordingly, but if `vstart`=0 and
-`vl`>0, then at least one element must be processed.
+fewer than csr:vl[] elements and reduce csr:vl[] accordingly, but if csr:vstart[]=0 and
+csr:vl[]>0, then at least one element must be processed.
 
 [[norm:vector_ff_interrupt_behavior]]
 When the fault-only-first instruction takes a trap due to an
-interrupt, implementations should not reduce `vl` and should instead
-set a `vstart` value.
+interrupt, implementations should not reduce csr:vl[] and should instead
+set a csr:vstart[] value.
 
 NOTE: When the fault-only-first instruction would trigger a debug
 data-watchpoint trap on an element after the first, implementations
-should not reduce `vl` but instead should trigger the debug trap as
+should not reduce csr:vl[] but instead should trigger the debug trap as
 otherwise the event might be lost.
 
 [[sec-aos]]
@@ -1879,7 +1879,7 @@ a possible future longer instruction encoding that has more
 addressable vector registers.
 
 [[norm:vector_ls_seg_op]]
-The `vl` register gives the number of segments to move, which is
+The csr:vl[] register gives the number of segments to move, which is
 equal to the number of elements transferred to each vector register
 group.  Masking is also applied at the level of whole segments.
 
@@ -1888,7 +1888,7 @@ For segment loads and stores, the individual memory accesses used to
 access fields within each segment are unordered with respect to each
 other even for ordered indexed segment loads and stores.
 
-[#norm:vector_ls_seg_vstart_dep]#The `vstart` value is in units of whole segments.#  [#norm:vector_ls_seg_partial_access]#If a trap occurs during
+[#norm:vector_ls_seg_vstart_dep]#The csr:vstart[] value is in units of whole segments.#  [#norm:vector_ls_seg_partial_access]#If a trap occurs during
 access to a segment, it is implementation-defined whether a subset
 of the faulting segment's accesses are performed before the trap is taken.#
 
@@ -1919,7 +1919,7 @@ vsseg3e32.v vs3, (rs1), vm  # Store packed vector of 3*4-byte segments from vs3,
 ----
 
 [[norm:vector_ls_seg_unit_stride_vd_vs3]]
-For loads, the `vd` register will hold the first field loaded from the
+For loads, the _vd_ register will hold the first field loaded from the
 segment.  For stores, the `vs3` register is read to provide the first
 field to be stored to each segment.
 
@@ -1951,7 +1951,7 @@ vlseg<nf>e<eew>ff.v vd, (rs1),  vm    # Unit-stride fault-only-first segment loa
 For fault-only-first segment loads, if an exception is detected partway
 through accessing the zeroth segment, the trap is taken.
 If an exception is detected partway through accessing a subsequent segment,
-`vl` is reduced to the index of that segment.
+csr:vl[] is reduced to the index of that segment.
 [[norm:vector_ff_seg_partial_access]]
 In both cases, it is implementation-defined whether a subset of the segment is
 loaded.
@@ -1965,8 +1965,7 @@ at which vector length is trimmed.
 
 [[norm:vector_ls_seg_constant_stride_op]]
 Vector constant-stride segment loads and stores move contiguous segments where
-each segment is separated by the byte-stride offset given in the `rs2`
-GPR argument.
+each segment is separated by the byte-stride offset given in the _rs2_ argument.
 
 NOTE: Negative and zero strides are supported.
 
@@ -1994,7 +1993,7 @@ in memory.
 
 ====== Vector Indexed Segment Loads and Stores
 
-[#norm:vector_ls_seg_indexed_op]#Vector indexed segment loads and stores move contiguous segments where each segment is located at an address given by adding the scalar base address in the `rs1` field to byte offsets in vector register `vs2`.# Both ordered and unordered forms are provided, where the ordered forms access segments in element order. [#norm:vector_ls_seg_indexed_unordered]#However, even for the ordered form, accesses to the fields within an individual segment are not ordered with respect to each other.#
+[#norm:vector_ls_seg_indexed_op]#Vector indexed segment loads and stores move contiguous segments where each segment is located at an address given by adding the scalar base address in the _rs1_ field to byte offsets in vector register _vs2_.# Both ordered and unordered forms are provided, where the ordered forms access segments in element order. [#norm:vector_ls_seg_indexed_unordered]#However, even for the ordered form, accesses to the fields within an individual segment are not ordered with respect to each other.#
 
 [[norm:vector_ls_seg_indexed_eew_emul_op]]
 The data vector register group has EEW=SEW, EMUL=LMUL, while the index
@@ -2081,11 +2080,11 @@ These instructions load and store whole vector register groups.
 
 NOTE: These instructions are intended to be used to save and restore
 vector registers when the type or length of the current contents of
-the vector register is not known, or where modifying `vl` and `vtype`
+the vector register is not known, or where modifying csr:vl[] and csr:vtype[]
 would be costly. Examples include compiler register spills, vector
 function calls where values are passed in vector registers, interrupt
 handlers, and OS context switches.  Software can determine the number
-of bytes transferred by reading the `vlenb` register.
+of bytes transferred by reading the csr:vlenb[] register.
 
 [[norm:vector_ls_seg_wholereg_eew]]
 The load instructions have the element width encoded in the `mew` and `width`
@@ -2116,13 +2115,13 @@ numbers are placed contiguously in memory.#
 
 [[norm:vector_ls_seg_wholereg_evl]]
 The instructions operate with an effective vector length,
-`evl`=NFIELDS*VLEN/EEW, regardless of current settings in `vtype` and
-`vl`.  The usual property that no elements are written if `vstart`
-{ge} `vl` does not apply to these instructions.
-Similarly, the property that the instructions are reserved if `vstart`
-exceeds the largest element index for the current `vtype` setting
+`evl`=NFIELDS*VLEN/EEW, regardless of current settings in csr:vtype[] and
+csr:vl[].  The usual property that no elements are written if csr:vstart[]
+{ge} csr:vl[] does not apply to these instructions.
+Similarly, the property that the instructions are reserved if csr:vstart[]
+exceeds the largest element index for the current csr:vtype[] setting
 does not apply.
-Instead, the instructions are reserved if `vstart` {ge} `evl`.
+Instead, the instructions are reserved if csr:vstart[] {ge} `evl`.
 
 The instructions operate similarly to unmasked unit-stride load and
 store instructions, with the base address passed in the scalar `x`
@@ -2181,11 +2180,11 @@ vs8r.v v8, (a1)      # Store v8-v15 to address in a1
 ----
 
 NOTE: We have considered adding a whole register mask load instruction
-(`vl1rm.v`) but have decided to omit from initial extension.  The
+(insn:vl1rm.v[]) but have decided to omit from initial extension.  The
 primary purpose would be to inform the microarchitecture that the data
 will be used as a mask.  The same effect can be achieved with the
 following code sequence, whose cost is at most four instructions. Of
-these, the first could likely be removed as `vl` is often already
+these, the first could likely be removed as csr:vl[] is often already
 in a scalar register, and the last might already be present if the
 following vector instruction needs a new SEW/LMUL. So, in best case
 only two instructions (of which only one performs vector operations) are needed to synthesize the effect of the
@@ -2225,7 +2224,7 @@ Vector memory instructions appear to execute in program order on the
 local hart.
 
 [#norm:vector_ls_rvwmo]#Vector memory instructions follow RVWMO at the instruction level.#
-[#norm:vector_ls_rvtso]#If the Ztso extension is implemented, vector memory instructions additionally follow RVTSO at the instruction level.#
+[#norm:vector_ls_rvtso]#If the ext:ztso[] extension is implemented, vector memory instructions additionally follow RVTSO at the instruction level.#
 
 [[norm:vector_ls_indexed_ordered_ordered]]
 Except for vector indexed-ordered loads and stores, element operations
@@ -2236,14 +2235,14 @@ Vector indexed-ordered loads and stores read and write elements
 from/to memory in element order respectively,
 obeying RVWMO at the element level.
 
-NOTE: Ztso only imposes RVTSO at the instruction level; intra-instruction
-ordering follows RVWMO regardless of whether Ztso is implemented.
+NOTE: ext:ztso[] only imposes RVTSO at the instruction level; intra-instruction
+ordering follows RVWMO regardless of whether ext:ztso[] is implemented.
 
 NOTE: More formal definitions required.
 
 [[norm:vl_control_dependency]]
-Instructions affected by the vector length register `vl` have a control
-dependency on `vl`, rather than a data dependency.
+Instructions affected by the vector length register csr:vl[] have a control
+dependency on csr:vl[], rather than a data dependency.
 [[norm:vmask_control_dependency]]
 Similarly, masked vector instructions have a control dependency on the source
 mask register, rather than a data dependency.
@@ -2290,10 +2289,10 @@ NOTE: In this discussion, fixed-point operations are
 considered to be integer operations.
 
 All standard vector floating-point arithmetic operations follow the
-IEEE 754-2008 arithmetic standard.  [#norm:V_fp_frm]#All vector floating-point operations use the dynamic rounding mode in the `frm` register.#  [#norm:V_inv_frm_rsv]#Use of the `frm` field
+IEEE 754-2008 arithmetic standard.  [#norm:V_fp_frm]#All vector floating-point operations use the dynamic rounding mode in the csr:frm[] register.#  [#norm:V_inv_frm_rsv]#Use of the `frm` field
 when it contains an invalid rounding mode by any vector floating-point
 instruction--even those that do not depend on the rounding mode, or
-when `vl`=0, or when `vstart` {ge} `vl`{emdash}is reserved.#
+when csr:vl[]=0, or when csr:vstart[] {ge} csr:vl[]{emdash}is reserved.#
 
 NOTE: All vector floating-point code will rely on a valid value in
 `frm`.  Implementations can make all vector FP instructions report
@@ -2326,8 +2325,8 @@ type width (which includes when FLEN < SEW) are reserved.#
 NOTE: Some instructions _zero_-extend the 5-bit immediate, and denote this
 by naming the immediate `uimm` in the assembly syntax.
 
-NOTE: [#norm:V_Zinx_fp_scalar]#When adding a vector extension to the Zfinx/Zdinx/Zhinx
-extensions, floating-point scalar arguments are taken from the `x` registers.
+NOTE: [#norm:V_Zinx_fp_scalar]#When adding a vector extension to the ext:zfinx[], ext:zdinx[], and
+ext:zhinx[] extensions, floating-point scalar arguments are taken from the `x` registers.
 NaN-boxing is not supported in these extensions, and so operands narrower
 than XLEN bits are not checked for a NaN box; bits XLEN-1:EEW are ignored.
 For RV32_Zdinx, EEW=64 scalar arguments are supplied by an `x`-register pair.#
@@ -2384,8 +2383,8 @@ operands are always next to each other.
 
 [#norm:vwop_vd_eew_emul]#A few vector arithmetic instructions are defined to be __widening__
 operations where the destination vector register group has EEW=2*SEW
-and EMUL=2*LMUL.#  These are generally given a `vw*` prefix on the
-opcode, or `vfw*` for vector floating-point instructions.
+and EMUL=2*LMUL.#  These are generally given a insn:vw*[] prefix on the
+opcode, or insn:vfw*[] for vector floating-point instructions.
 
 The first vector register group operand can be either single or
 double-width.
@@ -2406,9 +2405,9 @@ NOTE: Originally, a `w` suffix was used on opcode, but this could be
 confused with the use of a `w` suffix to mean word-sized operations in
 doubleword integers, so the `w` was moved to prefix.
 
-NOTE: The floating-point widening operations were changed to `vfw*`
-from `vwf*` to be more consistent with any scalar widening
-floating-point operations that will be written as `fw*`.
+NOTE: The floating-point widening operations were changed to insn:vfw*[]
+from insn:vwf*[] to be more consistent with any scalar widening
+floating-point operations that will be written as insn:fw*[].
 
 Widening instruction encodings must follow the constraints in
 <<sec-vec-operands>>.
@@ -2426,15 +2425,15 @@ source vector register group (specified by `vs1`), this has the same
 NOTE: An alternative design decision would have been to treat SEW/LMUL
 as defining the size of the source vector register group.  The choice
 here is motivated by the belief the chosen approach will require fewer
-`vtype` changes.
+csr:vtype[] changes.
 
 NOTE: Compare operations that set a mask register are also
 implicitly a narrowing operation.
 
-A `vn*` prefix on the opcode is used to distinguish these instructions
-in the assembler, or a `vfn*` prefix for narrowing floating-point
+A insn:vn*[] prefix on the opcode is used to distinguish these instructions
+in the assembler, or a insn:vfn*[] prefix for narrowing floating-point
 opcodes.  The double-width source vector register group is signified
-by a `w` in the source operand suffix (e.g., `vnsra.wv`)
+by a `w` in the source operand suffix (e.g., insn:vnsra.wv[]).
 
 ----
 Assembly syntax pattern for vector narrowing arithmetic instructions
@@ -2476,7 +2475,7 @@ vrsub.vi vd, vs2, imm, vm   # vd[i] = imm - vs2[i]
 
 NOTE: A vector of integer values can be negated using a
 reverse-subtract instruction with a scalar operand of `x0`. An
-assembly pseudoinstruction `vneg.v vd,vs` = `vrsub.vx vd,vs,x0` is provided.
+assembly pseudoinstruction insn:vneg.v[vd,vs] = insn:vrsub.vx[vd,vs,x0] is provided.
 
 ===== Vector Widening Integer Add/Subtract
 
@@ -2512,8 +2511,8 @@ vwsub.wx  vd, vs2, rs1, vm  # vector-scalar
 
 NOTE: An integer value can be doubled in width using the widening add
 instructions with a scalar operand of `x0`.  Assembly
-pseudoinstructions `vwcvt.x.x.v vd,vs,vm` = `vwadd.vx vd,vs,x0,vm` and
-`vwcvtu.x.x.v vd,vs,vm` = `vwaddu.vx vd,vs,x0,vm` are provided.
+pseudoinstructions insn:vwcvt.x.x.v[vd,vs,vm] = insn:vwadd.vx[vd,vs,x0,vm] and
+insn:vwcvtu.x.x.v[vd,vs,vm] = insn:vwaddu.vx[vd,vs,x0,vm] are provided.
 
 ===== Vector Integer Extension
 
@@ -2559,13 +2558,13 @@ encoding constraints, the carry input must come from the implicit `v0`
 register,# but carry outputs can be written to any vector register that
 respects the source/destination overlap restrictions.
 
-[#norm:vadc_vsbc_op]#`vadc` and `vsbc` add or subtract the source operands and the carry-in or
+[#norm:vadc_vsbc_op]#insn:vadc[] and insn:vsbc[] add or subtract the source operands and the carry-in or
 borrow-in, and write the result to vector register `vd`.#
 [#norm:vadc_vsbc_masked_write_all_elem]#These instructions are encoded as masked instructions (`vm=0`), but they operate
 on and write back all body elements.#
 [#norm:vadc_vsbc_unmasked_rsv]#Encodings corresponding to the unmasked versions (`vm=1`) are reserved.#
 
-[#norm:vmadc_vmsbc_op_masked]#`vmadc` and `vmsbc` add or subtract the source operands, optionally
+[#norm:vmadc_vmsbc_op_masked]#insn:vmadc[] and insn:vmsbc[] add or subtract the source operands, optionally
 add the carry-in or subtract the borrow-in if masked (`vm=0`), and
 write the resulting carry-out or borrow-out back to mask register `vd`.#
 [#norm:vmadc_vmsbc_op_unmasked]#If unmasked (`vm=1`), there is no carry-in or borrow-in.#  [#norm:vmadc_vmsbc_masked_write_all_elem]#These instructions
@@ -2617,7 +2616,7 @@ vadc.vvm v4, v4, v8, v0   # Calc new sum
 vmmv.m v0, v1             # Move temp carry into v0 for next word
 ----
 
-The subtract with borrow instruction `vsbc` performs the equivalent
+The subtract with borrow instruction insn:vsbc[] performs the equivalent
 function to support long word arithmetic for subtraction.  There are
 no subtract with immediate instructions.
 
@@ -2645,10 +2644,10 @@ vmsbc.vv    vd, vs2, vs1      # Vector-vector, no borrow-in
 vmsbc.vx    vd, vs2, rs1      # Vector-scalar, no borrow-in
 ----
 
-[#norm:vmsbc_borrow_neg]#For `vmsbc`, the borrow is defined to be 1 iff the difference, prior to
+[#norm:vmsbc_borrow_neg]#For insn:vmsbc[], the borrow is defined to be 1 iff the difference, prior to
 truncation, is negative.#
 
-[#norm:vadc_vsbc_vd_v0_rsv]#For `vadc` and `vsbc`, the instruction encoding is reserved if the
+[#norm:vadc_vsbc_vd_v0_rsv]#For insn:vadc[] and insn:vsbc[], the instruction encoding is reserved if the
 destination vector register is `v0`.#
 
 NOTE: This constraint corresponds to the constraint on masked vector
@@ -2672,15 +2671,15 @@ vxor.vx vd, vs2, rs1, vm    # vector-scalar
 vxor.vi vd, vs2, imm, vm    # vector-immediate
 ----
 
-NOTE: With an immediate of -1, scalar-immediate forms of the `vxor`
+NOTE: With an immediate of -1, scalar-immediate forms of the insn:vxor[]
 instruction provide a bitwise NOT operation.  This is provided as
-an assembler pseudoinstruction `vnot.v vd,vs,vm` = `vxor.vi vd,vs,-1,vm`.
+an assembler pseudoinstruction insn:vnot.v[vd,vs,vm] = insn:vxor.vi[vd,vs,-1,vm].
 
 ===== Vector Single-Width Shift Instructions
 
 [#norm:vsll_vsrl_vsra_op]#A full set of vector shift instructions are provided, including
-logical shift left (`sll`), and logical (zero-extending `srl`) and
-arithmetic (sign-extending `sra`) shift right.  The data to be shifted
+logical shift left (insn:sll[]), and logical (zero-extending insn:srl[]) and
+arithmetic (sign-extending insn:sra[]) shift right.  The data to be shifted
 is in the vector register group specified by `vs2` and the shift
 amount value can come from a vector register group `vs1`, a scalar
 integer register `rs1`, or a zero-extended 5-bit immediate.#  [#norm:vsll_vsrl_vsra_shamt]#Only the low
@@ -2705,8 +2704,8 @@ vsra.vi vd, vs2, uimm, vm   # vector-immediate
 ===== Vector Narrowing Integer Right Shift Instructions
 
 [#norm:vnsrl_vnsra_op]#The narrowing right shifts extract a smaller field from a wider
-operand and have both zero-extending (`srl`) and sign-extending
-(`sra`) forms.  The shift amount can come from a vector register
+operand and have both zero-extending (insn:srl[]) and sign-extending
+(insn:sra[]) forms.  The shift amount can come from a vector register
 group, or a scalar `x` register, or a zero-extended 5-bit immediate.#
 [#norm:vnsrl_vnsra_shamt]#The low lg2(2*SEW) bits of the shift-amount value are
 used (e.g., the low 6 bits for a SEW=64-bit to SEW=32-bit narrowing
@@ -2729,7 +2728,7 @@ a destination that is 1/4 the width of the source.
 
 NOTE: An integer value can be halved in width using the narrowing integer
 shift instructions with a scalar operand of `x0`. An assembly
-pseudoinstruction is provided `vncvt.x.x.w vd,vs,vm` = `vnsrl.wx vd,vs,x0,vm`.
+pseudoinstruction is provided insn:vncvt.x.x.w[vd,vs,vm] = insn:vnsrl.wx[vd,vs,x0,vm].
 
 ===== Vector Integer Compare Instructions
 
@@ -2810,38 +2809,38 @@ x      scalar integer register
 i      immediate
 ----
 
-NOTE: The immediate forms of `vmslt{u}.vi` are not provided as the
-immediate value can be decreased by 1 and the `vmsle{u}.vi` variants
-used instead.  The `vmsle.vi` range is -16 to 15, resulting in an
-effective `vmslt.vi` range of -15 to 16.  The `vmsleu.vi` range is 0
-to 15 giving an effective `vmsltu.vi` range of 1 to 16 (Note,
-`vmsltu.vi` with immediate 0 is not useful as it is always
+NOTE: The immediate forms of insn:vmslt.vi[] and insn:vmsltu.vi[] are not provided as the
+immediate value can be decreased by 1 and the insn:vmsle.vi[] and insn:vmsleu.vi[] variants
+used instead.  The insn:vmsle.vi[] range is -16 to 15, resulting in an
+effective insn:vmslt.vi[] range of -15 to 16.  The insn:vmsleu.vi[] range is 0
+to 15 giving an effective insn:vmsltu.vi[] range of 1 to 16 (Note,
+insn:vmsltu.vi[] with immediate 0 is not useful as it is always
 false).
 
-NOTE: Similarly, `vmsge{u}.vi` is not provided and the compare is
-implemented using `vmsgt{u}.vi` with the immediate decremented by one.
-The resulting effective `vmsge.vi` range is -15 to 16, and the
-resulting effective `vmsgeu.vi` range is 1 to 16 (Note, `vmsgeu.vi` with
+NOTE: Similarly, insn:vmsge.vi[] and insn:vmsgeu.vi[] are not provided and comparison is
+implemented using insn:vmsgt.vi[] and insn:vmsgtu.vi[] with the immediate decremented by one.
+The resulting effective insn:vmsge.vi[] range is -15 to 16, and the
+resulting effective insn:vmsgeu.vi[] range is 1 to 16 (Note, insn:vmsgeu.vi[] with
 immediate 0 is not useful as it is always true).
 
 NOTE: Because the 5-bit vector immediates are always sign-extended,
-when the high bit of the `simm5` immediate is set, `vmsleu.vi` and
-`vmsgtu.vi` also support unsigned immediate values in the range
-`2^SEW^-16` to `2^SEW^-1`, allowing corresponding `vmsltu.vi` and
-`vmsgeu.vi` compares against unsigned immediates in the range `2^SEW^-15`
-to `2^SEW^`. Note that `vmsltu.vi` and `vmsgeu.vi` with immediate
+when the high bit of the `simm5` immediate is set, insn:vmsleu.vi[] and
+insn:vmsgtu.vi[] also support unsigned immediate values in the range
+`2^SEW^-16` to `2^SEW^-1`, allowing corresponding insn:vmsltu.vi[] and
+insn:vmsgeu.vi[] compares against unsigned immediates in the range `2^SEW^-15`
+to `2^SEW^`. Note that insn:vmsltu.vi[] and insn:vmsgeu.vi[] with immediate
 `2^SEW^` is not useful as it is always true or false, respectively.
 
-NOTE: The `vmsgt` forms for register scalar and immediates are provided
+NOTE: The insn:vmsgt[] forms for register scalar and immediates are provided
 to allow a single compare instruction to provide the correct
 polarity of mask value without using additional mask logical
 instructions.
 
-To reduce encoding space, the `vmsge{u}.vx` form is not directly
+To reduce encoding space, the insn:vmsge.vx[] and insn:vmsgeu.vx[] forms are not directly
 provided, and so the `va {ge} x` case requires special treatment.
 
-NOTE: The `vmsge{u}.vx` could potentially be encoded in a
-non-orthogonal way under the unused OPIVI variant of `vmslt{u}`.  These
+NOTE: insn:vmsge.vx[] and insn:vmsgeu.vx[] could potentially be encoded in a
+non-orthogonal way under the unused OPIVI variants of insn:vmslt[] and insn:vmsltu[].  These
 would be the only instructions in OPIVI that use a scalar `x` register
 however.  Alternatively, a further two funct6 encodings could be used,
 but these would have a different operand format (writes to mask
@@ -2849,8 +2848,8 @@ register) than others in the same group of 8 funct6 encodings.  The
 current PoR is to omit these instructions and to synthesize where
 needed as described below.
 
-The `vmsge{u}.vx` operation can be synthesized by reducing the
-value of `x` by 1 and using the `vmsgt{u}.vx` instruction, when it is
+The insn:vmsge.vx[] and insn:vmsgeu.vx[] operations can be synthesized by reducing the
+value of `x` by 1 and using the insn:vmsgt.vx[] and insn:vmsgtu.vx[] instructions, when it is
 known that this will not underflow the representation in `x`.
 
 ----
@@ -2951,14 +2950,14 @@ vmulhsu.vv vd, vs2, vs1, vm   # Vector-vector
 vmulhsu.vx vd, vs2, rs1, vm   # vector-scalar
 ----
 
-NOTE: There is no `vmulhus.vx` opcode to return high half of
+NOTE: There is no insn:vmulhus.vx[] opcode to return high half of
 unsigned-vector * signed-scalar product.  The scalar can be splatted
-to a vector, then a `vmulhsu.vv` used.
+to a vector, then a insn:vmulhsu.vv[] used.
 
-NOTE: The current `vmulh*` opcodes perform simple fractional
+NOTE: The current insn:vmulh*[] opcodes perform simple fractional
 multiplies, but with no option to scale, round, and/or saturate the
-result.  A possible future extension can consider variants of `vmulh`,
-`vmulhu`, `vmulhsu` that use the `vxrm` rounding mode when discarding
+result.  A possible future extension can consider variants of insn:vmulh[],
+insn:vmulhu[], insn:vmulhsu[] that use the csr:vxrm[] rounding mode when discarding
 low half of product.  There is no possibility of overflow in these
 cases.
 
@@ -3018,15 +3017,15 @@ vwmulsu.vx vd, vs2, rs1, vm # vector-scalar
 
 [#norm:vmacc_vnmsac_vmadd_vnmsub_op]#The integer multiply-add instructions are destructive and are provided
 in two forms, one that overwrites the addend or minuend
-(`vmacc`, `vnmsac`) and one that overwrites the first multiplicand
-(`vmadd`, `vnmsub`).#
+(insn:vmacc[], insn:vnmsac[]) and one that overwrites the first multiplicand
+(insn:vmadd[], insn:vnmsub[]).#
 
 [#norm:vmacc_vnmsac_vmadd_vnmsub_op_lowhalf]#The low half of the product is added or subtracted from the third operand.#
 
-NOTE: `sac` is intended to be read as "subtract from accumulator". The
-opcode is `vnmsac` to match the (unfortunately counterintuitive)
-floating-point `fnmsub` instruction definition.  Similarly for the
-`vnmsub` opcode.
+NOTE: insn:sac[] is intended to be read as "subtract from accumulator". The
+opcode is insn:vnmsac[] to match the (unfortunately counterintuitive)
+floating-point insn:fnmsub[] instruction definition.  Similarly for the
+insn:vnmsub[] opcode.
 
 ----
 # Integer multiply-add, overwrite addend
@@ -3075,9 +3074,9 @@ vwmaccus.vx vd, rs1, vs2, vm  # vd[i] = (unsigned(x[rs1]) * signed(vs2[i])) + vd
 [#norm:vmerge_op]#The vector integer merge instructions combine two source operands
 based on a mask.#  [#norm:vmerge_all_elem]#Unlike regular arithmetic instructions, the
 merge operates on all body elements (i.e., the set of elements from
-`vstart` up to the current vector length in `vl`).#
+csr:vstart[] up to the current vector length in csr:vl[]).#
 
-[#norm:vmerge_op_mask]#The `vmerge` instructions are encoded as masked instructions (`vm=0`).
+[#norm:vmerge_op_mask]#The insn:vmerge[] instructions are encoded as masked instructions (`vm=0`).
 The instructions combine two
 sources as follows.  At elements where the mask value is zero, the
 first operand is copied to the destination element, otherwise the
@@ -3097,8 +3096,8 @@ vmerge.vim vd, vs2, imm, v0  # vd[i] = v0.mask[i] ? imm    : vs2[i]
 
 [#norm:vmv_op]#The vector integer move instructions copy a source operand to a vector
 register group.
-The `vmv.v.v` variant copies a vector register group, whereas the `vmv.v.x`
-and `vmv.v.i` variants __splat__ a scalar register or immediate to all active
+The insn:vmv.v.v[] variant copies a vector register group, whereas the insn:vmv.v.x[] and
+insn:vmv.v.i[] variants __splat__ a scalar register or immediate to all active
 elements of the destination vector register group.#
 These instructions are encoded as unmasked instructions (`vm=1`).
 [#norm:vmv_vs2_nv0_rsv]#The first operand specifier (`vs2`) must contain `v0`, and any other vector
@@ -3111,21 +3110,21 @@ vmv.v.i vd, imm # vd[i] = imm
 ----
 
 NOTE: Mask values can be widened into SEW-width elements using a
-sequence `vmv.v.i vd, 0; vmerge.vim vd, vd, 1, v0`.
+sequence insn:vmv.v.i[vd,0]; insn:vmerge.vim[vd,vd,1,v0].
 
 NOTE: The vector integer move instructions share the encoding with the vector
 merge instructions, but with `vm=1` and `vs2=v0`.
 
-The form `vmv.v.v vd, vd`, which leaves body elements unchanged,
+The form insn:vmv.v.v[vd,vd], which leaves body elements unchanged,
 can be used to indicate that the register will next be used
 with an EEW equal to SEW.
 
 NOTE: Implementations that internally reorganize data according to EEW
 can shuffle the internal representation according to SEW.
 Implementations that do not internally reorganize data can dynamically
-elide this instruction (aside from resetting `vstart` to 0).
+elide this instruction (aside from resetting csr:vstart[] to 0).
 
-NOTE: The `vmv.v.v vd, vd` instruction is not a RISC-V HINT as a
+NOTE: The insn:vmv.v.v[vd,vd] instruction is not a RISC-V HINT as a
 tail-agnostic setting may cause an architectural state change on some
 implementations.
 
@@ -3153,7 +3152,7 @@ to avoid overflow.
 [#norm:vsaddu_vsadd_vssubu_vssub_op]#Saturating forms of integer add and subtract are provided, for both
 signed and unsigned integers.#  [#norm:vsaddu_vsadd_vssubu_vssub_op_overflow_vxsat_op_vsaddsub]#If the result would overflow the
 destination, the result is replaced with the closest representable
-value, and the `vxsat` bit is set.#
+value, and the csr:vxsat[] bit is set.#
 
 ----
 # Saturating adds of unsigned integers.
@@ -3178,13 +3177,13 @@ vssub.vx vd, vs2, rs1, vm   # vector-scalar
 ===== Vector Single-Width Averaging Add and Subtract
 
 [#norm:vaaddu_vaadd_vasubu_vasub_op]#The averaging add and subtract instructions right shift the result by
-one bit and round off the result according to the setting in `vxrm`.
+one bit and round off the result according to the setting in csr:vxrm[].
 Computation is performed in infinite precision before rounding and truncating.#
 Both unsigned and signed versions are provided.
-For `vaaddu` and `vaadd` there can be no overflow in the result.
-[#norm:vasub_vasubu_op_overflow]#For `vasub` and `vasubu`, overflow is ignored and the result wraps around.#
+For insn:vaaddu[] and insn:vaadd[] there can be no overflow in the result.
+[#norm:vasub_vasubu_op_overflow]#For insn:vasub[] and insn:vasubu[], overflow is ignored and the result wraps around.#
 
-NOTE: For `vasub`, overflow occurs only when subtracting the smallest number
+NOTE: For insn:vasub[], overflow occurs only when subtracting the smallest number
 from the largest number under `rnu` or `rne` rounding.
 
 ----
@@ -3213,8 +3212,8 @@ vasub.vx vd, vs2, rs1, vm   # roundoff_signed(vs2[i] - x[rs1], 1)
 
 [#norm:vsmul_op]#The signed fractional multiply instruction produces a 2*SEW product of
 the two SEW inputs, then shifts the result right by SEW-1 bits,
-rounding these bits according to `vxrm`, then saturates the result to
-fit into SEW bits.#  [#norm:vxsat_op_vsmul]#If the result causes saturation, the `vxsat` bit
+rounding these bits according to csr:vxrm[], then saturates the result to
+fit into SEW bits.#  [#norm:vxsat_op_vsmul]#If the result causes saturation, the csr:vxsat[] bit
 is set.#
 
 ----
@@ -3235,14 +3234,14 @@ precision by one bit for all other products.
 NOTE: We do not provide an equivalent fractional multiply where one
 input is unsigned, as these would retain all upper SEW bits and would
 not need to saturate.  This operation is partly covered by the
-`vmulhu` and `vmulhsu` instructions, for the case where rounding is
+insn:vmulhu[] and insn:vmulhsu[] instructions, for the case where rounding is
 simply truncation (`rdn`).
 
 ===== Vector Single-Width Scaling Shift Instructions
 
 [#norm:vssrl_vssra_op]#These instructions shift the input value right, and round off the
-shifted out bits according to `vxrm`.  The scaling right shifts have
-both zero-extending (`vssrl`) and sign-extending (`vssra`) forms.  The
+shifted out bits according to csr:vxrm[].  The scaling right shifts have
+both zero-extending (insn:vssrl[]) and sign-extending (insn:vssra[]) forms.  The
 data to be shifted is in the vector register group specified by `vs2`
 and the shift amount value can come from a vector register group
 `vs1`, a scalar integer register `rs1`, or a zero-extended 5-bit
@@ -3262,7 +3261,7 @@ immediate.# [#norm:vssrl_vssra_shamt]#Only the low lg2(SEW) bits of the shift-am
 
 ===== Vector Narrowing Fixed-Point Clip Instructions
 
-[#norm:vnclipu_vnclip_op]#The `vnclip` instructions are used to pack a fixed-point value into a
+[#norm:vnclipu_vnclip_op]#The insn:vnclip[] instructions are used to pack a fixed-point value into a
 narrower destination.  The instructions support rounding, scaling, and
 saturation into the final destination format.  The source data is in
 the vector register group specified by `vs2`. The scaling shift amount
@@ -3284,11 +3283,11 @@ vnclip.wx vd, vs2, rs1, vm   # vd[i] = clip(roundoff_signed(vs2[i], x[rs1]))
 vnclip.wi vd, vs2, uimm, vm  # vd[i] = clip(roundoff_signed(vs2[i], uimm))
 ----
 
-[#norm:vnclipu_vnclip_rounding]#For `vnclipu`/`vnclip`, the rounding mode is specified in the `vxrm`
-CSR.  Rounding occurs around the least-significant bit of the
+[#norm:vnclipu_vnclip_rounding]#For insn:vnclipu[] and insn:vnclip[], the rounding mode is specified in the
+csr:vxrm[] CSR.  Rounding occurs around the least-significant bit of the
 destination and before saturation.#
 
-[#norm:vnclipu_overflow]#For `vnclipu`, the shifted rounded source value is treated as an
+[#norm:vnclipu_overflow]#For insn:vnclipu[], the shifted rounded source value is treated as an
 unsigned integer and saturates if the result would overflow the
 destination viewed as an unsigned integer.#
 
@@ -3296,16 +3295,16 @@ NOTE: There is no single instruction that can saturate a signed value
 into an unsigned destination.  A sequence of two vector instructions
 that first removes negative numbers by performing a max against 0
 using `vmax` then clips the resulting unsigned value into the
-destination using `vnclipu` can be used if setting `vxsat` value for
-negative numbers is not required.  A `vsetvli` is required between
+destination using insn:vnclipu[] can be used if setting csr:vxsat[] value for
+negative numbers is not required.  A insn:vsetvli[] is required between
 these two instructions to change SEW.
 
-[#norm:vnclip_overflow]#For `vnclip`, the shifted rounded source value is treated as a signed
+[#norm:vnclip_overflow]#For insn:vnclip[], the shifted rounded source value is treated as a signed
 integer and saturates if the result would overflow the destination viewed
 as a signed integer.#
 
-[#norm:vxsat_op_vnclip_u]#If any destination element is saturated, the `vxsat` bit is set in the
-`vxsat` register.#
+[#norm:vxsat_op_vnclip_u]#If any destination element is saturated, the least-significant bit is set in the
+csr:vxsat[] register.#
 
 [[sec-vector-float]]
 ==== Vector Floating-Point Instructions
@@ -3330,19 +3329,19 @@ NOTE: In particular, future vector extensions supporting 16-bit
 half-precision floating-point values will also require some scalar
 half-precision floating-point support.
 
-[#norm:mstatus_FS_off_V_fp_ill]#If the floating-point unit status field `mstatus.FS` is `Off` then any
+[#norm:mstatus_FS_off_V_fp_ill]#If the floating-point unit status field csr:mstatus[fs] is `Off` then any
 attempt to execute a vector floating-point instruction will raise an
 illegal-instruction exception.#  [#norm:mstatus_FS_dirty_V_fp]#Any vector floating-point instruction
 that modifies any floating-point extension state (i.e., floating-point
-CSRs or `f` registers) must set `mstatus.FS` to `Dirty`.#
+CSRs or `f` registers) must set csr:mstatus[fs] to `Dirty`.#
 
-[#norm:vsstatus_mstatus_FS_off_hypervisor_V_fp_ill]#If the hypervisor extension is implemented and V=1, the `vsstatus.FS` field is
+[#norm:vsstatus_mstatus_FS_off_hypervisor_V_fp_ill]#If the hypervisor extension is implemented and V=1, the csr:vsstatus[fs] field is
 additionally in effect for vector floating-point instructions.  If
-`vsstatus.FS` or `mstatus.FS` is `Off` then any
+csr:vsstatus[fs] or csr:mstatus[fs] is `Off` then any
 attempt to execute a vector floating-point instruction will raise an
 illegal-instruction exception.#  [#norm:vsstatus_mstatus_FS_dirty_hypervisor_V_fp]#Any vector floating-point instruction
 that modifies any floating-point extension state (i.e., floating-point
-CSRs or `f` registers) must set both `mstatus.FS` and `vsstatus.FS` to `Dirty`.#
+CSRs or `f` registers) must set both csr:mstatus[fs] and csr:vsstatus[fs] to `Dirty`.#
 
 The vector floating-point instructions have the same behavior as the
 scalar floating-point instructions with regard to NaNs.
@@ -3353,7 +3352,7 @@ as described in <<sec-arithmetic-encoding>>.
 ===== Vector Floating-Point Exception Flags
 
 [#norm:fflags_op_V_fp]#A vector floating-point exception at any active floating-point element
-sets the standard FP exception flags in the `fflags` register.  Inactive
+sets the standard FP exception flags in the csr:fflags[] register.  Inactive
 elements do not set FP exception flags.#
 
 ===== Vector Single-Width Floating-Point Add/Subtract Instructions
@@ -3482,8 +3481,8 @@ vfwnmsac.vf vd, rs1, vs2, vm   # vd[i] = -(f[rs1] * vs2[i]) + vd[i]
 
 ===== Vector Floating-Point Square-Root Instruction
 
-This is a unary vector-vector instruction.
-[#norm:vfsqrt_op]
+[[norm:vfsqrt_op]]
+The insn:vfsqrt.v[] instruction is a unary vector-vector instruction.
 
 ----
 # Floating-point square root
@@ -3500,7 +3499,7 @@ vfrsqrt7.v vd, vs2, vm
 [#norm:vfrsqrt7_op]#This is a unary vector-vector instruction that returns an estimate of
 1/sqrt(x) accurate to 7 bits.#
 
-NOTE: An earlier draft version had used the assembler name `vfrsqrte7`
+NOTE: An earlier draft version had used the assembler name insn:vfrsqrte7[]
 but this was deemed to cause confusion with the ``e``__x__ notation for element
 width.  The earlier name can be retained as alias in tool chains for
 backward compatibility.
@@ -3566,7 +3565,7 @@ with greater estimate accuracy.
 vfrec7.v vd, vs2, vm
 ----
 
-NOTE: An earlier draft version had used the assembler name `vfrece7`
+NOTE: An earlier draft version had used the assembler name insn:vfrece7[]
 but this was deemed to cause confusion with ``e``__x__ notation for element
 width.  The earlier name can be retained as alias in tool chains for
 backward compatibility.
@@ -3656,9 +3655,9 @@ with greater estimate accuracy.
 
 ===== Vector Floating-Point MIN/MAX Instructions
 
-[#norm:vfmin_vfmax_op]#The vector floating-point `vfmin` and `vfmax` instructions have the
+[#norm:vfmin_vfmax_op]#The vector floating-point insn:vfmin[] and insn:vfmax[] instructions have the
 same behavior as the corresponding scalar floating-point instructions
-in version 2.2 of the RISC-V F/D/Q extension: they perform the `minimumNumber`
+in the ext:f[], ext:d[], and ext:q[] extensions: they perform the IEEE 754-2008 `minimumNumber`
 or `maximumNumber` operation on active elements.#
 
 ----
@@ -3689,12 +3688,12 @@ vfsgnjx.vf vd, vs2, rs1, vm  # vector-scalar
 
 NOTE: A vector of floating-point values can be negated using a
 sign-injection instruction with both source operands set to the same
-vector operand.  An assembly pseudoinstruction is provided: `vfneg.v vd,vs` = `vfsgnjn.vv vd,vs,vs`.
+vector operand.  An assembly pseudoinstruction is provided: insn:vfneg.v[vd,vs] = insn:vfsgnjn.vv[vd,vs,vs].
 
 NOTE: The absolute value of a vector of floating-point elements can be
 calculated using a sign-injection instruction with both source
 operands set to the same vector operand.  An assembly
-pseudoinstruction is provided: `vfabs.v vd,vs` = `vfsgnjx.vv vd,vs,vs`.
+pseudoinstruction is provided: insn:vfabs.v[vd,vs] = insn:vfsgnjx.vv[vd,vs,vs].
 
 ===== Vector Floating-Point Compare Instructions
 
@@ -3707,11 +3706,11 @@ mask register (`v0`).#  [#norm:vmfeq_vmfne_vmflt_vmfle_vmfgt_vmfge_tail_agnostic
 operate under a tail-agnostic policy.#
 
 The compare instructions follow the semantics of the scalar
-floating-point compare instructions.  [#norm:vmfeq_vmfne_sNaN_invalid]#`vmfeq` and `vmfne` raise the invalid
-operation exception only on signaling NaN inputs.#  [#norm:vmflt_vmfle_vmfgt_vmfge_sqNaN_invalid]#`vmflt`, `vmfle`, `vmfgt`,
-and `vmfge` raise the invalid operation exception on both signaling and
+floating-point compare instructions.  [#norm:vmfeq_vmfne_sNaN_invalid]#insn:vmfeq[] and insn:vmfne[] raise the invalid
+operation exception only on signaling NaN inputs.#  [#norm:vmflt_vmfle_vmfgt_vmfge_sqNaN_invalid]#insn:vmflt[], insn:vmfle[], insn:vmfgt[],
+and insn:vmfge[] raise the invalid operation exception on both signaling and
 quiet NaN inputs.#
-[#norm:vmfne_vdval1_NaN]#`vmfne` writes 1 to the destination element when either
+[#norm:vmfne_vdval1_NaN]#insn:vmfne[] writes 1 to the destination element when either
 operand is NaN,# [#norm:vmfeq_vmflt_vmfle_vmfgt_vmfge_vdval0_NaN]#whereas the other compares write 0 when either operand
 is NaN.#
 
@@ -3772,8 +3771,8 @@ vmand.mm v0, v0, v1        # Only set where A and B are ordered,
 vmfgt.vv v0, va, vb, v0.t  #  so only set flags on ordered values.
 ----
 
-NOTE: In the above sequence, it is tempting to mask the second `vmfeq`
-instruction and remove the `vmand` instruction, but this more efficient
+NOTE: In the above sequence, it is tempting to mask the second insn:vmfeq[]
+instruction and remove the insn:vmand[] instruction, but this more efficient
 sequence incorrectly fails to raise the invalid exception when an
 element of `va` contains a quiet NaN and the corresponding element in
 `vb` contains a signaling NaN.
@@ -3796,10 +3795,10 @@ destination elements.#
 ===== Vector Floating-Point Merge Instruction
 
 [#norm:vfmerge_op]#A vector-scalar floating-point merge instruction is provided,# which
-[#norm:vfmerge_all_elem]#operates on all body elements from `vstart` up to the current vector
-length in `vl` regardless of mask value.#
+[#norm:vfmerge_all_elem]#operates on all body elements from csr:vstart[] up to the current vector
+length in csr:vl[] regardless of mask value.#
 
-The `vfmerge.vfm` instruction is encoded as a masked instruction (`vm=0`).
+The insn:vfmerge.vfm[] instruction is encoded as a masked instruction (`vm=0`).
 [#norm:vfmerge_op_mask]#At elements where the mask value is zero, the first vector operand is
 copied to the destination element, otherwise a scalar floating-point
 register value is copied to the destination element.#
@@ -3821,7 +3820,7 @@ values for `vs2` reserved.#
 vfmv.v.f vd, rs1  # vd[i] = f[rs1]
 ----
 
-NOTE: The `vfmv.v.f` instruction shares the encoding with the `vfmerge.vfm`
+NOTE: The insn:vfmv.v.f[] instruction shares the encoding with the insn:vfmerge.vfm[]
 instruction, but with `vm=1` and `vs2=v0`.
 
 ===== Single-Width Floating-Point/Integer Type-Convert Instructions
@@ -3843,7 +3842,7 @@ vfcvt.f.x.v  vd, vs2, vm       # Convert signed integer to float.
 
 [#norm:vfcvt_op_exceptions]#The conversions follow the same rules on exceptional conditions as the
 scalar conversion instructions.#
-[#norm:vfcvt_op_frm]#The conversions use the dynamic rounding mode in `frm`, except for the `rtz`
+[#norm:vfcvt_op_frm]#The conversions use the dynamic rounding mode in csr:frm[], except for the `rtz`
 variants, which round towards zero.#
 
 NOTE: The `rtz` variants are provided to accelerate truncating conversions
@@ -3909,10 +3908,10 @@ NOTE: A full set of floating-point narrowing conversions is not
 supported as single instructions. Conversions can be implemented in
 a sequence of halving steps.  Results are equivalently rounded and
 the same exception flags are raised if all but the last halving step
-use round-towards-odd (`vfncvt.rod.f.f.w`).  Only the final step
+use round-towards-odd (insn:vfncvt.rod.f.f.w[]).  Only the final step
 should use the desired rounding mode.
 
-NOTE: For `vfncvt.rod.f.f.w`, a finite value that exceeds the range of the
+NOTE: For insn:vfncvt.rod.f.f.w[], a finite value that exceeds the range of the
 destination format is converted to the destination format's largest finite value with the same sign.
 
 ==== Vector Reduction Operations
@@ -3936,32 +3935,32 @@ unit.
 from the reduction, but the scalar operand is always included
 regardless of the mask values.#
 
-[#norm:vreduction_tail_policy]#The other elements in the destination vector register ( 0 < index <
+[#norm:vreduction_tail_policy]#The other elements in the destination vector register (0 < index <
 VLEN/SEW) are considered the tail and are managed with the current
 tail agnostic/undisturbed policy.#
 
-[#norm:vreduction_vl_0]#If `vl`=0, no operation is performed and the destination register is
+[#norm:vreduction_vl_0]#If csr:vl[]=0, no operation is performed and the destination register is
 not updated.#
 
-NOTE: This choice of behavior for `vl`=0 reduces implementation
+NOTE: This choice of behavior for csr:vl[]=0 reduces implementation
 complexity as it is consistent with other operations on vector
 register state.  For the common case that the source and destination
 scalar operand are the same vector register, this behavior also
 produces the expected result.  For the uncommon case that the source
 and destination scalar operand are in different vector registers, this
-instruction will not copy the source into the destination when `vl`=0.
+instruction will not copy the source into the destination when csr:vl[]=0.
 However, it is expected that in most of these cases it will be
-statically known that `vl` is not zero.  In other cases, a check for
-`vl`=0 will have to be added to ensure that the source scalar is
-copied to the destination (e.g., by explicitly setting `vl`=1 and
+statically known that csr:vl[] is not zero.  In other cases, a check for
+csr:vl[]=0 will have to be added to ensure that the source scalar is
+copied to the destination (e.g., by explicitly setting csr:vl[]=1 and
 performing a register-register copy).
 
 [#norm:vreduction_trap]#Traps on vector reduction instructions are always reported with a
-`vstart` of 0.#  [#norm:vreduction_vstart_n0_ill]#Vector reduction operations raise an
-illegal-instruction exception if `vstart` is non-zero.#
+csr:vstart[] of 0.#  [#norm:vreduction_vstart_n0_ill]#Vector reduction operations raise an
+illegal-instruction exception if csr:vstart[] is non-zero.#
 
-The assembler syntax for a reduction operation is `vredop.vs`, where
-the `.vs` suffix denotes the first operand is a vector register group
+The assembler syntax for a reduction operation is insn:vredop.vs[], where
+the insn:.vs[] suffix denotes the first operand is a vector register group
 and the second operand is a scalar stored in element 0 of a vector
 register.
 
@@ -3986,14 +3985,14 @@ vredxor.vs  vd, vs2, vs1, vm   # vd[0] =  xor( vs1[0] , vs2[*] )
 [[sec-vector-integer-reduce-widen]]
 ===== Vector Widening Integer Reduction Instructions
 
-[#norm:vwredsumu_op]#The unsigned `vwredsumu.vs` instruction zero-extends the SEW-wide
+[#norm:vwredsumu_op]#The unsigned insn:vwredsumu.vs[] instruction zero-extends the SEW-wide
 vector elements before summing them, then adds the 2*SEW-width scalar
 element, and stores the result in a 2*SEW-width scalar element.#
 
-[#norm:vwredsum_op]#The `vwredsum.vs` instruction sign-extends the SEW-wide vector
+[#norm:vwredsum_op]#The insn:vwredsum.vs[] instruction sign-extends the SEW-wide vector
 elements before summing them.#
 
-[#norm:vwredsumu_vwredsum_op_overflow]#For both `vwredsumu.vs` and `vwredsum.vs`, overflows wrap around.#
+[#norm:vwredsumu_vwredsum_op_overflow]#For both insn:vwredsumu.vs[] and insn:vwredsum.vs[], overflows wrap around.#
 
 ----
 # Unsigned sum reduction into double-width accumulator
@@ -4014,11 +4013,11 @@ vfredmax.vs  vd, vs2, vs1, vm # Maximum value
 vfredmin.vs  vd, vs2, vs1, vm # Minimum value
 ----
 
-NOTE: Older assembler mnemonic `vfredsum` is retained as alias for `vfredusum`.
+NOTE: Older assembler mnemonic insn:vfredsum[] is retained as alias for insn:vfredusum[].
 
 ====== Vector Ordered Single-Width Floating-Point Sum Reduction
 
-[#norm:vfredosum_op]#The `vfredosum` instruction must sum the floating-point values in
+[#norm:vfredosum_op]#The insn:vfredosum[] instruction must sum the floating-point values in
 element order, starting with the scalar in `vs1[0]`#{emdash}that is, it
 performs the computation:
 
@@ -4043,7 +4042,7 @@ summation loop.
 
 ====== Vector Unordered Single-Width Floating-Point Sum Reduction
 
-The unordered sum reduction instruction, `vfredusum`, provides an
+The unordered sum reduction instruction, insn:vfredusum[], provides an
 implementation more freedom in performing the reduction.
 
 [#norm:vfredusum_op]#The implementation must produce a result equivalent to a reduction tree
@@ -4072,7 +4071,7 @@ is allowed to add an additional additive identity to the final result.
 -0.0 for all other rounding modes.#
 
 [#norm:vfredusum_redtree]#The reduction tree structure must be deterministic for a given value
-in `vtype` and `vl`.#
+in csr:vtype[] and csr:vl[].#
 
 NOTE: As a consequence of this definition, implementations need not propagate
 NaN payloads through the reduction tree when no elements are active. In
@@ -4080,15 +4079,15 @@ particular, if no elements are active and the scalar input is NaN,
 implementations are permitted to canonicalize the NaN and, if the NaN is
 signaling, set the invalid exception flag.  Implementations are alternatively
 permitted to pass through the original NaN and set no exception flags, as with
-`vfredosum`.
+insn:vfredosum[].
 
-NOTE: The `vfredosum` instruction is a valid implementation of the
-`vfredusum` instruction.
+NOTE: The insn:vfredosum[] instruction is a valid implementation of the
+insn:vfredusum[] instruction.
 
 ====== Vector Single-Width Floating-Point Max and Min Reductions
 
-[#norm:vfredmin_vfredmax_op]#The `vfredmin` and `vfredmax` instructions reduce the scalar argument in
-`vs1[0]` and active elements in `vs2` using the `minimumNumber` and
+[#norm:vfredmin_vfredmax_op]#The insn:vfredmin[] and insn:vfredmax[] instructions reduce the scalar argument in
+`vs1[0]` and active elements in `vs2` using the IEEE 754-2008 `minimumNumber` and
 `maximumNumber` operations, respectively.#
 
 NOTE: Floating-point max and min reductions should return the same
@@ -4111,14 +4110,14 @@ read and write a double-width reduction result.#
  vfwredusum.vs vd, vs2, vs1, vm # Unordered sum
 ----
 
-NOTE: Older assembler mnemonic `vfwredsum` is retained as alias for `vfwredusum`.
+NOTE: Older assembler mnemonic insn:vfwredsum[] is retained as alias for insn:vfwredusum[].
 
 [#norm:vfwredosum_vfwredusum_op_reduction]#The reduction of the SEW-width elements is performed as in the
 single-width reduction case, with the elements in `vs2` promoted
 to 2*SEW bits before adding to the 2*SEW-bit accumulator.#
 
-NOTE: `vfwredosum.vs` handles inactive elements and NaN payloads analogously
-to `vfredosum.vs`; `vfwredusum.vs` does so analogously to `vfredusum.vs`.
+NOTE: insn:vfwredosum.vs[] handles inactive elements and NaN payloads analogously
+to insn:vfredosum.vs[]; insn:vfwredusum.vs[] does so analogously to insn:vfredusum.vs[].
 
 [[sec-vector-mask]]
 ==== Vector Mask Instructions
@@ -4132,15 +4131,15 @@ a vector register.
 [#norm:vmask_maskreg_def]#Vector mask-register logical operations operate on mask registers.
 Each element in a mask register is a single bit,# [#norm:instrgrp_vmask_disregard_vlmul]#so these instructions
 all operate on single vector registers regardless of the setting of
-the `vlmul` field in `vtype`.  They do not change the value of
-`vlmul`.#  [#norm:vmask_vd_overlap_vs]#The destination vector register may be the same as either
+the csr::[vlmul] field in csr:vtype[].  They do not change the value of
+csr::[vlmul].#  [#norm:vmask_vd_overlap_vs]#The destination vector register may be the same as either
 source vector register.#
 
 [#norm:vmask_vstart]#As with other vector instructions, the elements with indices less than
-`vstart` are unchanged, and `vstart` is reset to zero after execution.#
+csr:vstart[] are unchanged, and csr:vstart[] is reset to zero after execution.#
 [#norm:vmasklogical_unmasked]#Vector mask logical instructions are always unmasked,# [#norm:vmasklogical_masked_rsv]#so there are no
 inactive elements, and the encodings with `vm=0` are reserved.#
-[#norm:vmasklogical_tail_agnostic]#Mask elements past `vl`, the tail elements, are
+[#norm:vmasklogical_tail_agnostic]#Mask elements past csr:vl[], the tail elements, are
 always updated with a tail-agnostic policy.#
 
 [#norm:vmand_vmnand_vmandn_vmxor_vmor_vmnor_vmorn_vmxnor_op]
@@ -4155,9 +4154,9 @@ vmorn.mm  vd, vs2, vs1  # vd.mask[i] =   vs2.mask[i] || !vs1.mask[i]
 vmxnor.mm vd, vs2, vs1  # vd.mask[i] = !(vs2.mask[i] ^^  vs1.mask[i])
 ----
 
-NOTE: The previous assembler mnemonics `vmandnot` and `vmornot` have
-been changed to `vmandn` and `vmorn` to be consistent with the
-equivalent scalar instructions.  The old `vmandnot` and `vmornot`
+NOTE: The previous assembler mnemonics csr:vmandnot[] and csr:vmornot[] have
+been changed to csr:vmandn[] and csr:vmorn[] to be consistent with the
+equivalent scalar instructions.  The old csr:vmandnot[] and csr:vmornot[]
 mnemonics can be retained as assembler aliases for compatibility.
 
 Several assembler pseudoinstructions are defined as shorthand for
@@ -4169,12 +4168,12 @@ vmset.m vd     => vmxnor.mm vd, vd, vd  # Set mask register
 vmnot.m vd, vs => vmnand.mm vd, vs, vs  # Invert bits
 ----
 
-NOTE: The `vmmv.m` instruction was previously called `vmcpy.m`, but
+NOTE: The csr:vmmv.m[] instruction was previously called csr:vmcpy.m[], but
 with new layout it is more consistent to name as a "mv" because bits
-are copied without interpretation.  The `vmcpy.m` assembler
+are copied without interpretation.  The csr:vmcpy.m[] assembler
 pseudoinstruction can be retained for compatibility.  For
 implementations that internally rearrange bits according to EEW, a
-`vmmv.m` instruction with same source and destination can be used as
+csr:vmmv.m[] instruction with same source and destination can be used as
 idiom to force an internal reformat into a mask vector.
 
 The set of eight mask logical instructions can generate any of the 16
@@ -4192,22 +4191,22 @@ possibly binary logical functions of the two input masks:
 |===
 4+| output  | instruction | pseudoinstruction
 
-| 0 | 0 | 0 | 0 | vmxor.mm vd, vd, vd         | vmclr.m vd
-| 1 | 0 | 0 | 0 | vmnor.mm vd, src1, src2     |
-| 0 | 1 | 0 | 0 | vmandn.mm vd, src2, src1    |
-| 1 | 1 | 0 | 0 | vmnand.mm vd, src1, src1    | vmnot.m vd, src1
-| 0 | 0 | 1 | 0 | vmandn.mm vd, src1, src2    |
-| 1 | 0 | 1 | 0 | vmnand.mm vd, src2, src2    | vmnot.m vd, src2
-| 0 | 1 | 1 | 0 | vmxor.mm vd, src1, src2     |
-| 1 | 1 | 1 | 0 | vmnand.mm vd, src1, src2    |
-| 0 | 0 | 0 | 1 | vmand.mm vd, src1, src2     |
-| 1 | 0 | 0 | 1 | vmxnor.mm vd, src1, src2    |
-| 0 | 1 | 0 | 1 | vmand.mm vd, src2, src2     | vmmv.m vd, src2
-| 1 | 1 | 0 | 1 | vmorn.mm vd, src2, src1     |
-| 0 | 0 | 1 | 1 | vmand.mm vd, src1, src1     | vmmv.m vd, src1
-| 1 | 0 | 1 | 1 | vmorn.mm vd, src1, src2     |
-| 0 | 1 | 1 | 1 | vmor.mm vd, src1, src2      |
-| 1 | 1 | 1 | 1 | vmxnor.mm vd, vd, vd        | vmset.m vd
+| 0 | 0 | 0 | 0 | insn:vmxor.mm[vd, vd, vd]    | insn:vmclr.m[vd]
+| 1 | 0 | 0 | 0 | insn:vmnor.mm[vd,src1,src2]  |
+| 0 | 1 | 0 | 0 | insn:vmandn.mm[vd,src2,src1] |
+| 1 | 1 | 0 | 0 | insn:vmnand.mm[vd,src1,src1] | insn:vmnot.m[vd,src1]
+| 0 | 0 | 1 | 0 | insn:vmandn.mm[vd,src1,src2] |
+| 1 | 0 | 1 | 0 | insn:vmnand.mm[vd,src2,src2] | insn:vmnot.m[vd,src2]
+| 0 | 1 | 1 | 0 | insn:vmxor.mm[vd,src1,src2]  |
+| 1 | 1 | 1 | 0 | insn:vmnand.mm[vd,src1,src2] |
+| 0 | 0 | 0 | 1 | insn:vmand.mm[vd,src1,src2]  |
+| 1 | 0 | 0 | 1 | insn:vmxnor.mm[vd,src1,src2] |
+| 0 | 1 | 0 | 1 | insn:vmand.mm[vd,src2,src2]  | insn:vmmv.m[vd,src2]
+| 1 | 1 | 0 | 1 | insn:vmorn.mm[vd,src2,src1]  |
+| 0 | 0 | 1 | 1 | insn:vmand.mm[vd,src1,src1]  | insn:vmmv.m[vd,src1]
+| 1 | 0 | 1 | 1 | insn:vmorn.mm[vd,src1,src2]  |
+| 0 | 1 | 1 | 1 | insn:vmor.mm[vd,src1,src2]   |
+| 1 | 1 | 1 | 1 | insn:vmxnor.mm[vd,vd,vd]     | insn:vmset.m[vd]
 |===
 
 NOTE: The vector mask logical instructions are designed to be easily
@@ -4216,21 +4215,21 @@ the number of predicate registers by moving values into `v0` before
 use.
 
 
-===== Vector count population in mask `vcpop.m`
+===== Vector Count Population in Mask insn:vcpop.m[]
 
 ----
 vcpop.m rd, vs2, vm
 ----
 
-NOTE: This instruction previously had the assembler mnemonic `vpopc.m`
+NOTE: This instruction previously had the assembler mnemonic insn:vpopc.m[]
 but was renamed to be consistent with the scalar instruction.  The
-assembler instruction alias `vpopc.m` is being retained for software
+assembler instruction alias insn:vpopc.m[] is being retained for software
 compatibility.
 
 [#norm:vcpop_vs_single_vreg]#The source operand is a single vector register holding mask register
 values as described in <<sec-mask-register-layout>>.#
 
-[#norm:vcpop_op]#The `vcpop.m` instruction counts the number of mask elements of the
+[#norm:vcpop_op]#The insn:vcpop.m[] instruction counts the number of mask elements of the
 active elements of the vector source mask register that have the value
 1 and writes the result to a scalar `x` register.#
 
@@ -4241,36 +4240,36 @@ masked elements are counted.#
 vcpop.m rd, vs2, v0.t # x[rd] = sum_i ( vs2.mask[i] && v0.mask[i] )
 ----
 
-[#norm:vcpop_vl0]#The `vcpop.m` instruction writes `x[rd]` even if `vl`=0 (with the
+[#norm:vcpop_vl0]#The insn:vcpop.m[] instruction writes `x[rd]` even if csr:vl[]=0 (with the
 value 0, since no mask elements are active).#
 
-[#norm:vcpop_trap]#Traps on `vcpop.m` are always reported with a `vstart` of 0.#  [#norm:vcpop_vstart_n0_ill]#The
+[#norm:vcpop_trap]#Traps on insn:vcpop.m[] are always reported with a csr:vstart[] of 0.#  [#norm:vcpop_vstart_n0_ill]#The
 `vcpop.m` instruction will raise an illegal-instruction exception if
 `vstart` is non-zero.#
 
-===== `vfirst` find-first-set mask bit
+===== insn:vfirst[] Find-First-Set Mask Bit
 
 ----
 vfirst.m rd, vs2, vm
 ----
 
-[#norm:vfirst_op]#The `vfirst` instruction finds the lowest-numbered active element of
+[#norm:vfirst_op]#The insn:vfirst[] instruction finds the lowest-numbered active element of
 the source mask vector that has the value 1 and writes that element's
-index to a GPR.  If no active element has the value 1, -1 is written
-to the GPR.#
+index to _rd_.  If no active element has the value 1, -1 is written
+to _rd_.#
 
 NOTE: Software can assume that any negative value (highest bit set)
 corresponds to no element found, as vector lengths will never reach
 2^(XLEN-1)^ on any implementation.
 
-[#norm:vfirst_vl0]#The `vfirst.m` instruction writes `x[rd]` even if `vl`=0 (with the
+[#norm:vfirst_vl0]#The insn:vfirst.m[] instruction writes `x[rd]` even if `vl`=0 (with the
 value -1, since no mask elements are active).#
 
-[#norm:vfirst_trap]#Traps on `vfirst` are always reported with a `vstart` of 0.#  [#norm:vfirst_vstart_n0_ill]#The
-`vfirst` instruction will raise an illegal-instruction exception if
-`vstart` is non-zero.#
+[#norm:vfirst_trap]#Traps on insn:vfirst[] are always reported with a csr:vstart[] of 0.#  [#norm:vfirst_vstart_n0_ill]#The
+insn:vfirst[] instruction will raise an illegal-instruction exception if
+csr:vstart[] is non-zero.#
 
-===== `vmsbf.m` set-before-first mask bit
+===== insn:vmsbf.m[] Set-Before-First Mask Bit
 
 ----
     vmsbf.m vd, vs2, vm
@@ -4297,7 +4296,7 @@ value -1, since no mask elements are active).#
      0 1 x x x x 1 1   v2 contents
 ----
 
-[#norm:vmsbf_op]#The `vmsbf.m` instruction takes a mask register as input and writes
+[#norm:vmsbf_op]#The insn:vmsbf.m[] instruction takes a mask register as input and writes
 results to a mask register.  The instruction writes a 1 to all active
 mask elements before the first active source element that is a 1, then
 writes a 0 to that element and all following active elements.  If
@@ -4307,14 +4306,14 @@ all active elements in the destination are written with a 1.#
 [#norm:vmsbf_tail_agnostic]#The tail elements in the destination mask register are updated under a
 tail-agnostic policy.#
 
-[#norm:vmsbf_trap]#Traps on `vmsbf.m` are always reported with a `vstart` of 0.#  [#norm:vmsbf_vstart_n0_ill]#The
-`vmsbf` instruction will raise an illegal-instruction exception if
-`vstart` is non-zero.#
+[#norm:vmsbf_trap]#Traps on insn:vmsbf.m[] are always reported with a csr:vstart[] of 0.#  [#norm:vmsbf_vstart_n0_ill]#The
+insn:vmsbf.m[] instruction will raise an illegal-instruction exception if
+csr:vstart[] is non-zero.#
 
 [#norm:vmsbf_vreg_constr]#The destination register cannot overlap the source register
 and, if masked, cannot overlap the mask register (`v0`).#
 
-===== `vmsif.m` set-including-first mask bit
+===== insn:vmsif.m[] Set-Including-First Mask Bit
 
 [#norm:vmsif_op]#The vector mask set-including-first instruction is similar to
 set-before-first, except it also includes the element with a set bit.#
@@ -4343,14 +4342,14 @@ set-before-first, except it also includes the element with a set bit.#
 [#norm:vmsif_tail_agnostic]#The tail elements in the destination mask register are updated under a
 tail-agnostic policy.#
 
-[#norm:vmsif_trap]#Traps on `vmsif.m` are always reported with a `vstart` of 0.#  [#norm:vmsif_vstart_n0_ill]#The
-`vmsif` instruction will raise an illegal-instruction exception if
-`vstart` is non-zero.#
+[#norm:vmsif_trap]#Traps on insn:vmsif.m[] are always reported with a csr:vstart[] of 0.#  [#norm:vmsif_vstart_n0_ill]#The
+insn:vmsif.m[] instruction will raise an illegal-instruction exception if
+csr:vstart[] is non-zero.#
 
 [#norm:vmsif_vreg_constr]#The destination register cannot overlap the source register
 and, if masked, cannot overlap the mask register (`v0`).#
 
-===== `vmsof.m` set-only-first mask bit
+===== insn:vmsof.m[] Set-Only-First Mask Bit
 
 [#norm:vmsof_op]#The vector mask set-only-first instruction is similar to
 set-before-first, except it only sets the first element with a bit
@@ -4380,9 +4379,9 @@ set, if any.#
 [#norm:vmsof_tail_agnostic]#The tail elements in the destination mask register are updated under a
 tail-agnostic policy.#
 
-[#norm:vmsof_trap]#Traps on `vmsof.m` are always reported with a `vstart` of 0.#  [#norm:vmsof_vstart_n0_ill]#The
-`vmsof` instruction will raise an illegal-instruction exception if
-`vstart` is non-zero.#
+[#norm:vmsof_trap]#Traps on insn:vmsof.m[] are always reported with a `vstart` of 0.#  [#norm:vmsof_vstart_n0_ill]#The
+insn:vmsof.m[] instruction will raise an illegal-instruction exception if
+csr:vstart[] is non-zero.#
 
 [#norm:vmsof_vreg_constr]#The destination register cannot overlap the source register
 and, if masked, cannot overlap the mask register (`v0`).#
@@ -4400,7 +4399,7 @@ include::example/strncpy.s[lines=4..-1]
 
 ===== Vector Iota Instruction
 
-[#norm:viota_op]#The `viota.m` instruction reads a source vector mask register and
+[#norm:viota_op]#The insn:viota.m[] instruction reads a source vector mask register and
 writes to each element of the destination vector register group the
 sum of all the bits of elements in the mask register
 whose index is less than the element, e.g., a parallel prefix sum of
@@ -4431,15 +4430,15 @@ elements contribute to the sum.#
 SEW is wider than the result.#  [#norm:viota_op_overflow]#If the result value would overflow the
 destination SEW, the least-significant SEW bits are retained.#
 
-[#norm:viota_trap]#Traps on `viota.m` are always reported with a `vstart` of 0,# and
+[#norm:viota_trap]#Traps on insn:viota.m[] are always reported with a csr:vstart[] of 0,# and
 [#norm:viota_restart]#execution is always restarted from the beginning when resuming after a
-trap handler.#  [#norm:viota_vstart_n0_ill]#An illegal-instruction exception is raised if `vstart`
-is non-zero.#
+trap handler.#  [#norm:viota_vstart_n0_ill]#An illegal-instruction exception is raised if
+csr:vstart[] is non-zero.#
 
 [#norm:viota_vreg_constr]#The destination register group cannot overlap the source register
 and, if masked, cannot overlap the mask register (`v0`).#
 
-The `viota.m` instruction can be combined with memory scatter
+The insn:viota.m[] instruction can be combined with memory scatter
 instructions (indexed stores) to perform vector compress functions.
 
 ----
@@ -4488,8 +4487,8 @@ loop:
 
 ===== Vector Element Index Instruction
 
-[#norm:vid_op]#The `vid.v` instruction writes each element's index to the
-destination vector register group, from 0 to `vl`-1.#
+[#norm:vid_op]#The insn:vid.v[] instruction writes each element's index to the
+destination vector register group, from 0 to csr:vl[]-1.#
 
 ----
 vid.v vd, vm  # Write element ID to destination.
@@ -4505,8 +4504,8 @@ encoding is _reserved_.#
 SEW is wider than the result.#  [#norm:vid_op_overflow]#If the result value would overflow the
 destination SEW, the least-significant SEW bits are retained.#
 
-NOTE: Microarchitectures can implement `vid.v` instruction using the
-same datapath as `viota.m` but with an implicit set mask source.
+NOTE: Microarchitectures can implement insn:vid.v[] instruction using the
+same datapath as insn:viota.m[] but with an implicit set mask source.
 
 [[sec-vector-integer-permute]]
 ==== Vector Integer Permutation Instructions
@@ -4525,26 +4524,26 @@ vmv.x.s rd, vs2  # x[rd] = vs2[0] (vs1=0)
 vmv.s.x vd, rs1  # vd[0] = x[rs1] (vs2=0)
 ----
 
-[#norm:vmv-x-s_op]#The `vmv.x.s` instruction copies a single SEW-wide element from index 0 of the
+[#norm:vmv-x-s_op]#The insn:vmv.x.s[] instruction copies a single SEW-wide element from index 0 of the
 source vector register to a destination integer register.  If SEW > XLEN, the
 least-significant XLEN bits are transferred and the upper SEW-XLEN bits are
 ignored.  If SEW < XLEN, the value is sign-extended to XLEN bits.#
 
-NOTE: [#norm:vmv-x-s_vstartgevl_vl0]#`vmv.x.s` performs its operation even if `vstart` {ge} `vl` or `vl`=0.#
+NOTE: [#norm:vmv-x-s_vstartgevl_vl0]#insn:vmv.x.s[] performs its operation even if csr:vstart[] {ge} csr:vl[] or csr:vl[]=0.#
 
-[#norm:vmv-s-x_op]#The `vmv.s.x` instruction copies the scalar integer register to element 0 of
+[#norm:vmv-s-x_op]#The insn:vmv.s.x[] instruction copies the scalar integer register to element 0 of
 the destination vector register group with EMUL = ceil(EEW/VLEN).
 If SEW < XLEN, the least-significant bits
 are copied and the upper XLEN-SEW bits are ignored.  If SEW > XLEN, the value
 is sign-extended to SEW bits.  The other elements in the destination vector
-register ( 0 < index < VLEN/SEW) are treated as tail elements using the current tail agnostic/undisturbed policy.#  [#norm:vmv-s-x_vstart_ge_vl]#If `vstart` {ge} `vl`, no
+register ( 0 < index < VLEN/SEW) are treated as tail elements using the current tail agnostic/undisturbed policy.#  [#norm:vmv-s-x_vstart_ge_vl]#If csr:vstart[] {ge} csr:vl[], no
 operation is performed and the destination register is not updated.#
 
-NOTE: As a consequence, when `vl`=0, no elements are updated in the
-destination vector register group, regardless of `vstart`.
+NOTE: As a consequence, when csr:vl[]=0, no elements are updated in the
+destination vector register group, regardless of csr:vstart[].
 
-[#norm:vmv-s-x_vmv-x-s_masked_rsv]#The encodings corresponding to the masked versions (`vm=0`) of `vmv.x.s`
-and `vmv.s.x` are reserved.#
+[#norm:vmv-s-x_vmv-x-s_masked_rsv]#The encodings corresponding to the masked versions (`vm=0`) of
+insn:vmv.x.s[] and insn:vmv.s.x[] are reserved.#
 
 ===== Vector Slide Instructions
 
@@ -4553,16 +4552,16 @@ group.
 
 NOTE: The slide operations can be implemented much more efficiently
 than using the arbitrary register gather instruction.  Implementations
-may optimize certain OFFSET values for `vslideup` and `vslidedown`.
+may optimize certain OFFSET values for insn:vslideup[] and insn:vslidedown[].
 In particular, power-of-2 offsets may operate substantially faster
 than other offsets.
 
-[#norm:vslide_vstart_ge_vl]#For all of the `vslideup`, `vslidedown`, `v[f]slide1up`, and
-`v[f]slide1down` instructions, if `vstart` {ge} `vl`, the instruction performs no
+[#norm:vslide_vstart_ge_vl]#For all of the insn:vslideup[], insn:vslidedown[], insn:vslide1up[], insn:vfslide1up[],
+insn:vslide1down[], and insn:vfslide1down[] instructions, if csr:vstart[] {ge} csr:vl[], the instruction performs no
 operation and leaves the destination vector register unchanged.#
 
-NOTE: As a consequence, when `vl`=0, no elements are updated in the
-destination vector register group, regardless of `vstart`.
+NOTE: As a consequence, when csr:vl[]=0, no elements are updated in the
+destination vector register group, regardless of csr:vstart[].
 
 The tail agnostic/undisturbed policy is followed for tail elements.
 
@@ -4577,13 +4576,13 @@ vslideup.vx vd, vs2, rs1, vm        # vd[i+x[rs1]] = vs2[i]
 vslideup.vi vd, vs2, uimm, vm       # vd[i+uimm] = vs2[i]
 ----
 
-[#norm:vslideup_op]#For `vslideup`, the value in `vl` specifies the maximum number of destination
+[#norm:vslideup_op]#For insn:vslideup[], the value in csr:vl[] specifies the maximum number of destination
 elements that are written.  The start index (_OFFSET_) for the
 destination can be either specified using an unsigned integer in the
 `x` register specified by `rs1`, or a 5-bit immediate, zero-extended to XLEN bits.
 If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
-Destination elements _OFFSET_ through `vl`-1 are written if unmasked and
-if _OFFSET_ < `vl`.#
+Destination elements _OFFSET_ through csr:vl[]-1 are written if unmasked and
+if _OFFSET_ < csr:vl[].#
 
 ----
 vslideup behavior for destination elements (vstart < vl)
@@ -4595,13 +4594,13 @@ max(vstart, OFFSET) <= i < vl                            vd[i] = vs2[i-OFFSET] i
                  vl <= i < VLMAX                         Follow tail policy
 ----
 
-[#norm:vslideup_vreg_constr]#The destination vector register group for `vslideup` cannot overlap
+[#norm:vslideup_vreg_constr]#The destination vector register group for insn:vslideup[] cannot overlap
 the source vector register group, otherwise the instruction encoding
 is reserved.#
 
 NOTE: The non-overlap constraint avoids WAR hazards on the
 input vectors during execution, and enables restart with non-zero
-`vstart`.
+csr:vstart[].
 
 ====== Vector Slide-down Instructions
 
@@ -4610,9 +4609,9 @@ vslidedown.vx vd, vs2, rs1, vm       # vd[i] = vs2[i+x[rs1]]
 vslidedown.vi vd, vs2, uimm, vm      # vd[i] = vs2[i+uimm]
 ----
 
-[#norm:vslidedown_op]#For `vslidedown`, the value in `vl` specifies the maximum number of
+[#norm:vslidedown_op]#For insn:vslidedown[], the value in csr:vl[] specifies the maximum number of
 destination elements that are written.  The remaining elements past
-`vl` are handled according to the current tail policy
+csr:vl[] are handled according to the current tail policy
 (<<sec-agnostic>>).#
 
 [#norm:vslidedown_op_src]#The start index (_OFFSET_) for the source can be either specified
@@ -4641,20 +4640,20 @@ element position.
 vslide1up.vx  vd, vs2, rs1, vm        # vd[0]=x[rs1], vd[i+1] = vs2[i]
 ----
 
-[#norm:vslide1up-vx_op]#The `vslide1up` instruction places the `x` register argument at
+[#norm:vslide1up-vx_op]#The insn:vslide1up[] instruction places the `x` register argument at
 location 0 of the destination vector register group, provided that
 element 0 is active, otherwise the destination element update follows the
 current mask agnostic/undisturbed policy.  If XLEN < SEW, the value is
 sign-extended to SEW bits.  If XLEN > SEW, the least-significant bits
 are copied over and the high XLEN-SEW bits are ignored.#
 
-[#norm:vslide1up-vx_op_rem_elem]#The remaining active `vl`-1 elements are copied over from index _i_ in
+[#norm:vslide1up-vx_op_rem_elem]#The remaining active csr:vl[]-1 elements are copied over from index _i_ in
 the source vector register group to index _i_+1 in the destination
 vector register group.#
 
-[#norm:vslide1up-vx_op_vl]#The `vl` register specifies the maximum number of destination vector
+[#norm:vslide1up-vx_op_vl]#The csr:vl[] register specifies the maximum number of destination vector
 register elements updated with source values, and remaining elements
-past `vl` are handled according to the current tail policy
+past csr:vl[] are handled according to the current tail policy
 (<<sec-agnostic>>).#
 
 
@@ -4667,28 +4666,28 @@ max(vstart, 1) <= i < vl      vd[i] = vs2[i-1] if v0.mask[i] enabled
             vl <= i < VLMAX   Follow tail policy
 ----
 
-[#norm:vslide1up-vx_vreg_constr]#The `vslide1up` instruction requires that the destination vector
+[#norm:vslide1up-vx_vreg_constr]#The insn:vslide1up[] instruction requires that the destination vector
 register group does not overlap the source vector register group.
 Otherwise, the instruction encoding is reserved.#
 
 ====== Vector Slide-1-down Instruction
 
-[#norm:vslide1down-vx_op]#The `vslide1down` instruction copies the first `vl`-1 active elements
+[#norm:vslide1down-vx_op]#The insn:vslide1down[] instruction copies the first csr:vl[]-1 active elements
 values from index _i_+1 in the source vector register group to index
 _i_ in the destination vector register group.#
 
-[#norm:vslide1down-vx_op_vl]#The `vl` register specifies the maximum number of destination vector
+[#norm:vslide1down-vx_op_vl]#The csr:vl[] register specifies the maximum number of destination vector
 register elements written with source values, and remaining elements
-past `vl` are handled according to the current tail policy
+past csr:vl[] are handled according to the current tail policy
 (<<sec-agnostic>>).#
 
 ----
 vslide1down.vx  vd, vs2, rs1, vm      # vd[i] = vs2[i+1], vd[vl-1]=x[rs1]
 ----
 
-[#norm:vslide1down-vx_op_details]#The `vslide1down` instruction places the `x` register argument at
-location `vl`-1 in the destination vector register, provided that
-element `vl-1` is active, otherwise the destination element update
+[#norm:vslide1down-vx_op_details]#The insn:vslide1down[] instruction places the `x` register argument at
+location csr:vl[]-1 in the destination vector register, provided that
+element csr:vl[]-1 is active, otherwise the destination element update
 follows the current mask agnostic/undisturbed policy.
 If XLEN < SEW, the value is sign-extended to SEW bits.  If
 XLEN > SEW, the least-significant bits are copied over and the high
@@ -4703,11 +4702,11 @@ vstart <= i = vl-1    vd[vl-1] = x[rs1] if v0.mask[i] enabled
     vl <= i < VLMAX   Follow tail policy
 ----
 
-NOTE: The `vslide1down` instruction can be used to load values into a
+NOTE: The insn:vslide1down[] instruction can be used to load values into a
 vector register without using memory and without disturbing other
 vector registers.  This provides a path for debuggers to modify the
 contents of a vector register, albeit slowly, with multiple repeated
-`vslide1down` invocations.
+insn:vslide1down[] invocations.
 
 ===== Vector Register Gather Instructions
 
@@ -4715,9 +4714,9 @@ The vector register gather instructions read elements from a first
 source vector register group at locations given by a second source
 vector register group.  [#norm:vrgather_vrgatherei16_vs2_uint]#The index values in the second vector are
 treated as unsigned integers.#  [#norm:vrgather_vrgatherei16_vs_ignore_vl]#The source vector can be read at any
-index < VLMAX regardless of `vl`.#  [#norm:vrgather_vrgatherei16_vl]#The maximum number of elements to write to
-the destination register is given by `vl`,# [#norm:vrgather_vrgatherei16_tail]#and the remaining elements
-past `vl` are handled according to the current tail policy
+index < VLMAX regardless of csr:vl[].#  [#norm:vrgather_vrgatherei16_vl]#The maximum number of elements to write to
+the destination register is given by csr:vl[],# [#norm:vrgather_vrgatherei16_tail]#and the remaining elements
+past csr:vl[] are handled according to the current tail policy
 (<<sec-agnostic>>).#  [#norm:vrgather_vrgatherei16_mask]#The operation can be masked, and the mask
 undisturbed/agnostic policy is followed for inactive elements.#
 
@@ -4727,12 +4726,12 @@ vrgather.vv vd, vs2, vs1, vm     # vd[i] = (vs1[i] >= VLMAX) ? 0 : vs2[vs1[i]];
 vrgatherei16.vv vd, vs2, vs1, vm # vd[i] = (vs1[i] >= VLMAX) ? 0 : vs2[vs1[i]];
 ----
 
-[#norm:vrgather-vv_sew_lmul]#The `vrgather.vv` form uses SEW/LMUL for both the data and
-indices.# [#norm:vrgatherei16-vv_sew_lmul]#The `vrgatherei16.vv` form uses SEW/LMUL for the data in
+[#norm:vrgather-vv_sew_lmul]#The insn:vrgather.vv[] form uses SEW/LMUL for both the data and
+indices.# [#norm:vrgatherei16-vv_sew_lmul]#The insn:vrgatherei16.vv[] form uses SEW/LMUL for the data in
 `vs2` but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in `vs1`.#
 
-NOTE: When SEW=8, `vrgather.vv` can only reference vector elements
-0-255.  The `vrgatherei16` form can index 64K elements, and can also
+NOTE: When SEW=8, insn:vrgather.vv[] can only reference vector elements
+0-255.  The insn:vrgatherei16[] form can index 64K elements, and can also
 be used to reduce the register capacity needed to hold indices when
 SEW > 16.
 
@@ -4754,7 +4753,7 @@ vrgather.vx vd, vs2, rs1, vm  # vd[i] = (x[rs1] >= VLMAX) ? 0 : vs2[x[rs1]]
 vrgather.vi vd, vs2, uimm, vm # vd[i] =  (uimm >= VLMAX)  ? 0 : vs2[uimm]
 ----
 
-[#norm:vrgather_vrgatherei16_vreg_constr]#For any `vrgather` instruction, the destination vector register group
+[#norm:vrgather_vrgatherei16_vreg_constr]#For any insn:vrgather[] instruction, the destination vector register group
 cannot overlap with the source vector register groups, otherwise the
 instruction encoding is reserved.#
 
@@ -4770,7 +4769,7 @@ vcompress.vm vd, vs2, vs1  # Compress into vd elements of vs2 where vs1 is enabl
 ----
 
 [#norm:vcompress_op]#The vector mask register specified by `vs1` indicates which of the
-first `vl` elements of vector register group `vs2` should be extracted
+first csr:vl[] elements of vector register group `vs2` should be extracted
 and packed into contiguous elements at the beginning of vector
 register `vd`. The remaining elements of `vd` are treated as tail
 elements according to the current tail policy
@@ -4789,26 +4788,26 @@ Example use of vcompress instruction
 1 2 3 4 8 7 5 2 0   v2
 ----
 
-[#norm:vcompress_enc]#T`vcompress` is encoded as an unmasked instruction (`vm=1`).# [#norm:vcompress_masked_rsv]#The equivalent
+[#norm:vcompress_enc]#insn:vcompress[] is encoded as an unmasked instruction (`vm=1`).# [#norm:vcompress_masked_rsv]#The equivalent
 masked instruction (`vm=0`) is reserved.#
 
 [#norm:vcompress_vreg_constr]#The destination vector register group cannot overlap the source vector
 register group or the source mask register, otherwise the instruction
 encoding is reserved.#
 
-[#norm:vcompress_trap]#A trap on a `vcompress` instruction is always reported with a
-`vstart` of 0.#  [#norm:vcompress_vstart_n0_ill]#Executing a `vcompress` instruction with a non-zero
-`vstart` raises an illegal-instruction exception.#
+[#norm:vcompress_trap]#A trap on a insn:vcompress[] instruction is always reported with a
+csr:vstart[] of 0.#  [#norm:vcompress_vstart_n0_ill]#Executing a insn:vcompress[] instruction with a non-zero
+csr:vstart[] raises an illegal-instruction exception.#
 
-NOTE: Although possible, `vcompress` is one of the more difficult
-instructions to restart with a non-zero `vstart`, so assumption is
+NOTE: Although possible, insn:vcompress[] is one of the most difficult
+instructions to restart with a non-zero csr:vstart[], so assumption is
 implementations will choose not do that but will instead restart from
 element 0.  This does mean elements in destination register after
-`vstart` will already have been updated.
+csr:vstart[] will already have been updated.
 
-====== Synthesizing `vdecompress`
+====== Synthesizing insn:vdecompress[]
 
-There is no inverse `vdecompress` provided, as this operation can be
+There is no inverse insn:vdecompress[] provided, as this operation can be
 readily synthesized using iota and a masked vrgather:
 
 ----
@@ -4840,21 +4839,21 @@ e q r d c b v a    # v11 destination after vrgather using viota.m under mask
 
 ===== Whole Vector Register Move
 
-[#norm:vmv-nr-r_op]#The `vmv<nr>r.v` instructions copy whole vector registers (i.e., all
+[#norm:vmv-nr-r_op]#The insn:vmv&#60;nr&#62;r.v[] instructions copy whole vector registers (i.e., all
 VLEN bits) and can copy whole vector register groups.  The `nr` value
 in the opcode is the number of individual vector registers, NREG, to
 copy.  The instructions operate as if EMUL = NREG, EEW = min(VLEN*EMUL, SEW), and effective
 length `evl` = EMUL * VLEN/EEW.#
 
 NOTE: These instructions are intended to aid compilers to shuffle
-vector registers without needing to know or change `vl`.
+vector registers without needing to know or change csr:vl[].
 
-The usual property that no elements are written if `vstart` {ge} `vl`
+The usual property that no elements are written if csr:vstart[] {ge} csr:vl[]
 does not apply to these instructions.
-Similarly, the property that the instructions are reserved if `vstart`
-exceeds the largest element index for the current `vtype` setting
+Similarly, the property that the instructions are reserved if csr:vstart[]
+exceeds the largest element index for the current csr:vtype[] setting
 does not apply.
-Instead, the instructions are reserved if `vstart` {ge} `evl`.
+Instead, the instructions are reserved if csr:vstart[] {ge} `evl`.
 
 NOTE: If `vd` is equal to `vs2`, the instruction does not change any
 vector register state.
@@ -4872,10 +4871,10 @@ other than 0, 1, 3, and 7 are reserved.#
 
 NOTE: A future extension may support other numbers of registers to be moved.
 
-NOTE: The instruction uses the same funct6 encoding as the `vsmul`
+NOTE: The instruction uses the same funct6 encoding as the insn:vsmul[]
 instruction but with an immediate operand, and only the unmasked
 version (`vm=1`).  This encoding is chosen as it is close to the
-related `vmerge` encoding, and it is unlikely the `vsmul` instruction
+related insn:vmerge[] encoding, and it is unlikely the insn:vsmul[] instruction
 would benefit from an immediate form.
 
 ----
@@ -4911,24 +4910,24 @@ vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)
 vfmv.s.f vd, rs1  # vd[0] = f[rs1] (vs2=0)
 ----
 
-[#norm:vfmv-f-s_op]#The `vfmv.f.s` instruction copies a single SEW-wide element from index
+[#norm:vfmv-f-s_op]#The insn:vfmv.f.s[] instruction copies a single SEW-wide element from index
 0 of the source vector register to a destination scalar floating-point
 register.#
 
-NOTE: `vfmv.f.s` performs its operation even if `vstart` {ge} `vl` or `vl`=0.
+NOTE: insn:vfmv.f.s[] performs its operation even if csr:vstart[] {ge} csr:vl[] or csr:vl[]=0.
 
-[#norm:vfmv-s-f_op]#The `vfmv.s.f` instruction copies the scalar floating-point register
+[#norm:vfmv-s-f_op]#The insn:vfmv.s.f[] instruction copies the scalar floating-point register
 to element 0 of the destination vector register.  The other elements
-in the destination vector register ( 0 < index < VLEN/SEW) are treated
+in the destination vector register (0 < index < VLEN/SEW) are treated
 as tail elements using the current tail agnostic/undisturbed policy.#
-[#norm:vfmv-s-f_vstart_ge_vl]#If `vstart` {ge} `vl`, no operation is performed and the destination
+[#norm:vfmv-s-f_vstart_ge_vl]#If csr:vstart[] {ge} csr:vl[], no operation is performed and the destination
 register is not updated.#
 
-NOTE: As a consequence, when `vl`=0, no elements are updated in the
-destination vector register group, regardless of `vstart`.
+NOTE: As a consequence, when csr:vl[]=0, no elements are updated in the
+destination vector register group, regardless of csr:vstart[].
 
-[#norm:vfmv-s-f_masked_rsv]#The encodings corresponding to the masked versions (`vm=0`) of `vfmv.f.s`
-and `vfmv.s.f` are reserved.#
+[#norm:vfmv-s-f_masked_rsv]#The encodings corresponding to the masked versions (`vm=0`) of
+insn:vfmv.f.s[] and insn:vfmv.s.f[] are reserved.#
 
 [[sec-vfslide1up]]
 ====== Vector Floating-Point Slide-1-up Instruction
@@ -4937,7 +4936,7 @@ and `vfmv.s.f` are reserved.#
 vfslide1up.vf vd, vs2, rs1, vm        # vd[0]=f[rs1], vd[i+1] = vs2[i]
 ----
 
-[#norm:vslide1up-vf_op]#The `vfslide1up` instruction is defined analogously to `vslide1up`,
+[#norm:vslide1up-vf_op]#The insn:vfslide1up[] instruction is defined analogously to insn:vslide1up[],
 but sources its scalar argument from an `f` register.#
 
 [[sec-vfslide1down]]
@@ -4947,22 +4946,22 @@ but sources its scalar argument from an `f` register.#
 vfslide1down.vf vd, vs2, rs1, vm      # vd[i] = vs2[i+1], vd[vl-1]=f[rs1]
 ----
 
-[#norm:vslide1down-vf_op]#The `vfslide1down` instruction is defined analogously to `vslide1down`,
+[#norm:vslide1down-vf_op]#The insn:vfslide1down[] instruction is defined analogously to insn:vslide1down[],
 but sources its scalar argument from an `f` register.#
 
 ==== Exception Handling
 
 [#norm:epc_vstart_op_V_trap]#On a trap during a vector instruction (caused by either a synchronous
-exception or an asynchronous interrupt), the existing `*epc` CSR is
+exception or an asynchronous interrupt), the existing csr:*epc[] CSR is
 written with a pointer to the trapping vector instruction, while the
-`vstart` CSR contains the element index on which the trap was
+csr:vstart[] CSR contains the element index on which the trap was
 taken.#
 
-NOTE: We chose to add a `vstart` CSR to allow resumption of a
+NOTE: We chose to add the csr:vstart[] CSR to allow resumption of a
 partially executed vector instruction to reduce interrupt latencies
 and to simplify forward-progress guarantees.  This is similar to the
 scheme in the IBM 3090 vector facility.  To ensure forward progress
-without the `vstart` CSR, implementations would have to guarantee an
+without the csr:vstart[] CSR, implementations would have to guarantee an
 entire vector instruction can always complete atomically without
 generating a trap.  This is particularly difficult to ensure in the
 presence of constant-stride or scatter/gather operations and demand-paged
@@ -4977,12 +4976,12 @@ Precise vector traps require that:
 
 . all instructions older than the trapping vector instruction have committed their results
 . no instructions newer than the trapping vector instruction have altered architectural state
-. any operations within the trapping vector instruction affecting result elements preceding the index in the `vstart` CSR have committed their results
-. no operations within the trapping vector instruction affecting elements at or following the `vstart` CSR have altered architectural state except if restarting and completing the affected vector instruction will nevertheless produce the correct final state.
+. any operations within the trapping vector instruction affecting result elements preceding the index in the csr:vstart[] CSR have committed their results
+. no operations within the trapping vector instruction affecting elements at or following the csr:vstart[] CSR have altered architectural state except if restarting and completing the affected vector instruction will nevertheless produce the correct final state.
 
-We relax the last requirement to allow elements following `vstart` to
+We relax the last requirement to allow elements following csr:vstart[] to
 have been updated at the time the trap is reported, provided that
-re-executing the instruction from the given `vstart` will correctly
+re-executing the instruction from the given csr:vstart[] will correctly
 overwrite those elements.
 
 In idempotent memory regions, vector store instructions may have
@@ -4993,19 +4992,19 @@ trap during a vector store instruction.
 
 Except where noted above, vector instructions are allowed to overwrite
 their inputs, and so in most cases, the vector instruction restart
-must be from the `vstart` element index. However, there are a number of
+must be from the csr:vstart[] element index. However, there are a number of
 cases where this overwrite is prohibited to enable execution of the
 vector instructions to be idempotent and hence restartable from an
 earlier index location.
 
 Implementations must ensure forward progress can be eventually
-guaranteed for the element or segment reported by `vstart`.
+guaranteed for the element or segment reported by csr:vstart[].
 
 ===== Imprecise vector traps
 
 Imprecise vector traps are traps that are not precise.  In particular,
-instructions newer than `*epc` may have committed results, and
-instructions older than `*epc` may have not completed execution.
+instructions newer than csr:*epc[] may have committed results, and
+instructions older than csr:*epc[] may have not completed execution.
 Imprecise traps are primarily intended to be used in situations where
 reporting an error and terminating execution is the appropriate
 response.
@@ -5015,7 +5014,7 @@ traps are imprecise.  We assume many embedded implementations will
 generate only imprecise traps for vector instructions on fatal errors,
 as they will not require resumable traps.
 
-Imprecise traps shall report the faulting element in `vstart` for
+Imprecise traps shall report the faulting element in csr:vstart[] for
 traps caused by synchronous vector exceptions.
 
 There is no support for imprecise traps in the current standard extensions.
@@ -5049,16 +5048,16 @@ implementation to support context switching with imprecise traps.
 
 This section describes the standard vector extensions.
 A set of smaller extensions intended for embedded
-use are named with a "Zve" prefix, while a larger vector extension
-designed for application processors is named as a single-letter V
-extension.  A set of vector length extension names with prefix "Zvl"
+use are named with a ext:zve[] prefix, while a larger vector extension
+designed for application processors is named as a single-letter ext:v[]
+extension.  A set of vector length extension names with prefix ext:zvl[]
 are also provided.
 
 The initial vector extensions are designed to act as a base for
 additional vector extensions in various domains, including
 cryptography and machine learning.
 
-===== Zvl*: Minimum Vector Length Extensions
+===== ext:zvl*[]: Minimum Vector Length Extensions
 
 All standard vector extensions have a minimum required VLEN as
 described below.  A set of vector length extensions are provided to
@@ -5087,7 +5086,7 @@ NOTE: Longer vector length extensions should follow the same pattern.
 NOTE: Every vector length extension effectively includes all shorter
 vector length extensions.
 
-NOTE: Explicit use of the Zvl32b extension string is not required for
+NOTE: Explicit use of the ext:zvl32b[] extension string is not required for
 any standard vector extension as they all effectively mandate at least
 this minimum, but the string can be useful when stating hardware
 capabilities.
@@ -5096,10 +5095,10 @@ capabilities.
 ==== Vector Element Groups
 
 Some vector instructions treat operands as a vector of one or more
-_element_ _groups_, where each element group is a fixed number of
+_element groups_, where each element group is a fixed number of
 elements.  For example, complex numbers can be viewed as a two-element
 group (one real element and one imaginary element).
-As another example, the SHA-256 cryptographic instructions in the Zvknha
+As another example, the SHA-256 cryptographic instructions in the ext:zvknha[]
 extension operate on 128-bit values represented as a 4-element group of 32-bit
 elements.
 
@@ -5109,16 +5108,16 @@ groups.
 
 ===== Element Group Size
 
-The _element_ _group_ _size_ (EGS) is the number of elements in one
+The _element group size_ (EGS) is the number of elements in one
 group, and must be a power-of-two (POT).
 
 NOTE: Support for non-POT EGS was considered but causes many practical
-complications and so has been dropped.  Error checking for `vl` is a
+complications and so has been dropped.  Error checking for csr:vl[] is a
 little more difficult.  For LMUL>1, non-POT EGSs will result in groups
 straddling the individual vector registers in a vector register
 group. Non-POT EGS can also cause large increases in the
 lowest-common-multiple of element group sizes, which adds constraints
-to `vl` setting in order to avoid splitting an element group across
+to csr:vl[] setting in order to avoid splitting an element group across
 strip-mine iterations in vector-length-agnostic code.
 
 The element group size is statically encoded in the instruction, often
@@ -5126,7 +5125,7 @@ implicitly as part of the opcode.
 
 [#norm:egs_ge_vlmax_rsv]#Vector instructions with EGS > VLMAX are reserved.#
 
-NOTE: The vector instructions in the base V vector ISA can be viewed
+NOTE: The vector instructions in the base ext:v[] vector ISA can be viewed
 as all having an element group size of 1 for all operands statically
 encoded in the instruction.
 
@@ -5134,22 +5133,22 @@ NOTE: Many operations only make sense with a certain number of
 elements per group (e.g., complex operations require a element group
 size of 2 and SHA-256 requires an element group size of 4).
 
-===== Setting `vl`
+===== Setting csr:vl[]
 
 Each source and destination operand to a vector instruction might be
 defined as either a single element group or a vector of element
-groups.  [#norm:egs_vl_rsv]#When an operand is a vector of element groups, the `vl`
-setting must correspond to an integer multiple of the element group
-size, with other values of `vl` reserved.#
+groups.  [#norm:egs_vl_rsv]#When an operand is a vector of element groups, the
+csr:vl[] setting must correspond to an integer multiple of the element group
+size, with other values of csr:vl[] reserved.#
 
-NOTE: For example, a SHA-256 instruction would require that `vl` is a
+NOTE: For example, a SHA-256 instruction would require that csr:vl[] is a
 multiple of 4.
 
 [#norm:egs_vl_avl]#When element group instructions are present, an additional constraint
-is placed on the setting of `vl` based on an AVL value
+is placed on the setting of csr:vl[] based on an AVL value
 (augmenting <<constraints-on-setting-vl>>).
 EGSMAX is the largest EGS supported by the
-implementation.  When AVL > VLMAX, the value of `vl` must be set to
+implementation.  When AVL > VLMAX, the value of csr:vl[] must be set to
 either VLMAX or a positive integer multiple of EGSMAX.#
 
 NOTE: As the base vector extension only has element group size of 1,
@@ -5162,7 +5161,7 @@ of element groups.
 
 NOTE: If EEW is encoded statically in the instruction, or if an
 instruction has multiple operands containing vectors of element groups
-with different EEW, an appropriate SEW must be chosen for `vsetvl`
+with different EEW, an appropriate SEW must be chosen for insn:vsetvl[]
 instructions.
 
 NOTE: Additional constraints may be required for some element group
@@ -5170,7 +5169,7 @@ instructions to ensure legal length values for all operands.
 
 ===== Determining EEW
 
-[#norm:egs_sew_eew]#The `vtype` SEW can be used to indicate or calculate the effective
+[#norm:egs_sew_eew]#The csr:vtype[] SEW can be used to indicate or calculate the effective
 element size (EEW) of one or more operands of an element group
 instruction.  Where the operand is an element group, SEW and EEW refer
 to the number of bits in each individual element within a group not
@@ -5190,7 +5189,7 @@ the individual elements in the vector.
 
 ===== Determining EMUL
 
-[#norm:egs_lmul_emul]#The `vtype` LMUL setting can be used to indicate or calculate the
+[#norm:egs_lmul_emul]#The csr:vtype[] LMUL setting can be used to indicate or calculate the
 effective length multiplier (EMUL) for one or more operands.  Element
 group instructions tend to exhibit a much wider range of relationships
 between various operand EEW/EMUL values.  For example, an instruction
@@ -5204,9 +5203,9 @@ different element group size, different EMUL, and/or different EEW.
 
 ===== Element Group Width
 
-[#norm:egs_egw]#The _element_ _group_ _width_ (EGW) is the number of bits in the
+[#norm:egs_egw]#The _element group width_ (EGW) is the number of bits in the
 element group as a whole.
-For example, the SHA-256 instructions in the Zvknha extension operate on an
+For example, the SHA-256 instructions in the ext:zvknha[] extension operate on an
 EGW of 128, with EGS=4 and EEW=32.
 It is possible to use LMUL to concatenate multiple vector registers together
 to support larger EGW>VLEN.#

--- a/src/unpriv/zv.adoc
+++ b/src/unpriv/zv.adoc
@@ -19,10 +19,10 @@ ext:zve64x[] and ext:zve64f[].
 The extlink:zve64d[] extension extends ext:zve64f[] by adding
 double-precision floating-point support.
 
-The extlink:V[] extension, intended for application processors,
+The extlink:v[] extension, intended for application processors,
 builds on ext:zve64d[] and imposes a minimum vector length of 128 bits.
 
-Several additional ext:Zv*[] extensions that add new arithmetic
+Several additional ext:zv*[] extensions that add new arithmetic
 and permutation instructions are also defined.
 
 include::vector-common.adoc[]


### PR DESCRIPTION
The vector chapter is so large that I decided to split the macro conversion PR into few parts.

Fix https://github.com/riscv/riscv-isa-manual/issues/3035
Fix https://github.com/riscv/riscv-isa-manual/issues/3036