### PR TITLE
Use vset* when appropriate

### DIFF
--- a/src/unpriv/vector-common.adoc
+++ b/src/unpriv/vector-common.adoc
@@ -155,7 +155,7 @@ vector register, and how multiple vector registers are grouped. The
 csr:vtype[] register also indicates how masked-off elements and elements
 past the current vector length in a vector result are handled.
 
-NOTE: Allowing updates only via the insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions
+NOTE: Allowing updates only via the insn:vset*[] instructions
 simplifies maintenance of the csr:vtype[] register state.
 
 [[norm:vtype_fields_sz]]
@@ -173,12 +173,12 @@ fields to support a greater variety of data types.
 
 NOTE: The primary motivation for the csr:vtype[] CSR is to allow the
 vector instruction set to fit into a 32-bit instruction encoding
-space.  A separate insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[] instruction can be used to set csr:vl[]
+space.  A separate insn:vset*[] instruction can be used to set csr:vl[]
 and/or csr:vtype[] fields before execution of a vector instruction, and
 implementations may choose to fuse these two instructions into a single
 internal vector microop.  In many cases, the csr:vl[] and csr:vtype[] values
 can be reused across multiple instructions, reducing the static and
-dynamic instruction overhead from the insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions.  It
+dynamic instruction overhead from the insn:vset*[] instructions.  It
 is anticipated that a future extended 64-bit instruction encoding
 would allow these fields to be specified statically in the instruction
 encoding.
@@ -473,8 +473,8 @@ flags, it was decided to always require them in future assembly code.
 
 ====== Vector Type Illegal (csr::[vill])
 
-The csr::[vill] bit is used to encode that a previous insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[]
-instruction attempted to write an unsupported value to csr:vtype[].
+The csr::[vill] bit is used to encode that a previous insn:vset*[] instruction
+attempted to write an unsupported value to csr:vtype[].
 
 NOTE: The csr::[vill] bit is held in bit XLEN-1 of the CSR to support
 checking for illegal values with a branch on the sign bit.
@@ -483,7 +483,7 @@ checking for illegal values with a branch on the sign bit.
 If the csr::[vill] bit is set, then any attempt to execute a vector instruction
 that depends upon csr:vtype[] will raise an illegal-instruction exception.
 
-NOTE: insn:vsetvli[], insn:vsetivli[], insn:vsetvl[], and whole register loads and stores do not depend
+NOTE: insn:vset*[] and whole register loads and stores do not depend
 upon csr:vtype[].
 
 When the csr::[vill] bit is set, the other XLEN-1 bits in csr:vtype[] shall be
@@ -493,7 +493,7 @@ zero.
 
 [[norm:vl_acc]]
 The _XLEN_-bit-wide read-only csr:vl[] CSR can only be updated by the
-insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions, and the _fault-only-first_ vector load
+insn:vset*[] instructions, and the _fault-only-first_ vector load
 instruction variants.
 
 [[norm:vl_op]]
@@ -537,7 +537,7 @@ element number given in the csr:vstart[] CSR, leaving earlier elements in
 the destination vector undisturbed#, and to [#norm:vstart_update]#reset the csr:vstart[] CSR to
 zero at the end of execution.#
 
-NOTE: All vector instructions, including insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[], reset the csr:vstart[]
+NOTE: All vector instructions, including insn:vset*[], reset the csr:vstart[]
 CSR to zero.
 
 [[norm:vstart_unmodified]]
@@ -671,8 +671,8 @@ remaining bits in csr:vtype[] are zero, and csr:vl[] is set to zero.
 
 The csr:vstart[], csr:vxrm[], csr:vxsat[] CSRs can have arbitrary values at reset.
 
-NOTE: Most uses of the vector unit will require an initial insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[],
-which will reset csr:vstart[].  The csr:vxrm[] and csr:vxsat[] fields should be
+NOTE: Most uses of the vector unit will require an initial insn:vset*[] which
+will reset csr:vstart[].  The csr:vxrm[] and csr:vxsat[] fields should be
 reset explicitly in software before use.
 
 The vector registers can have arbitrary values at reset.
@@ -1215,7 +1215,7 @@ The new csr:vtype[] value is encoded in the immediate fields of insn:vsetvli[] a
 insn:vsetivli[], and in the _rs2_ register for insn:vsetvl[].
 
 ----
- Suggested assembler names used for vset{i}vli vtypei immediate
+ Suggested assembler names used for vsetvli and vsetivli vtypei immediate
 
  e8    # SEW=8b
  e16   # SEW=16b
@@ -1322,7 +1322,7 @@ registers, in which case there is no strip-mining overhead.
 ===== Constraints on Setting csr:vl[]
 
 [[norm:vl_val_lead-in]]
-The insn:vsetvli[], insn:vsetivli[], and insn:vsetvl[] instructions first set VLMAX according to their csr:vtype[]
+The insn:vset*[] instructions first set VLMAX according to their csr:vtype[]
 argument, then set csr:vl[] obeying the following constraints:
 
 [[norm:vl_val_list]]
@@ -1335,7 +1335,7 @@ argument, then set csr:vl[] obeying the following constraints:
 .. csr:vl[] > 0 if `AVL > 0`
 .. csr:vl[] {le} VLMAX
 .. csr:vl[] {le} AVL
-.. a value read from csr:vl[] when used as the AVL argument to insn:vsetvli[], insn:vsetivli[], or insn:vsetvl[] results in the same
+.. a value read from csr:vl[] when used as the AVL argument to insn:vset*[] results in the same
 value in csr:vl[], provided the resultant VLMAX equals the value of VLMAX at the time that csr:vl[] was read
 
 [NOTE]


### PR DESCRIPTION
It shortened *vsetvli, vsetivli, and/or vsetvl* to *vset\** in vector-common. Exceptions:

- The first time they appear in the text (before specifying them)
- The first time they appear in the NormRule of themselves