### PR TITLE
Fix wrong references to IEEE 754-2008

### DIFF
--- a/src/unpriv/vector-common.adoc
+++ b/src/unpriv/vector-common.adoc
@@ -3657,7 +3657,7 @@ with greater estimate accuracy.
 
 [#norm:vfmin_vfmax_op]#The vector floating-point insn:vfmin[] and insn:vfmax[] instructions have the
 same behavior as the corresponding scalar floating-point instructions
-in the ext:f[], ext:d[], and ext:q[] extensions: they perform the IEEE 754-2008 `minimumNumber`
+in the ext:f[], ext:d[], and ext:q[] extensions: they perform the IEEE 754-2019 `minimumNumber`
 or `maximumNumber` operation on active elements.#
 
 ----
@@ -4087,7 +4087,7 @@ insn:vfredusum[] instruction.
 ====== Vector Single-Width Floating-Point Max and Min Reductions
 
 [#norm:vfredmin_vfredmax_op]#The insn:vfredmin[] and insn:vfredmax[] instructions reduce the scalar argument in
-`vs1[0]` and active elements in `vs2` using the IEEE 754-2008 `minimumNumber` and
+`vs1[0]` and active elements in `vs2` using the IEEE 754-2019 `minimumNumber` and
 `maximumNumber` operations, respectively.#
 
 NOTE: Floating-point max and min reductions should return the same


### PR DESCRIPTION
`minimumNumber` and `maximumNumber` are defined in IEEE 754-2019.