### PR TITLE
Clarify that Zfh implies Zfhmin

### DIFF
--- a/src/unpriv/zfhmin.adoc
+++ b/src/unpriv/zfhmin.adoc
@@ -5,7 +5,8 @@ This section describes the ext:zfhmin[] standard extension, which provides
 minimal support for 16-bit half-precision binary floating-point
 instructions. The ext:zfhmin[] extension is a subset of the ext:zfh[] extension,
 consisting only of data transfer and conversion instructions. Like ext:zfh[],
-the ext:zfhmin[] extension depends on the ext:f[] extension. The expectation is
+the ext:zfhmin[] extension depends on the ext:f[] extension. ext:zfh[] implies
+ext:zfhmin[]. The expectation is
 that ext:zfhmin[] software primarily uses the half-precision format for storage,
 performing most computation in higher precision.
 

--- a/src/unpriv/zfinx.adoc
+++ b/src/unpriv/zfinx.adoc
@@ -137,6 +137,7 @@ number.
 The ext:zhinxmin[] extension provides minimal support for 16-bit
 half-precision floating-point instructions that operate on the `x`
 registers. The ext:zhinxmin[] extension depends upon the ext:zfinx[] extension.
+ext:zhinx[] implies ext:zhinxmin[].
 
 [[norm:Zfhinxmin_instrs]]
 The ext:zhinxmin[] extension includes the following instructions from the


### PR DESCRIPTION
Zhinxmin was also updated to clarify that Zhinx implies Zhinxmin.

Fix https://github.com/riscv/riscv-isa-manual/issues/3068