### PR TITLE
Replace fprs table with bytefield diagram

### DIFF
--- a/src/unpriv/images/bytefield/fprs.edn
+++ b/src/unpriv/images/bytefield/fprs.edn
@@ -1,0 +1,26 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])
+(def row-height 30)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 16)
+
+(draw-box "FLEN-1" {:span 8 :text-anchor "start" :borders {}})
+(draw-box "0" {:span 8 :text-anchor "end" :borders {}})
+
+(draw-box "f0" {:span 16 :borders {:left :border-unrelated :top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+(draw-box "f1" {:span 16 :borders {:left :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+(draw-box "⋮" {:span 16 :borders {}})
+(draw-box "f31" {:span 16 :borders {:left :border-unrelated :top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+
+(draw-box "FLEN" {:span 16 :borders {}})
+
+(draw-box "31" {:span 8 :text-anchor "start" :borders {}})
+(draw-box "0" {:span 8 :text-anchor "end" :borders {}})
+
+(draw-box "fcsr" {:span 16 :borders {:left :border-unrelated :top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+
+(draw-box "32" {:span 16 :borders {}})
+----

--- a/src/unpriv/zf.adoc
+++ b/src/unpriv/zf.adoc
@@ -62,47 +62,8 @@ can be 32, 64, or 128 depending on which of the ext:f[], ext:d[], and ext:q[]
 extensions are supported.
 
 [[fprs]]
-.RISC-V floating-point register state.
-[cols="<,^,>",options="header",width="50%",align="center",grid="rows"]
-|===
-| [.small]#FLEN-1#| >| [.small]#0#
-3+^| [.small]#f0#
-3+^| [.small]#f1#
-3+^| [.small]#f2#
-3+^| [.small]#f3#
-3+^| [.small]#f4#
-3+^| [.small]#f5#
-3+^| [.small]#f6#
-3+^| [.small]#f7#
-3+^| [.small]#f8#
-3+^| [.small]#f9#
-3+^| [.small]#f10#
-3+^| [.small]#f11#
-3+^| [.small]#f12#
-3+^| [.small]#f13#
-3+^| [.small]#f14#
-3+^| [.small]#f15#
-3+^| [.small]#f16#
-3+^| [.small]#f17#
-3+^| [.small]#f18#
-3+^| [.small]#f19#
-3+^| [.small]#f20#
-3+^| [.small]#f21#
-3+^| [.small]#f22#
-3+^| [.small]#f23#
-3+^| [.small]#f24#
-3+^| [.small]#f25#
-3+^| [.small]#f26#
-3+^| [.small]#f27#
-3+^| [.small]#f28#
-3+^| [.small]#f29#
-3+^| [.small]#f30#
-3+^| [.small]#f31#
-3+^| [.small]#FLEN#
-| [.small]#31#| >| [.small]#0#
-3+^|  [.small]#fcsr#
-3+^| [.small]#32#
-|===
+.RISC-V floating-point register state
+include::images/bytefield/fprs.edn[]
 
 Most floating-point instructions operate on values in the floating-point
 register file. Floating-point load and store instructions transfer


### PR DESCRIPTION
This is my proposal for <https://github.com/riscv/riscv-isa-manual/issues/2985>. I will draw another one for RV32I if this PR is accepted.

HTML version:

<img width="895" height="490" alt="Screenshot" src="https://github.com/user-attachments/assets/9c690c24-4b43-44ed-a655-b6d87808ec1a" />