### PR TITLE
Replace gprs table with bytefield diagram

### DIFF
--- a/src/unpriv/images/bytefield/gprs.edn
+++ b/src/unpriv/images/bytefield/gprs.edn
@@ -1,0 +1,20 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])
+(def row-height 30)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 16)
+
+(draw-box "XLEN-1" {:span 8 :text-anchor "start" :borders {}})
+(draw-box "0" {:span 8 :text-anchor "end" :borders {}})
+
+(draw-box "x0/zero" {:span 16 :borders {:left :border-unrelated :top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+(draw-box "x1" {:span 16 :borders {:left :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+(draw-box "⋮" {:span 16 :borders {}})
+(draw-box "x31" {:span 16 :borders {:left :border-unrelated :top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+(draw-box "pc" {:span 16 :borders {:left :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+
+(draw-box "XLEN" {:span 16 :borders {}})
+----

--- a/src/unpriv/rv32.adoc
+++ b/src/unpriv/rv32.adoc
@@ -41,7 +41,7 @@ Most of the commentary for RV32I also applies to the RV64I base.
 <<gprs>> shows the unprivileged state for the base integer ISA.
 [#norm:rv32i_xreg_sz]#For RV32I, the 32 `x` registers are each 32 bits wide,
 i.e., `XLEN=32`.# [#norm:x0eq0]#Register `x0` is hardwired with all bits equal to 0.#
-[#norm:rv32i_rv64i_other_xregs]#General purpose registers `x1-x31` hold values that various
+[#norm:rv32i_rv64i_other_xregs]#General purpose registers `x1`-`x31` hold values that various
 instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.#
 
@@ -50,44 +50,9 @@ There is one additional unprivileged register: the program counter `pc`
 holds the address of the current instruction.
 
 [[gprs]]
-.RISC-V base unprivileged integer register state.
-[cols="<,^,>",options="header",width="50%",align="center",grid="rows"]
-|===
-<| [.small]#XLEN-1#| >| [.small]#0#
-3+^| [.small]#x0/zero#
-3+^| [.small]#x1#
-3+^| [.small]#x2#
-3+^| [.small]#x3#
-3+^| [.small]#x4#
-3+^| [.small]#x5#
-3+^| [.small]#x6#
-3+^| [.small]#x7#
-3+^| [.small]#x8#
-3+^| [.small]#x9#
-3+^| [.small]#x10#
-3+^| [.small]#x11#
-3+^| [.small]#x12#
-3+^| [.small]#x13#
-3+^| [.small]#x14#
-3+^| [.small]#x15#
-3+^| [.small]#x16#
-3+^| [.small]#x17#
-3+^| [.small]#x18#
-3+^| [.small]#x19#
-3+^| [.small]#x20#
-3+^| [.small]#x21#
-3+^| [.small]#x22#
-3+^| [.small]#x23#
-3+^| [.small]#x24#
-3+^| [.small]#x25#
-3+^| [.small]#x26#
-3+^| [.small]#x27#
-3+^| [.small]#x28#
-3+^| [.small]#x29#
-3+^| [.small]#x30#
-3+^| [.small]#x31#
-3+^| [.small]#pc#
-|===
+.RISC-V base unprivileged integer register state
+include::images/bytefield/gprs.edn[]
+
 [NOTE]
 ====
 There is no dedicated stack pointer or subroutine return address link


### PR DESCRIPTION
HTML version:

<img width="889" height="449" alt="Screenshot" src="https://github.com/user-attachments/assets/f818fce1-197a-4f96-907e-1f6d39a3baed" />


Fix https://github.com/riscv/riscv-isa-manual/issues/2985