### PR TITLE
Clarifying choices regarding underflow/inexact flags in RVBNA

### DIFF
--- a/src/unpriv/rvbna.adoc
+++ b/src/unpriv/rvbna.adoc
@@ -306,6 +306,13 @@ If the result of a dot product operation is zero, then `+0` is returned, even if
 
 Under RVBNA, only the invalid operation and overflow exceptions can be raised.
 
+
+Note:: The underflow and inexact flags are not raised, for two different reasons.
++
+Detecting underflow accurately would add significant implementation complexity for little practical benefit. Furthermore, in some RVBNA configurations (e.g. product of OFP8 numbers into an FP32 accumulator), underflow cannot actually occur, because the product range is narrower than the range in which underflow could be triggered during accumulation.
++
+Inexact is suppressed because, given the compound nature of RVBNA, the flag would carry no meaningful numerical information: nearly every result would either always raise it or never raise it at all.
+
 ===== Invalid operation
 
 The invalid operation flag must be raised if at least one of the following conditions is met:


### PR DESCRIPTION
Addressing some comments on RVBNA spec from https://lists.riscv.org/g/tech-vme/topic/119043904 in particular 

> §15.1.1.8 also drops inexact, underflow, and divide-by-zero from fflags for SEW≤16 inputs. There is no normative justification, and no acknowledgement that this is a deviation from the V-extension exception model.


* Adding a non normative note to explain some of the choices made regarding Floating-Point exception flag underflow and inexact in RVBNA (RISC-V Bulk Normalization Algorithm)
* The comment mentioned division-by-zero but I don't think anyone would actually expect a dot product (or any MAC-like operation) to raise this flag

An LLM was used to rewrite a first hand made version of this suggestion.