### PR TITLE
Update dco and signing checks to trigger on additional PR events.

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -3,6 +3,11 @@ name: DCO Check
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - converted_to_draft
 
 jobs:
   dco_check:

--- a/.github/workflows/signing_check.yml
+++ b/.github/workflows/signing_check.yml
@@ -3,6 +3,11 @@ name: Commit Signing Check
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - converted_to_draft
 
 jobs:
   signing_check:


### PR DESCRIPTION
Update the dco and signing checks to trigger on opened, reopened, synchronize, and converted_to_draft events Signed-off-by: Bill Traynor wmat@riscv.org