### PR TITLE
Zvk: Use macros

### DIFF
--- a/src/unpriv/zvk.adoc
+++ b/src/unpriv/zvk.adoc
@@ -165,7 +165,7 @@ policies:
 
 Many vector crypto instructions operate on operands that are wider than elements (which are currently limited
 to 64 bits wide).
-Typically, these operands are 128- and 256-bits wide. In many cases, these operands are comprised of smaller
+Typically, these operands are 128 and 256 bits wide. In many cases, these operands are comprised of smaller
 operands that are combined (for example, each SHA-2 operand is comprised of 4 words). However, in other cases
 these operands are a single value (for example, in the AES round instructions, each operand is 128-bit block
 or round key).
@@ -194,17 +194,17 @@ parameters: EGW, EGS, and EEW.
 
 [NOTE]
 ====
-- Element Group Width (`EGW`) - total number of bits in an element group
-- Effective Element Width (`EEW`) - number of bits in each element
-- Element Group Size (`EGS`) - number of elements in an element group
+- Element Group Width (EGW) - total number of bits in an element group
+- Effective Element Width (EEW) - number of bits in each element
+- Element Group Size (EGS) - number of elements in an element group
 ====
 
 [[norm:veccrypto_eeweqsew]]
-For all of the vector crypto instructions in this specification, `EEW`=`SEW`.
+For all of the vector crypto instructions in this specification, EEW=SEW.
 
 [NOTE]
 ====
-The required `SEW` for each cryptographic instruction was chosen to match what is
+The required SEW for each cryptographic instruction was chosen to match what is
 typically needed for other instructions when implementing the targeted algorithm.
 ====
 
@@ -212,27 +212,27 @@ typically needed for other instructions when implementing the targeted algorithm
 - A *Scalar Element Group* is a single element group.
 
 Element groups can be formed across registers in implementations where
-`VLEN`< `EGW` by using an `LMUL`>1.
+VLEN<EGW by using an LMUL>1.
 
 [NOTE]
 ====
 Since the ext:v[] extension requires a minimum of VLEN of 128,
 at most such implementations would require LMUL=2 to form the largest element groups in this specification.
 
-However, implementations with a smaller VLEN, such as embedded designs, will requires a larger `LMUL`
+However, implementations with a smaller VLEN, such as embedded designs, will requires a larger LMUL
 to form the necessary element groups.
 It is important to keep in mind that this reduces the number of register groups available such
 that it may be difficult or impossible to write efficient code for the intended cryptographic algorithms.
 
-For example, an implementation with `VLEN`=32 would need to set `LMUL`=8 to create a
-256-bit element group for `SM3`. This would mean that there would only be 4 register groups,
-3 of which would be consumed by a single `SM3` message-expansion instruction.
+For example, an implementation with VLEN=32 would need to set LMUL=8 to create a
+256-bit element group for SM3. This would mean that there would only be 4 register groups,
+3 of which would be consumed by a single SM3 message-expansion instruction.
 ====
 
 As with all vector instructions, the number of elements processed is specified by the
-vector length `vl`. The number of element groups operated upon is then `vl`/`EGS`.
-Likewise the starting element group is `vstart`/`EGS`.
-See <<crypto-vector-instruction-constraints>> for limitations on `vl` and `vstart`
+vector length csr:vl[]. The number of element groups operated upon is then csr:vl[]/EGS.
+Likewise the starting element group is csr:vstart[]/EGS.
+See <<crypto-vector-instruction-constraints>> for limitations on csr:vl[] and csr:vstart[]
 for vector crypto instructions.
 
 // If this ratio is not an integer for a vector crypto instruction, an illegal-instruction exception is raised.
@@ -243,18 +243,18 @@ for vector crypto instructions.
 [[crypto-vector-instruction-constraints]]
 ===== Instruction Constraints
 
-All standard vector instruction constraints specified by RVV 1.0 apply to Vector Crypto instructions.
+All standard vector instruction constraints specified by the ext:v[] extension apply to Vector Crypto instructions.
 In addition to those constraints a few additional specific constraints are introduced.
 
 The following is a quick reference for the various constraints of specific Vector Crypto instructions.
 
 
-vl and vstart constraints::
-[#norm:veccrypto_vl_vstart_egsconstr]#Since `vl` and `vstart` refer to elements, Vector Crypto instructions that use elements groups
+csr:vl[] and csr:vstart[] constraints::
+[#norm:veccrypto_vl_vstart_egsconstr]#Since csr:vl[] and csr:vstart[] refer to elements, Vector Crypto instructions that use elements groups
 (See <<crypto-vector-element-groups>>) require that these values are an integer multiple of the
-Element Group Size (`EGS`).#
+Element Group Size (EGS).#
 
-- [#norm:veccrypto_vl_vstart_rsv]#Instructions that violate the `vl` or `vstart` requirements are _reserved_.#
+- [#norm:veccrypto_vl_vstart_rsv]#Instructions that violate the csr:vl[] or csr:vstart[] requirements are _reserved_.#
 
 [%autowidth]
 [%header,cols="4,4"]
@@ -262,17 +262,17 @@ Element Group Size (`EGS`).#
 | Instructions
 | EGS
 
-| vaes*   | 4
-| vsha2*  | 4
-| vg*     | 4
-| vsm3*   | 8
-| vsm4*   | 4
+| insn:vaes*[]   | 4
+| insn:vsha2*[]  | 4
+| insn:vg*[]     | 4
+| insn:vsm3*[]   | 8
+| insn:vsm4*[]   | 4
 
 |===
 
 LMUL constraints::
-[#norm:veccrypto_lmul_egwconstr]#For element-group instructions, `LMUL`*`VLEN` must always be at least as large as `EGW`, otherwise an
-_illegal-instruction exception_ is raised, even if `vl`=0.#
+[#norm:veccrypto_lmul_egwconstr]#For element-group instructions, LMUL{times}VLEN must always be at least as large as EGW, otherwise an
+_illegal-instruction exception_ is raised, even if csr:vl[]=0.#
 
 [%autowidth]
 [%header,cols="4,2,2"]
@@ -281,19 +281,19 @@ _illegal-instruction exception_ is raised, even if `vl`=0.#
 | SEW
 | EGW
 
-| vaes*   | 32 | 128
-| vsha2*  | 32 | 128
-| vsha2*  | 64 | 256
-| vg*     | 32 | 128
-| vsm3*   | 32 | 256
-| vsm4*   | 32 | 128
+| insn:vaes*[]   | 32 | 128
+| insn:vsha2*[]  | 32 | 128
+| insn:vsha2*[]  | 64 | 256
+| insn:vg*[]     | 32 | 128
+| insn:vsm3*[]   | 32 | 256
+| insn:vsm4*[]   | 32 | 128
 
 |===
 
 
 SEW constraints::
-[#norm:veccrypto_sew_rsv]#Some Vector Crypto instructions are only defined for a specific `SEW`. In such a case
-all other `SEW` values are _reserved_.#
+[#norm:veccrypto_sew_rsv]#Some Vector Crypto instructions are only defined for a specific SEW. In such a case
+all other SEW values are _reserved_.#
 
 [%autowidth]
 [%header,cols="4,4"]
@@ -301,31 +301,31 @@ all other `SEW` values are _reserved_.#
 | Instructions
 | Required SEW
 
-| vaes*          | 32
-| Zvknha: vsha2* | 32
-| Zvknhb: vsha2* | 32 or 64
-| vclmul[h]      | 64
-| vg*            | 32
-| vsm3*          | 32
-| vsm4*          | 32
+| insn:vaes*[]          | 32
+| Zvknha: insn:vsha2*[] | 32
+| Zvknhb: insn:vsha2*[] | 32 or 64
+| insn:vclmul*[]        | 64
+| insn:vg*[]            | 32
+| insn:vsm3*[]          | 32
+| insn:vsm4*[]          | 32
 
 
 |===
 
 Vector/Scalar constraints::
-This specification defines new vector/scalar (.vs) instructions that uses *Scalar Element Groups*. The *Scalar Element Group* operand has `EMUL = ceil(EGW / VLEN)`.
+This specification defines new vector/scalar (insn:*.vs[]) instructions that uses *Scalar Element Groups*. The *Scalar Element Group* operand has EMUL = ceil(EGW / VLEN).
 
 [NOTE]
 ====
 Scalar element group operands do not need to be aligned to LMUL for any implementation with VLEN >= EGW.
 ====
 
-[#norm:veccrypto_vsins_vs2]#In the case of the `.vs` instructions defined in this specification, `vs2` holds a 128-bit scalar element group.#
-[#norm:veccrypto_vsins_vdvs2overlap]#For implementations with `VLEN` ≥ 128, `vs2` refers to a single register. Thus, the `vd` register group must not
-overlap the `vs2` register.
-However, in implementations where `VLEN` < 128, `vs2` refers to a register group comprised of the number
-of registers needed to hold the 128-bit scalar element group. In this case, the `vd` register group must not
-overlap this `vs2` register group.#
+[#norm:veccrypto_vsins_vs2]#In the case of the insn:*.vs[] instructions defined in this specification, _vs2_ holds a 128-bit scalar element group.#
+[#norm:veccrypto_vsins_vdvs2overlap]#For implementations with VLEN ≥ 128, _vs2_ refers to a single register. Thus, the _vd_ register group must not
+overlap the _vs2_ register.
+However, in implementations where VLEN < 128, _vs2_ refers to a register group comprised of the number
+of registers needed to hold the 128-bit scalar element group. In this case, the _vd_ register group must not
+overlap this _vs2_ register group.#
 
 [%autowidth]
 [%header,cols="4,4,4"]
@@ -334,12 +334,12 @@ overlap this `vs2` register group.#
 | Register
 | Cannot Overlap
 
-| vaes*.vs      | vs2      | vd
-| vsm4r.vs      | vs2      | vd
-| vsha2c[hl]    | vs1, vs2 | vd
-| vsha2ms       | vs1, vs2 | vd
-| vsm3me        | vs2      | vd
-| vsm3c         | vs2      | vd
+| insn:vaes*.vs[]      | vs2      | vd
+| insn:vsm4r.vs[]      | vs2      | vd
+| insn:vsha2c*[]       | vs1, vs2 | vd
+| insn:vsha2ms[]       | vs1, vs2 | vd
+| insn:vsm3me[]        | vs2      | vd
+| insn:vsm3c[]         | vs2      | vd
 
 
 |===
@@ -355,25 +355,25 @@ The RISC-V Vector Extension defines three encodings for Vector-Scalar operations
 
 However, the Vector Extensions include Vector Reduction Operations which can also be considered
 Vector-Scalar operations because a scalar operand is provided from element 0 of
-vector register `vs1`. The vector operand is provided in vector register group `vs2`.
-These reduction operations all use the `.vs` suffix in their mnemonics. Additionally, the reduction operations all produce a scalar result in element 0 of the destination register, `vd`.
+vector register _vs1_. The vector operand is provided in vector register group _vs2_.
+These reduction operations all use the insn:*.vs[] suffix in their mnemonics. Additionally, the reduction operations all produce a scalar result in element 0 of the destination register, _vd_.
 
 The Vector Crypto Extensions define Vector-Scalar instructions that are similar to these
 Vector Reduction Operations in that they get a scalar operand from a vector register. However, they differ
 in that they get a scalar element group
 (see <<crypto-vector-element-groups>>)
-from `vs2` and [#norm:veccrypto_vsins_vd]#they return _vector_ results to `vd`, which is also a source vector operand.#
-These Vector-Scalar crypto instructions also use the `.vs` suffix in their mnemonics.
+from _vs2_ and [#norm:veccrypto_vsins_vd]#they return _vector_ results to _vd_, which is also a source vector operand.#
+These Vector-Scalar crypto instructions also use the insn:*.vs[] suffix in their mnemonics.
 
 [NOTE]
 ====
-We chose to use `vs2` as the scalar operand, and `vd` as the vector operand, so that we could use the `vs1`
+We chose to use _vs2_ as the scalar operand, and _vd_ as the vector operand, so that we could use the _vs1_
 specifier as additional encoding bits for these instructions. This allows these instructions to have a
 much smaller encoding footprint, leaving more rooms for other instructions in the future.
 ====
 
-[#norm:veccrypto_vsins_vs2function]#These instructions enable a single key, specified as a scalar element group in `vs2`, to be
-applied to each element group of register group `vd`.#
+[#norm:veccrypto_vsins_vs2function]#These instructions enable a single key, specified as a scalar element group in _vs2_, to be
+applied to each element group of register group _vd_.#
 
 [NOTE]
 ====
@@ -409,29 +409,29 @@ crypto instructions allow the round key to be specified as a scalar element grou
 [[crypto-vector-software-portability]]
 ===== Software Portability
 The following contains some guidelines that enable the portability of vector-crypto-based code
-to implementations with different values for `VLEN`
+to implementations with different values for VLEN.
 
 Application Processors::
-Application processors are expected to follow the V-extension and will therefore have `VLEN` {ge} 128.
+Application processors are expected to follow the ext:v[] extension and will therefore have VLEN{ge}128.
 
 
 
 // [NOTE]
 // ====
-Since most of the _cryptography-specific_ instructions have an `EGW`=128, nothing special needs to be done
-for these instructions to support implementations with `VLEN`=128.
+Since most of the _cryptography-specific_ instructions have an EGW=128, nothing special needs to be done
+for these instructions to support implementations with VLEN=128.
 
-However, the SHA-512 and SM3 instructions have an `EGW`=256. Implementations with `VLEN` = 128, require that
-`LMUL` is doubled for these instructions in order to create 256-bit elements across a pair of registers.
-Code written with this doubling of `LMUL` will not affect the results returned by implementations with `VLEN` {ge} 256
-because `vl` controls how many element groups are processed. Therefore, we recommend that libraries that implement
-SHA-512 and SM3 employ this doubling of `LMUL` to ensure that the software can run on all implementation
-with `VLEN` {ge} 128.
+However, the SHA-512 and SM3 instructions have an EGW=256. Implementations with VLEN=128, require that
+LMUL is doubled for these instructions in order to create 256-bit elements across a pair of registers.
+Code written with this doubling of LMUL will not affect the results returned by implementations with VLEN{ge}256
+because csr:vl[] controls how many element groups are processed. Therefore, we recommend that libraries that implement
+SHA-512 and SM3 employ this doubling of LMUL to ensure that the software can run on all implementation
+with VLEN{ge}128.
 
-While the doubling of `LMUL` for these instructions is _safe_ for implementations with `VLEN` {ge} 256, it may be less
+While the doubling of LMUL for these instructions is _safe_ for implementations with VLEN{ge}256, it may be less
 optimal as it will result in unnecessary register pressure and might exact a performance penalty in
 some microarchitectures. Therefore, we suggest that in addition to providing portable code for SHA-512 and SM3,
-libraries should also include more optimal code for these instructions when `VLEN` {ge} 256.
+libraries should also include more optimal code for these instructions when VLEN{ge}256.
 // ====
 
 [%autowidth]
@@ -442,8 +442,8 @@ libraries should also include more optimal code for these instructions when `VLE
 | VLEN
 | LMUL
 
-| SHA-512 |  vsha2* | 64 | vl/2
-| SM3     | vsm3*   | 32 | vl/4
+| SHA-512 | insn:vsha2*[] | 64 | csr:vl[]/2
+| SM3     | insn:vsm3*[]  | 32 | csr:vl[]/4
 |===
 
 // [NOTE]
@@ -455,18 +455,18 @@ libraries should also include more optimal code for these instructions when `VLE
 
 Embedded Processors::
 
-Embedded processors will typically have implementations with `VLEN` < 128. This will require code to be written with
-larger `LMUL` values to enable the element groups to be formed.
+Embedded processors will typically have implementations with VLEN<128. This will require code to be written with
+larger LMUL values to enable the element groups to be formed.
 
-The `.vs` instructions require scalar element groups of `EGW`=128. On implementations with `VLEN` < 128, these scalar
+The insn:*.vs[] instructions require scalar element groups of EGW=128. On implementations with VLEN<128, these scalar
 element groups will necessarily be formed across registers. This is different from most scalars in vector instructions
 that typically consume part of a single register.
 
 
 // [NOTE]
 // ====
-We recommend that different code be available for `VLEN`=32 and `VLEN`=64, as code written for `VLEN`=32 will
-likely be too burdensome for `VLEN`=64 implementations.
+We recommend that different code be available for VLEN=32 and VLEN=64, as code written for VLEN=32 will
+likely be too burdensome for VLEN=64 implementations.
 // ====
 
 [[crypto_vector_extensions]]
@@ -475,13 +475,13 @@ likely be too burdensome for `VLEN`=64 implementations.
 The section introduces all of the  extensions in the Vector Cryptography
 Instruction Set Extension Specification.
 
-[#norm:Zvknhb_Zvbc_Zvkn_Zvknc_Zvkng_depZve64x]#The extlink:zvknhb[] and extlink:zvbc[] Vector Crypto Extensions--and accordingly the composite extensions extlink:zvkn[], extlink:zvknc[], extlink:zvkng[], and extlink:zvksc[]{emdash}depend on Zve64x.#
+[#norm:Zvknhb_Zvbc_Zvkn_Zvknc_Zvkng_depZve64x]#The extlink:zvknhb[] and extlink:zvbc[] Vector Crypto Extensions--and accordingly the composite extensions extlink:zvkn[], extlink:zvknc[], extlink:zvkng[], and extlink:zvksc[]{emdash}depend on ext:zve64x[].#
 
-[#norm:Zvbb_Zvkb_Zvkg_Zvkned_Zvknha_Zvksed_Zvksh_Zvks_Zvksc_Zvksg_Zvkt_depZve32x]#All of the other Vector Crypto Extensions depend on `Zve32x`.#
+[#norm:Zvbb_Zvkb_Zvkg_Zvkned_Zvknha_Zvksed_Zvksh_Zvks_Zvksc_Zvksg_Zvkt_depZve32x]#All of the other Vector Crypto Extensions depend on ext:zve32x[].#
 
-[#norm:Zvknhb_impZvknha]#`Zvknhb` implies `Zvknha`.#
+[#norm:Zvknhb_impZvknha]#ext:zvknhb[] implies ext:zvknha[].#
 
-Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 8, 16, and 32. If `Zve64x` is supported then `Zvkb` or `Zvbb` also add support for EEW 64.
+Note: If ext:zve32x[] is supported then ext:zvkb[] or ext:zvbb[] provide support for EEW of 8, 16, and 32. If ext:zve64x[] is supported then ext:zvkb[] or ext:zvbb[] also add support for EEW 64.
 
 
 // See <<crypto-vector-element-groups>> for more details on vector element groups and the drawbacks of
@@ -489,11 +489,11 @@ Note: If `Zve32x` is supported then `Zvkb` or `Zvbb` provide support for EEW of 
 
 
 All _cryptography-specific_ instructions defined in this Vector Crypto specification (i.e., those
-in extlink:zvkned[], extlink:zvknha[], extlink:zvknhb[], extlink:zvkg[], extlink:zvksed[] and extlink:zvksh[] but _not_ extlink:zvbb[],extlink:zvkb[], or extlink:zvbc[]) shall
+in extlink:zvkned[], extlink:zvknha[], extlink:zvknhb[], extlink:zvkg[], extlink:zvksed[] and extlink:zvksh[] but _not_ extlink:zvbb[], extlink:zvkb[], or extlink:zvbc[]) shall
 be executed with data-independent execution latency as defined in the
 <<#crypto_scalar_instructions,RISC-V Scalar Cryptography Extensions specification>>.
 [#norm:veccrypto_indepZkt]#It is important to note that the Vector Crypto instructions are independent of the
-implementation of the `Zkt` extension and do not require that `Zkt` is implemented.#
+implementation of the ext:zkt[] extension and do not require that ext:zkt[] is implemented.#
 
 This specification includes a extlink:zvkt[] extension that, when implemented, requires certain vector instructions
 (including extlink:zvbb[], extlink:zvkb[], and extlink:zvbc[]) to be executed with data-independent execution latency.
@@ -523,16 +523,16 @@ This extension is a superset of the extlink:zvkb[] extension.
 |Mnemonic
 |Instruction
 
-| vandn.[vv,vx]      | <<insns-vandn>>
-| vbrev.v            | <<insns-vbrev>>
-| vbrev8.v           | <<insns-vbrev8>>
-| vrev8.v            | <<insns-vrev8>>
-| vclz.v             | <<insns-vclz>>
-| vctz.v             | <<insns-vctz>>
-| vcpop.v            | <<insns-vcpop>>
-| vrol.[vv,vx]       | <<insns-vrol>>
-| vror.[vv,vx,vi]    | <<insns-vror>>
-| vwsll.[vv,vx,vi]   | <<insns-vwsll>>
+| insn:vandn.*[]   | <<insns-vandn>>
+| insn:vbrev.v[]   | <<insns-vbrev>>
+| insn:vbrev8.v[]  | <<insns-vbrev8>>
+| insn:vrev8.v[]   | <<insns-vrev8>>
+| insn:vclz.v[]    | <<insns-vclz>>
+| insn:vctz.v[]    | <<insns-vctz>>
+| insn:vcpop.v[]   | <<insns-vcpop>>
+| insn:vrol.*[]    | <<insns-vrol>>
+| insn:vror.*[]    | <<insns-vror>>
+| insn:vwsll.*[]   | <<insns-vwsll>>
 
 |===
 
@@ -544,15 +544,15 @@ This extension is a superset of the extlink:zvkb[] extension.
 General purpose carry-less multiplication instructions which are commonly used in cryptography
 and hashing (e.g., Elliptic curve cryptography, GHASH, CRC).
 
-[#norm:Zvbc_sew64only]#These instructions are only defined for `SEW`=64.#
+[#norm:Zvbc_sew64only]#These instructions are only defined for SEW=64.#
 
 [%autowidth]
 [%header,cols="^2,4"]
 |===
 |Mnemonic
 |Instruction
-| vclmul.[vv,vx]     | <<insns-vclmul>>
-| vclmulh.[vv,vx]    | <<insns-vclmulh>>
+| insn:vclmul.*[]     | <<insns-vclmul>>
+| insn:vclmulh.*[]    | <<insns-vclmulh>>
 
 |===
 
@@ -567,10 +567,11 @@ efficiently.
 
 [NOTE]
 ====
-This Zvkb extension is a proper subset of the Zvbb extension.
-Zvkb allows for vector crypto implementations without incurring
+This ext:zvkb[] extension is a proper subset of the ext:zvbb[] extension.
+ext:zvkb[] allows for vector crypto implementations without incurring
 the cost of implementing the additional bitmanip instructions
-in the Zvbb extension: vbrev.v, vclz.v, vctz.v, vcpop.v, and vwsll.[vv,vx,vi].
+in the ext:zvbb[] extension: insn:vbrev.v[], insn:vclz.v[], insn:vctz.v[],
+insn:vcpop.v[], insn:vwsll.vv[], insn:vwsll.vx[], and insn:vwsll.vi[].
 ====
 
 [%autowidth]
@@ -579,16 +580,11 @@ in the Zvbb extension: vbrev.v, vclz.v, vctz.v, vcpop.v, and vwsll.[vv,vx,vi].
 |Mnemonic
 |Instruction
 
-| vandn.[vv,vx]      | <<insns-vandn>>
-// | vbrev.v            | <<insns-vbrev>>
-| vbrev8.v           | <<insns-vbrev8>>
-| vrev8.v            | <<insns-vrev8>>
-// | vclz.v             | <<insns-vclz>>
-// | vctz.v             | <<insns-vctz>>
-// | vcpop.v            | <<insns-vcpop>>
-| vrol.[vv,vx]       | <<insns-vrol>>
-| vror.[vv,vx,vi]    | <<insns-vror>>
-// | vwsll.[vv,vx,vi]   | <<insns-vwsll>>
+| insn:vandn.*[]   | <<insns-vandn>>
+| insn;vbrev8.v*[] | <<insns-vbrev8>>
+| insn:vrev8.v*[]  | <<insns-vrev8>>
+| insn:vrol.*[]    | <<insns-vrol>>
+| insn:vror.*[]    | <<insns-vror>>
 |===
 
 <<<
@@ -616,10 +612,10 @@ GMAC is used to provide authentication of a message without encryption.
 
 [#norm:Zvkg_dataindeptiming]#To help avoid side-channel timing attacks, these instructions shall be implemented with data-independent timing.#
 
-[#norm:Zvkg_vl]#The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW=32` elements to be processed and
-therefore must be a multiple of `EGS=4`.# +
-[#norm:Zvkg_vstart]#Likewise, `vstart` must be a multiple of `EGS=4`.#
+[#norm:Zvkg_vl]#The number of element groups to be processed is csr:vl[]/EGS.
+csr:vl[] must be set to the number of SEW=32 elements to be processed and
+therefore must be a multiple of EGS=4.#
+[#norm:Zvkg_vstart]#Likewise, csr:vstart[] must be a multiple of EGS=4.#
 
 [%autowidth]
 [%header,cols="^2,4,4,4"]
@@ -629,8 +625,8 @@ therefore must be a multiple of `EGS=4`.# +
 |EGW
 |Mnemonic
 |Instruction
-| 32 | 128 | vghsh.vv | <<insns-vghsh>>
-| 32 | 128 | vgmul.vv | <<insns-vgmul>>
+| 32 | 128 | insn:vghsh.vv[] | <<insns-vghsh>>
+| 32 | 128 | insn:vgmul.vv[] | <<insns-vgmul>>
 
 |===
 
@@ -648,9 +644,9 @@ cite:[nist:fips:197]
 [#norm:Zvkned_egw128b_elem32b]#All of these instructions work on 128-bit element groups comprised of four
 32-bit elements.#
 
-For the best performance, it is suggested that these instruction be implemented on systems with `VLEN`>=128.
-On systems with `VLEN`<128, element groups may be formed by concatenating 32-bit elements
-from two or four registers by using an LMUL =2 and LMUL=4 respectively.
+For the best performance, it is suggested that these instruction be implemented on systems with VLEN>=128.
+On systems with VLEN<128, element groups may be formed by concatenating 32-bit elements
+from two or four registers by using an LMUL=2 and LMUL=4 respectively.
 
 // Implementations with `VLEN<128` should consider the existing
 // Scalar Cryptography Extensions, specifically extlink:zkne[] and extlink:zknd[]
@@ -658,10 +654,10 @@ from two or four registers by using an LMUL =2 and LMUL=4 respectively.
 
 [#norm:Zvkned_dataindeptiming]#To help avoid side-channel timing attacks, these instructions shall be implemented with data-independent timing.#
 
-[#norm:Zvkned_vl]#The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW=32` elements to be processed and
-therefore must be a multiple of `EGS=4`.# +
-[#norm:Zvkned_vstart]#Likewise, `vstart` must be a multiple of `EGS=4`.#
+[#norm:Zvkned_vl]#The number of element groups to be processed is csr:vl[]/EGS.
+csr:vl[] must be set to the number of SEW=32 elements to be processed and
+therefore must be a multiple of EGS=4.#
+[#norm:Zvkned_vstart]#Likewise, csr:vstart[] must be a multiple of EGS=4.#
 
 [%autowidth]
 [%header,cols="^2,4,4,4"]
@@ -671,13 +667,13 @@ therefore must be a multiple of `EGS=4`.# +
 |Mnemonic
 |Instruction
 
-| 32| 128 | vaesef.[vv,vs]  | <<insns-vaesef>>
-| 32| 128 | vaesem.[vv,vs]  | <<insns-vaesem>>
-| 32| 128 | vaesdf.[vv,vs]  | <<insns-vaesdf>>
-| 32| 128 | vaesdm.[vv,vs]  | <<insns-vaesdm>>
-| 32| 128 | vaeskf1.vi      | <<insns-vaeskf1>>
-| 32| 128 | vaeskf2.vi      | <<insns-vaeskf2>>
-| 32| 128 | vaesz.vs        | <<insns-vaesz>>
+| 32| 128 | insn:vaesef.*[]   | <<insns-vaesef>>
+| 32| 128 | insn:vaesem.*[]   | <<insns-vaesem>>
+| 32| 128 | insn:vaesdf.*[]   | <<insns-vaesdf>>
+| 32| 128 | insn:vaesdm.*[]   | <<insns-vaesdm>>
+| 32| 128 | insn:vaeskf1.vi[] | <<insns-vaeskf1>>
+| 32| 128 | insn:vaeskf2.vi[] | <<insns-vaeskf2>>
+| 32| 128 | insn:vaesz.vs[]   | <<insns-vaesz>>
 |===
 
 <<<
@@ -689,7 +685,7 @@ therefore must be a multiple of `EGS=4`.# +
 Instructions for accelerating SHA-2 as defined in FIPS PUB 180-4 Secure Hash Standard (SHS)
 cite:[nist:fips:180:4]
 
-`SEW` differentiates between SHA-256 (`SEW`=32) and SHA-512 (`SEW`=64).
+SEW differentiates between SHA-256 (SEW=32) and SHA-512 (SEW=64).
 
 - [#norm:Zvknha_Zvknhb_sha256_egw128b_elem32b]#SHA-256: these instructions work on 128-bit element groups comprised of four 32-bit elements.#
 - [#norm:Zvknhb_sha512_egw256b_elem64b]#SHA-512: these instructions work on 256-bit element groups comprised of four 64-bit elements.#
@@ -702,14 +698,14 @@ cite:[nist:fips:180:4]
 |SHA-2
 |Extension
 
-|32 | 128 | SHA-256 | Zvknha, Zvknhb
-|64 | 256 | SHA-512 | Zvknhb
+|32 | 128 | SHA-256 | ext:zvknha[], ext:zvknhb[]
+|64 | 256 | SHA-512 | ext:zvknhb[]
 |===
 
 // link:https://doi.org/10.6028/NIST.FIPS.180-4[FIPS PUB 180-4 Secure Hash Standard (SHS)])
 
-- [#norm:Zvknhb_sha256_sha512]#Zvknhb supports SHA-256 and SHA-512.#
-- [#norm:Zvknha_sha256]#Zvknha supports only SHA-256.#
+- [#norm:Zvknhb_sha256_sha512]#ext:zvknhb[] supports SHA-256 and SHA-512.#
+- [#norm:Zvknha_sha256]#ext:zvknha[] supports only SHA-256.#
 
 // [NOTE]
 // ====
@@ -717,10 +713,10 @@ cite:[nist:fips:180:4]
 // If Zvknha is implemented, only SHA-256 is supported, and SEW must be 32.
 // ====
 
-SHA-256 implementations with VLEN < 128 require LMUL>1 to combine
+SHA-256 implementations with VLEN<128 require LMUL>1 to combine
 32-bit elements from register groups to provide all four elements of the element group.
 
-SHA-512 implementations with VLEN < 256 require LMUL>1 to combine
+SHA-512 implementations with VLEN<256 require LMUL>1 to combine
 64-bit elements from register groups to provide all four elements of the element group.
 
 // SHA-2 is defined in
@@ -736,10 +732,10 @@ SHA-512 implementations with VLEN < 256 require LMUL>1 to combine
 // specified register groups can be combined to form the full element group.
 // ====
 
-[#norm:Zvknha_Zvknhb_vl]#The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW` elements to be processed and
-therefore must be a multiple of `EGS=4`.# +
-[#norm:Zvknha_Zvknhb_vstart]#Likewise, `vstart` must be a multiple of `EGS=4`.#
+[#norm:Zvknha_Zvknhb_vl]#The number of element groups to be processed is csr:vl[]/EGS.
+csr:vl[] must be set to the number of SEW elements to be processed and
+therefore must be a multiple of EGS=4.# +
+[#norm:Zvknha_Zvknhb_vstart]#Likewise, csr:vstart[] must be a multiple of EGS=4.#
 
 [%autowidth]
 [%header,cols="2,4"]
@@ -749,9 +745,9 @@ therefore must be a multiple of `EGS=4`.# +
 |Instruction
 
 // | 128
-| vsha2ms.vv   | <<insns-vsha2ms>>
+| insn:vsha2ms.vv[]   | <<insns-vsha2ms>>
 // | 128
-| vsha2c[hl].vv    | <<insns-vsha2c>>
+| insn:vsha2c*.vv[]   | <<insns-vsha2c>>
 |===
 
 <<<
@@ -776,16 +772,16 @@ is useful and easy to access.
 [#norm:Zvksed_egw128b_elem32b]#All of these instructions work on 128-bit element groups comprised of four
 32-bit elements.#
 
-// Systems which implement `VLEN<128` should consider the existing
+// Systems which implement VLEN<128 should consider the existing
 // Scalar Cryptography Extensions, specifically extlink:zkne[] and extlink:zknd[]
 // for accelerated cryptographic operations.
 
 [#norm:Zvksed_dataindeptiming]#To help avoid side-channel timing attacks, these instructions shall be implemented with data-independent timing.#
 
-[#norm:Zvksed_vl]#The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW=32` elements to be processed and
-therefore must be a multiple of `EGS=4`.# +
-[#norm:Zvksed_vstart]#Likewise, `vstart` must be a multiple of `EGS=4`.#
+[#norm:Zvksed_vl]#The number of element groups to be processed is csr:vl[]/EGS.
+csr:vl[] must be set to the number of SEW=32 elements to be processed and
+therefore must be a multiple of EGS=4.# +
+[#norm:Zvksed_vstart]#Likewise, csr:vstart[] must be a multiple of EGS=4.#
 
 [%autowidth]
 [%header,cols="^2,4,4,4"]
@@ -795,8 +791,8 @@ therefore must be a multiple of `EGS=4`.# +
 |Mnemonic
 |Instruction
 
-| 32 | 128 | vsm4k.vi        | <<insns-vsm4k>>
-| 32 | 128 | vsm4r.[vv,vs]   | <<insns-vsm4r>>
+| 32 | 128 | insn:vsm4k.vi[]  | <<insns-vsm4k>>
+| 32 | 128 | insn:vsm4r.*[]   | <<insns-vsm4r>>
 |===
 
 <<<
@@ -820,7 +816,7 @@ is useful and easy to access.
 [#norm:Zvksh_egw256b_elem32b]#All of these instructions work on 256-bit element groups comprised of
 eight 32-bit elements.#
 
-Implementations with VLEN < 256 require LMUL>1 to combine 32-bit elements from register groups
+Implementations with VLEN<256 require LMUL>1 to combine 32-bit elements from register groups
 to provide all eight elements of the element group.
 
 // The instructions will be most efficient on implementations where `VLEN`{ge}256.
@@ -834,10 +830,10 @@ to provide all eight elements of the element group.
 
 [#norm:Zvksh_dataindeptiming]#To help avoid side-channel timing attacks, these instructions shall be implemented with data-independent timing.#
 
-[#norm:Zvksh_vl]#The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW=32` elements to be processed and
-therefore must be a multiple of `EGS=8`.# +
-[#norm:Zvksh_vstart]#Likewise, `vstart` must be a multiple of `EGS=8`.#
+[#norm:Zvksh_vl]#The number of element groups to be processed is csr:vl[]/EGS.
+csr:vl[] must be set to the number of SEW=32 elements to be processed and
+therefore must be a multiple of EGS=8.# +
+[#norm:Zvksh_vstart]#Likewise, csr:vstart[] must be a multiple of EGS=8.#
 
 [%autowidth]
 [%header,cols="2,4,4,4"]
@@ -847,8 +843,8 @@ therefore must be a multiple of `EGS=8`.# +
 | Mnemonic
 | Instruction
 
-| 32 | 256 | vsm3me.vv | <<insns-vsm3me>>
-| 32 | 256 | vsm3c.vi   | <<insns-vsm3c>>
+| 32 | 256 | insn:vsm3me.vv[] | <<insns-vsm3me>>
+| 32 | 256 | insn:vsm3c.vi[]  | <<insns-vsm3c>>
 |===
 
 <<<
@@ -865,17 +861,15 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvkned  | extlink:zvkned[]
-| Zvknhb  | extlink:zvknhb[]
-// | Zvbb    | extlink:zvbb[]
-| Zvkb    | extlink:zvkb[]
-// | Zvbc    | extlink:zvbc[]
-| Zvkt    | extlink:zvkt[]
+| ext:zvkned[]  | extlink:zvkned[]
+| ext:zvknhb[]  | extlink:zvknhb[]
+| ext:zvkb[]    | extlink:zvkb[]
+| ext:zvkt[]    | extlink:zvkt[]
 |===
 
 [NOTE]
 ====
-While Zvkg and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
+While ext:zvkg[] and ext:zvbc[] are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient AES-GCM.
 ====
 
 <<<
@@ -892,8 +886,8 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvkn  | extlink:zvkn[]
-| Zvbc  | extlink:zvbc[]
+| ext:zvkn[]  | extlink:zvkn[]
+| ext:zvbc[]  | extlink:zvbc[]
 |===
 
 [NOTE]
@@ -916,8 +910,8 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvkn  | extlink:zvkn[]
-| Zvkg  | extlink:zvkg[]
+| ext:zvkn[]  | extlink:zvkn[]
+| ext:zvkg[]  | extlink:zvkg[]
 |===
 
 [NOTE]
@@ -940,17 +934,15 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvksed  | extlink:zvksed[]
-| Zvksh   | extlink:zvksh[]
-// | Zvbb    | extlink:zvbb[]
-| Zvkb    | extlink:zvkb[]
-// | Zvbc    | extlink:zvbc[]
-| Zvkt    | extlink:zvkt[]
+| ext:zvksed[]  | extlink:zvksed[]
+| ext:zvksh[]   | extlink:zvksh[]
+| ext:zvkb[]    | extlink:zvkb[]
+| ext:zvkt[]    | extlink:zvkt[]
 |===
 
 [NOTE]
 ====
-While Zvkg and Zvbc are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
+While ext:zvkg[] and ext:zvbc[] are not part of this extension, it is recommended that at least one of them is implemented with this extension to enable efficient SM4-GCM.
 ====
 
 <<<
@@ -967,8 +959,8 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvks  | extlink:zvks[]
-| Zvbc  | extlink:zvbc[]
+| ext:zvks[]  | extlink:zvks[]
+| ext:zvbc[]  | extlink:zvbc[]
 |===
 
 [NOTE]
@@ -991,8 +983,8 @@ This extension is shorthand for the following set of other extensions:
 |Description
 
 
-| Zvks  | extlink:zvks[]
-| Zvkg  | extlink:zvkg[]
+| ext:zvks[]  | extlink:zvks[]
+| ext:zvkg[]  | extlink:zvkg[]
 |===
 
 [NOTE]
@@ -1012,12 +1004,12 @@ executed with data-independent execution latency as defined in the
 
 Data-independent execution latency (DIEL) applies to all _data operands_ of an instruction, even those that are not a
 part of the body or that are inactive. However, DIEL does not apply
-to other values such as vl, vtype, and the mask (when used to control
+to other values such as csr:vl[], csr:vtype[], and the mask (when used to control
 execution of a masked vector instruction).
 Also, DIEL does not apply to constant values specified in the
 instruction encoding such as the use of the zero register (`x0`), and, in the
 case of immediate forms of an instruction, the values in the immediate
-fields (i.e., imm, and uimm).
+fields (i.e., _imm_ and _uimm_).
 
 In some cases--which are explicitly specified in the lists below--operands that are used as control rather than data
 are exempt from DIEL.
@@ -1038,16 +1030,22 @@ also needs to be kept secret.
 ====
 
 ====== All extlink:zvbb[]  instructions
-- vandn.v[vx]
-- vclz.v
-- vcpop.v
-- vctz.v
-- vbrev.v
-- vbrev8.v
-- vrev8.v
-- vrol.v[vx]
-- vror.v[vxi]
-- vwsll.[vv,vx,vi]
+- insn:vandn.vv[]
+- insn:vandn.vx[]
+- insn:vclz.v[]
+- insn:vcpop.v[]
+- insn:vctz.v[]
+- insn:vbrev.v[]
+- insn:vbrev8.v[]
+- insn:vrev8.v[]
+- insn:vrol.vv[]
+- insn:vrol.vx[]
+- insn:vror.vv[]
+- insn:vror.vx[]
+- insn:vror.vi[]
+- insn:vwsll.vv[]
+- insn:vwsll.vx[]
+- insn:vwsll.vi[]
 
 [NOTE]
 ====
@@ -1056,144 +1054,293 @@ proper subset of extlink:zvbb[]
 ====
 
 ====== All extlink:zvbc[] instructions
-- vclmul[h].v[vx]
+- insn:vclmul.vv[]
+- insn:vclmul.vx[]
+- insn:vclmulh.vv[]
+- insn:vclmulh.vx[]
+
 
 ====== add/sub
-- v[r]sub.v[vx]
-- vadd.v[ivx]
-- vsub.v[vx]
-- vwadd[u].[vw][vx]
-- vwsub[u].[vw][vx]
+- insn:vsub.vv[]
+- insn:vsub.vx[]
+- insn:vrsub.vv[]
+- insn:vrsub.vx[]
+- insn:vadd.vv[]
+- insn:vadd.vx[]
+- insn:vadd.vi[]
+- insn:vsub.vv[]
+- insn:vsub.vx[]
+- insn:vwadd.vv[]
+- insn:vwadd.vx[]
+- insn:vwadd.wv[]
+- insn:vwadd.wx[]
+- insn:vwaddu.vv[]
+- insn:vwaddu.vx[]
+- insn:vwaddu.wv[]
+- insn:vwaddu.wx[]
+- insn:vwsub.vv[]
+- insn:vwsub.vx[]
+- insn:vwsub.wv[]
+- insn:vwsub.wx[]
+- insn:vwsubu.vv[]
+- insn:vwsubu.vx[]
+- insn:vwsubu.wv[]
+- insn:vwsubu.wx[]
 
 ====== add/sub with carry
-- vadc.v[ivx]m
-- vmadc.v[ivx][m]
-- vmsbc.v[vx]m
-- vsbc.v[vx]m
+- insn:vadc.vvm[]
+- insn:vadc.vxm[]
+- insn:vadc.vim[]
+- insn:vmadc.vv[]
+- insn:vmadc.vx[]
+- insn:vmadc.vi[]
+- insn:vmadc.vvm[]
+- insn:vmadc.vxm[]
+- insn:vmadc.vim[]
+- insn:vmsbc.vvm[]
+- insn:vmsbc.vxm[]
+- insn:vsbc.vvm[]
+- insn:vsbc.vxm[]
 
 ====== compare and set
-- vmseq.v[vxi]
-- vmsgt[u].v[xi]
-- vmsle[u].v[xi]
-- vmslt[u].v[xi]
-- vmsne.v[ivx]
+- insn:vmseq.vv[]
+- insn:vmseq.vx[]
+- insn:vmseq.vi[]
+- insn:vmsgt.vx[]
+- insn:vmsgt.vi[]
+- insn:vmsgtu.vx[]
+- insn:vmsgtu.vi[]
+- insn:vmsle.vx[]
+- insn:vmsle.vi[]
+- insn:vmsleu.vx[]
+- insn:vmsleu.vi[]
+- insn:vmslt.vx[]
+- insn:vmslt.vi[]
+- insn:vmsltu.vx[]
+- insn:vmsltu.vi[]
+- insn:vmsne.vv[]
+- insn:vmsne.vx[]
+- insn:vmsne.vi[]
 
 ====== copy
-- vmv.s.x
-- vmv.v.[ivxs]
-- vmv[1248]r.v
+- insn:vmv.s.x[]
+- insn:vmv.v.s[]
+- insn:vmv.v.v[]
+- insn:vmv.v.x[]
+- insn:vmv.v.i[]
+- insn:vmv1r.v[]
+- insn:vmv2r.v[]
+- insn:vmv4r.v[]
+- insn:vmv8r.v[]
 
 ====== extend
-- vsext.vf[248]
-- vzext.vf[248]
+- insn:vsext.vf2[]
+- insn:vsext.vf4[]
+- insn:vsext.vf8[]
+- insn:vzext.vf2[]
+- insn:vzext.vf4[]
+- insn:vzext.vf8[]
 
 ====== logical
-- vand.v[ivx]
-- vm[n]or.mm
-- vmand[n].mm
-- vmnand.mm
-- vmorn.mm
-- vmx[n]or.mm
-- vor.v[ivx]
-- vxor.v[ivx]
+- insn:vand.vv[]
+- insn:vand.vx[]
+- insn:vand.vi[]
+- insn:vmor.mm[]
+- insn:vmnor.mm[]
+- insn:vmand.mm[]
+- insn:vmandn.mm[]
+- insn:vmnand.mm[]
+- insn:vmorn.mm[]
+- insn:vmxor.mm[]
+- insn:vmxnor.mm[]
+- insn:vor.vv[]
+- insn:vor.vx[]
+- insn:vor.vi[]
+- insn:vxor.vv[]
+- insn:vxor.vx[]
+- insn:vxor.vi[]
 
 ====== multiply
-- vmul[h].v[vx]
-- vmulh[s]u.v[vx]
-- vwmul.v[vx]
-- vwmul[s]u.v[vx]
+- insn:vmul.vv[]
+- insn:vmul.vx[]
+- insn:vmulh.vv[]
+- insn:vmulh.vx[]
+- insn:vmulhu.vv[]
+- insn:vmulhu.vx[]
+- insn:vmulhsu.vv[]
+- insn:vmulhsu.vx[]
+- insn:vwmul.vv[]
+- insn:vwmul.vx[]
+- insn:vwmulu.vv[]
+- insn:vwmulu.vx[]
+- insn:vwmulsu.vv[]
+- insn:vwmulsu.vx[]
 
 ====== multiply-add
-- vmacc.v[vx]
-- vmadd.v[vx]
-- vnmsac.v[vx]
-- vnmsub.v[vx]
-- vwmacc.v[vx]
-- vwmacc[s]u.v[vx]
-- vwmaccus.vx
+- insn:vmacc.vv[]
+- insn:vmacc.vx[]
+- insn:vmadd.vv[]
+- insn:vmadd.vx[]
+- insn:vnmsac.vv[]
+- insn:vnmsac.vx[]
+- insn:vnmsub.vv[]
+- insn:vnmsub.vx[]
+- insn:vwmacc.vv[]
+- insn:vwmacc.vx[]
+- insn:vwmaccu.vv[]
+- insn:vwmaccu.vx[]
+- insn:vwmaccsu.vv[]
+- insn:vwmaccsu.vx[]
+- insn:vwmaccus.vx[]
 
 ====== Integer Merge
-- vmerge.v[ivx]m
+- insn:vmerge.vvm[]
+- insn:vmerge.vxm[]
+- insn:vmerge.vim[]
 
 ====== permute
-In the `.vv` and `.xv` forms of the `vrgather[ei16]` instructions,
-the values in `vs1` and `rs1` are used for control and therefore are exempt from DIEL.
+In the insn:*.vv[] and insn:*.xv[] forms of the insn:vrgather[] and insn:vrgatherei16[] instructions,
+the values in _vs1_ and _rs1_ are used for control and therefore are exempt from DIEL.
 
-- vrgather.v[ivx]
-- vrgatherei16.vv
+- insn:vrgather.vv[]
+- insn:vrgather.vx[]
+- insn:vrgather.vi[]
+- insn:vrgatherei16.vv[]
 
 ====== shift
-// The values in `vs1`, `rs1`, `imm` are used for control (i.e., shift amount) and are exempt from DIEL.
+// The values in _vs1_, _rs1_, _imm_ are used for control (i.e., shift amount) and are exempt from DIEL.
 
-- vnsr[al].w[ivx]
-- vsll.v[ivx]
-- vsr[al].v[ivx]
+- insn:vnsra.wv[]
+- insn:vnsra.wx[]
+- insn:vnsra.wi[]
+- insn:vnsrl.wv[]
+- insn:vnsrl.wx[]
+- insn:vnsrl.wi[]
+- insn:vsll.vv[]
+- insn:vsll.vx[]
+- insn:vsll.vi[]
+- insn:vsra.vv[]
+- insn:vsra.vx[]
+- insn:vsra.vi[]
+- insn:vsrl.vv[]
+- insn:vsrl.vx[]
+- insn:vsrl.vi[]
 
 ====== slide
-- vslide1[up|down].vx
-- vfslide1[up|down].vf
+- insn:vslide1up.vx[]
+- insn:vslide1down.vx[]
+- insn:vfslide1up.vf[]
+- insn:vfslide1down.vf[]
 
-In the vslide[up|down].vx instructions, the value in `rs1`
+In the insn:vslideup.vx[] and insn:vslidedown.vx[] instructions, the value in _rs1_
 is used for control (i.e., slide amount) and therefore is exempt
 from DIEL.
 
-- vslide[up|down].v[ix]
+- insn:vslideup.vx[]
+- insn:vslideup.vi[]
+- insn:vslidedown.vx[]
+- insn:vslidedown.vi[]
 
 [NOTE]
 ====
-The following instructions are not affected by Zvkt:
+The following instructions are not affected by ext:zvkt[]:
 
 - *All storage operations*
 - *All floating-point operations*
 - add/sub saturate
-* vsadd[u].v[ivx]
-* vssub[u].v[vx]
+* insn:vsadd.vv[]
+* insn:vsadd.vx[]
+* insn:vsadd.vi[]
+* insn:vsaddu.vv[]
+* insn:vsaddu.vx[]
+* insn:vsaddu.vi[]
+* insn:vssub.vv[]
+* insn:vssub.vx[]
+* insn:vssubu.vv[]
+* insn:vssubu.vx[]
 - clip
-* vnclip[u].w[ivx]
+* insn:vnclip.wv[]
+* insn:vnclip.wx[]
+* insn:vnclip.wi[]
+* insn:vnclipu.wv[]
+* insn:vnclipu.wx[]
+* insn:vnclipu.wi[]
 - compress
-* vcompress.vm
+* insn:vcompress.vm[]
 - divide
-* vdiv[u].v[vx]
-* vrem[u].v[vx]
+* insn:vdiv.vv[]
+* insn:vdiv.vx[]
+* insn:vdivu.vv[]
+* insn:vdivu.vx[]
+* insn:vrem.vv[]
+* insn:vrem.vx[]
+* insn:vremu.vv[]
+* insn:vremu.vx[]
 - average
-* vaadd[u].v[vx]
-* vasub[u].v[vx]
+* insn:vaadd.vv[]
+* insn:vaadd.vx[]
+* insn:vaaddu.vv[]
+* insn:vaaddu.vx[]
+* insn:vasub.vv[]
+* insn:vasub.vx[]
+* insn:vasubu.vv[]
+* insn:vasubu.vx[]
 - mask Op
-* vcpop.m
-* vfirst.m
-* vid.v
-* viota.m
-* vms[bio]f.m
+* insn:vcpop.m[]
+* insn:vfirst.m[]
+* insn:vid.v[]
+* insn:viota.m[]
+* insn:vmsbf.m[]
+* insn:vmsif.m[]
+* insn:vmsof.m[]
 - min/max
-* vmax[u].v[vx]
-* vmin[u].v[vx]
+* insn:vmax.vv[]
+* insn:vmax.vx[]
+* insn:vmaxu.vv[]
+* insn:vmaxu.vx[]
+* insn:vmin.vv[]
+* insn:vmin.vx[]
+* insn:vminu.vv[]
+* insn:vminu.vx[]
 - Multiply-saturate
-* vsmul.v[vx]
+* insn:vsmul.vv[]
+* insn:vsmul.vx[]
 - reduce
-* vredsum.vs
-* vwredsum[u].vs
-* vred[and|or|xor].vs
-* vred[min|max][u].vs
+* insn:vredsum.vs[]
+* insn:vwredsum.vs[]
+* insn:vwredsumu.vs[]
+* insn:vredand.vs[]
+* insn:vredor.vs[]
+* insn:vredxor.vs[]
+* insn:vredmax.vs[]
+* insn:vredmaxu.vs[]
+* insn:vredmin.vs[]
+* insn:vredminu.vs[]
 - shift round
-* vssra.v[ivx]
-* vssrl.v[ivx]
+* insn:vssra.vv[]
+* insn:vssra.vx[]
+* insn:vssra.vi[]
+* insn:vssrl.vv[]
+* insn:vssrl.vx[]
+* insn:vssrl.vi[]
 - vset
-* vsetivli
-* vsetvl[i]
+* insn:vsetivli[]
+* insn:vsetvl[]
+* insn:vsetvli[]
 ====
 
 [[crypto_vector_insns, reftext="Vector Cryptography Instructions"]]
 ==== Instructions
 
 [[insns-vaesdf, Vector AES decrypt final round]]
-===== vaesdf.[vv,vs]
+===== insn:vaesdf.vv[] and insn:vaesdf.vs[]
 
 Synopsis::
 Vector AES final-round decryption
 
 Mnemonic::
-vaesdf.vv vd, vs2 +
-vaesdf.vs vd, vs2
+insn:vaesdf.vv[vd,vs2] +
+insn:vaesdf.vs[vd,vs2]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -1223,8 +1370,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
-* Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
+* SEW is any value other than 32
+* Only for the insn:*.vs[] form: the _vd_ register group overlaps the _vs2_ scalar element group
 
 Arguments::
 
@@ -1238,17 +1385,17 @@ Arguments::
 |EEW
 |Definition
 
-| Vd  | input  | 128  | 4 | 32 | round state
-| Vs2 | input  | 128  | 4 | 32 | round key
-| Vd  | output | 128  | 4 | 32 | new round state
+| _vd_  | input  | 128  | 4 | 32 | round state
+| _vs2_ | input  | 128  | 4 | 32 | round key
+| _vd_  | output | 128  | 4 | 32 | new round state
 |===
 
 Description::
 [[norm:vaesdf_final]] A final-round AES block cipher decryption is performed.
 
-[#norm:vaesdf_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from `vd`.#
-[#norm:vaesdf_xor_form]#This is then XORed with the round key in either the corresponding element group in `vs2` (vector-vector
-form) or scalar element group in `vs2` (vector-scalar form).#
+[#norm:vaesdf_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from _vd_.#
+[#norm:vaesdf_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
+form) or scalar element group in _vs2_ (vector-scalar form).#
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.
@@ -1287,14 +1434,14 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaesdm, Vector AES decrypt middle round]]
-===== vaesdm.[vv,vs]
+===== insn:vaesdm.vv[] and insn:vaesdm.vs[]
 
 Synopsis::
 Vector AES middle-round decryption
 
 Mnemonic::
-vaesdm.vv vd, vs2 +
-vaesdm.vs vd, vs2
+insn:vaesdm.vv[vd,vs2] +
+insn:vaesdm.vs[vd,vs2]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -1324,8 +1471,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
-* Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
+* SEW is any value other than 32
+* Only for the insn:*.vs[] form: the _vd_ register group overlaps the _vs2_ scalar element group
 
 Arguments::
 
@@ -1339,17 +1486,17 @@ Arguments::
 |EEW
 |Definition
 
-| Vd  | input  | 128  | 4 | 32 | round state
-| Vs2 | input  | 128  | 4 | 32 | round key
-| Vd  | output | 128  | 4 | 32 | new round state
+| _vd_  | input  | 128  | 4 | 32 | round state
+| _vs2_ | input  | 128  | 4 | 32 | round key
+| _vd_  | output | 128  | 4 | 32 | new round state
 |===
 
 Description::
 [[norm:vaesdm_mid]] A middle-round AES block cipher decryption is performed.
 
-[#norm:vaesdm_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from `vd`.#
-[#norm:vaesdm_xor_form]#This is then XORed with the round key in either the corresponding element group in `vs2` (vector-vector
-form) or the scalar element group in `vs2` (vector-scalar form).# The result is then applied to the
+[#norm:vaesdm_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from _vd_.#
+[#norm:vaesdm_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
+form) or the scalar element group in _vs2_ (vector-scalar form).# The result is then applied to the
 [#norm:vaesdm_invmix]#InvMixColumns step.#
 
 This instruction must always be implemented such that its execution latency does not depend
@@ -1393,14 +1540,14 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaesef, Vector AES encrypt final round]]
-===== vaesef.[vv,vs]
+===== insn:vaesef.vv[] and insn:vaesef.vs[]
 
 Synopsis::
 Vector AES final-round encryption
 
 Mnemonic::
-vaesef.vv vd, vs2 +
-vaesef.vs vd, vs2
+insn:vaesef.vv[vd,vs2] +
+insn:vaesef.vs[vd,vs2]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -1430,8 +1577,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
-* Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
+* SEW is any value other than 32
+* Only for the insn:*.vs[] form: the _vd_ register group overlaps the _vs2_ scalar element group
 
 Arguments::
 
@@ -1445,17 +1592,17 @@ Arguments::
 |EEW
 |Definition
 
-| vd  | input  | 128  | 4 | 32 | round state
-| vs2 | input  | 128  | 4 | 32 | round key
-| vd  | output | 128  | 4 | 32 | new round state
+| _vd_  | input  | 128  | 4 | 32 | round state
+| _vs2_ | input  | 128  | 4 | 32 | round key
+| _vd_  | output | 128  | 4 | 32 | new round state
 |===
 
 Description::
 [[norm:vaesef_final]] A final-round encryption function of the AES block cipher is performed.
 
-[#norm:vaesef_ops]#The SubBytes and ShiftRows steps are applied to each round state element group from `vd`.#
-[#norm:vaesef_xor_form]#This is then XORed with the round key in either the corresponding element group in `vs2` (vector-vector
-form) or the scalar element group in `vs2` (vector-scalar form).#
+[#norm:vaesef_ops]#The SubBytes and ShiftRows steps are applied to each round state element group from _vd_.#
+[#norm:vaesef_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
+form) or the scalar element group in _vs2_ (vector-scalar form).#
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.
@@ -1498,14 +1645,14 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaesem, Vector AES encrypt middle round]]
-===== vaesem.[vv,vs]
+===== insn:vaesem.vv[] and insn:vaesem.vs[]
 
 Synopsis::
 Vector AES middle-round encryption
 
 Mnemonic::
-vaesem.vv vd, vs2 +
-vaesem.vs vd, vs2
+insn:vaesem.vv[vd,vs2] +
+insn:vaesem.vs[vd,vs2]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -1535,8 +1682,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
-* Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
+* SEW is any value other than 32
+* Only for the insn:*.vs[] form: the _vd_ register group overlaps the _vs2_ scalar element group
 
 
 Arguments::
@@ -1551,17 +1698,17 @@ Arguments::
 |EEW
 |Definition
 
-| Vd  | input  | 128  | 4 | 32 | round state
-| Vs2 | input  | 128  | 4 | 32 | Round key
-| Vd  | output | 128  | 4 | 32 | new round state
+| _vd_  | input  | 128  | 4 | 32 | round state
+| _vs2_ | input  | 128  | 4 | 32 | Round key
+| _vd_  | output | 128  | 4 | 32 | new round state
 |===
 
 Description::
 [[norm:vaesem_mid]] A middle-round encryption function of the AES block cipher is performed.
 
-[#norm:vaesem_ops]#The SubBytes, ShiftRows, and MixColumns steps are applied to each round state element group from `vd`.#
-[#norm:vaesem_xor_form]#This is then XORed with the round key in either the corresponding  element group in `vs2` (vector-vector
-form) or the scalar element group in `vs2` (vector-scalar form).#
+[#norm:vaesem_ops]#The SubBytes, ShiftRows, and MixColumns steps are applied to each round state element group from _vd_.#
+[#norm:vaesem_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
+form) or the scalar element group in _vs2_ (vector-scalar form).#
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.
@@ -1604,13 +1751,13 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaeskf1, Vector AES-128 Forward KeySchedule]]
-===== vaeskf1.vi
+===== insn:vaeskf1.vi[]
 
 Synopsis::
 Vector AES-128 Forward KeySchedule generation
 
 Mnemonic::
-vaeskf1.vi vd, vs2, uimm
+insn:vaeskf1.vi[vd,vs2,uimm]
 
 Encoding::
 [wavedrom, , svg]
@@ -1626,7 +1773,7 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
+* SEW is any value other than 32
 
 Arguments::
 
@@ -1640,9 +1787,9 @@ Arguments::
 |EEW
 |Definition
 
-| uimm | input  | -    | - | -  | Round Number (rnd)
-| Vs2  | input  | 128  | 4 | 32 | Current round key
-| Vd   | output | 128  | 4 | 32 | Next round key
+| _uimm_ | input  | -    | - | -  | Round Number (rnd)
+| _vs2_  | input  | 128  | 4 | 32 | Current round key
+| _vd_   | output | 128  | 4 | 32 | Next round key
 |===
 
 Description::
@@ -1650,15 +1797,15 @@ Description::
 
 // Within each element group,
 [#norm:vaeskf1_wordgen]#The next round key is generated word by word from the
-current round key element group in `vs2` and the immediately previous word of the
+current round key element group in _vs2_ and the immediately previous word of the
 round key.# The least significant word is generated using the most significant
 word of the current round key as well as a round constant which is selected by
 the round number.
 
-The round number, which [#norm:vaeskf1_uimm_src]#ranges from 1 to 10, comes from `uimm[3:0]`;
-`uimm[4]` is ignored.#
-[#norm:vaeskf1_uimm_map]#The out-of-range `uimm[3:0]` values of 0 and 11-15 are mapped to in-range
-values by inverting `uimm[3]`.# Thus, 0 maps to 8, and 11-15 maps to 3-7.
+The round number, which [#norm:vaeskf1_uimm_src]#ranges from 1 to 10, comes from _uimm[3:0]_;
+_uimm[4]_ is ignored.#
+[#norm:vaeskf1_uimm_map]#The out-of-range _uimm[3:0]_ values of 0 and 11{endash}15 are mapped to in-range
+values by inverting _uimm[3]_.# Thus, 0 maps to 8, and 11{endash}15 maps to 3{endash}7.
 The round number is used to specify a round constant which is used in generating
 the first round key word.
 
@@ -1668,7 +1815,7 @@ on the data being operated upon.
 [NOTE]
 ====
 We chose to map out-of-range round numbers to in-range values as this allows the instruction's
-behavior to be fully defined for all values of `uimm[4:0]` with minimal extra logic.
+behavior to be fully defined for all values of _uimm[4:0]_ with minimal extra logic.
 ====
 
 // Each `EGW=128` element group next-round-key output is produced and is written to each `EGW=128`
@@ -1720,13 +1867,13 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaeskf2, Vector AES-256 Forward KeySchedule]]
-===== vaeskf2.vi
+===== insn:vaeskf2.vi[]
 
 Synopsis::
 Vector AES-256 Forward KeySchedule generation
 
 Mnemonic::
-vaeskf2.vi vd, vs2, uimm
+insn:vaeskf2.vi[vd,vs2,uimm]
 
 Encoding::
 [wavedrom, , svg]
@@ -1742,7 +1889,7 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
+* SEW is any value other than 32
 
 Arguments::
 
@@ -1756,10 +1903,10 @@ Arguments::
 |EEW
 |Definition
 
-| Vd   | input  | 128  | 4 | 32 | Previous Round key
-| uimm | input  | -    | - | -  | Round Number (rnd)
-| Vs2  | input  | 128  | 4 | 32 | Current Round key
-| Vd   | output | 128  | 4 | 32 | Next round key
+| _vd_   | input  | 128  | 4 | 32 | Previous Round key
+| _uimm_ | input  | -    | - | -  | Round Number (rnd)
+| _vs2_  | input  | 128  | 4 | 32 | Current Round key
+| _vd_   | output | 128  | 4 | 32 | Next round key
 |===
 
 Description::
@@ -1767,16 +1914,16 @@ Description::
 
 // Within each element group,
 [#norm:vaeskf2_wordgen]#The next round key is generated word by word from the
-previous round key element group in `vd` and the immediately previous word of the
+previous round key element group in _vd_ and the immediately previous word of the
 round key.# The [#norm:vaeskf2_rcon_lsw]#least significant word of the next round key is generated by
 applying a function to the most significant word of the current round key and
 then XORing the result with the round constant.#
 [#norm:vaeskf2_rcon_func]#The round number is used to select the round constant as well as the function.#
 
-The round number, which [#norm:vaeskf2_uimm_src]#ranges from 2 to 14, comes from `uimm[3:0]`;
-`uimm[4]` is ignored.#
-[#norm:vaeskf2_uimm_map]#The out-of-range `uimm[3:0]` values of 0-1 and 15 are mapped to in-range
-values by inverting `uimm[3]`.# Thus, 0-1 maps to 8-9, and 15 maps to 7.
+The round number, which [#norm:vaeskf2_uimm_src]#ranges from 2 to 14, comes from _uimm[3:0]_;
+_uimm[4]_ is ignored.#
+[#norm:vaeskf2_uimm_map]#The out-of-range _uimm[3:0]_ values of 0{endash}1 and 15 are mapped to in-range
+values by inverting _uimm[3]_.# Thus, 0{endash}1 maps to 8{endash}9, and 15 maps to 7.
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.
@@ -1784,7 +1931,7 @@ on the data being operated upon.
 [NOTE]
 ====
 We chose to map out-of-range round numbers to in-range values as this allows the instruction's
-behavior to be fully defined for all values of `uimm[4:0]` with minimal extra logic.
+behavior to be fully defined for all values of _uimm[4:0]_ with minimal extra logic.
 ====
 
 //
@@ -1833,13 +1980,13 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vaesz, Vector AES round zero]]
-===== vaesz.vs
+===== insn:vaesz.vs[]
 
 Synopsis::
 Vector AES round zero encryption/decryption
 
 Mnemonic::
-vaesz.vs vd, vs2
+insn:vaesz.vs[vd,vs2]
 
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
@@ -1855,8 +2002,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 32
-* The `vd` register group overlaps the `vs2` register
+* SEW is any value other than 32
+* The _vd_ register group overlaps the _vs2_ register
 
 Arguments::
 
@@ -1870,20 +2017,20 @@ Arguments::
 |EEW
 |Definition
 
-| vd  | input  | 128  | 4 | 32 | round state
-| vs2 | input  | 128  | 4 | 32 | round key
-| vd  | output | 128  | 4 | 32 | new round state
+| _vd_  | input  | 128  | 4 | 32 | round state
+| _vs2_ | input  | 128  | 4 | 32 | round key
+| _vd_  | output | 128  | 4 | 32 | new round state
 |===
 
 Description::
 [#norm:vaesz_round0]#A round-0 AES block cipher operation is performed.# This operation is used for both encryption and decryption.
 
-[#norm:vaesz_vs_only]#There is only a `.vs` form of the instruction.#
-[#norm:vaesz_vs2_rk]#`Vs2` holds a
+[#norm:vaesz_vs_only]#There is only a insn:*.vs[] form of the instruction.#
+[#norm:vaesz_vs2_rk]#_vs2_ holds a
 scalar element group that is used
 as the round key for all of the round state element groups.#
 The new round state output of each element group is produced by XORing
-the round key with each element group of `vd`.
+the round key with each element group of _vd_.
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.
@@ -1891,9 +2038,9 @@ on the data being operated upon.
 [NOTE]
 ====
 This instruction is needed to avoid the need to "`splat`" a 128-bit vector register group when the round key is the same for
-all 128-bit "`lanes`". Such a splat would typically be implemented with a `vrgather` instruction which would hurt performance
+all 128-bit "`lanes`". Such a splat would typically be implemented with a insn:vrgather[] instruction which would hurt performance
 in many implementations.
-This instruction only exists in the `.vs` form because the `.vv` form would be identical to the `vxor.vv vd, vs2, vd` instruction.
+This instruction only exists in the insn:*.vs[] form because the insn:*.vv[] form would be identical to the insn:vxor.vv[vd,vs2,vd] instruction.
 ====
 
 //
@@ -1931,14 +2078,14 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkned[], extlink:zvkng[]
 <<<
 
 [[insns-vandn, Vector And-Not]]
-===== vandn.[vv,vx]
+===== insn:vandn.vv[] and insn:vandn.vx[]
 
 Synopsis::
 Bitwise And-Not
 
 Mnemonic::
-vandn.vv vd, vs2, vs1, vm +
-vandn.vx vd, vs2, rs1, vm
+insn:vandn.vv[vd,vs2,vs1,vm] +
+insn:vandn.vx[vd,vs2,rs1,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -1977,9 +2124,9 @@ Vector-Vector Arguments::
 |Direction
 |Definition
 
-| Vs1 | input  | Op1  (to be inverted)
-| Vs2 | input  | Op2
-| Vd  | output | Result
+| _vs1_ | input  | Op1  (to be inverted)
+| _vs2_ | input  | Op2
+| _vd_  | output | Result
 |===
 
 Vector-Scalar Arguments::
@@ -1991,18 +2138,18 @@ Vector-Scalar Arguments::
 |Direction
 |Definition
 
-| Rs1     | input  | Op1  (to be inverted)
-| Vs2     | input  | Op2
-| Vd      | output | Result
+| _rs1_     | input  | Op1  (to be inverted)
+| _vs2_     | input  | Op2
+| _vd_      | output | Result
 |===
 
 Description::
 A bitwise _and-not_ operation is performed.
 
-[#norm:vandn_op]#Each bit of `Op1` is inverted and logically ANDed with the corresponding bits in `vs2`.#
+[#norm:vandn_op]#Each bit of `Op1` is inverted and logically ANDed with the corresponding bits in _vs2_.#
 [#norm:vandn-vx_rs1]#In the vector-scalar version, `Op1` is the sign-extended or truncated value in scalar
-register `rs1`.#
-[#norm:vandn-vv_vs1]#In the vector-vector version, `Op1` is `vs1`.#
+register _rs1_.#
+[#norm:vandn-vv_vs1]#In the vector-vector version, `Op1` is _vs1_.#
 
 // This instruction must always be implemented such that its execution latency does not depend
 // on the data being operated upon.
@@ -2012,13 +2159,13 @@ register `rs1`.#
 ====
 This instruction is performance-critical to SHA3. Specifically, the Chi step of the FIPS 202 Keccak Permutation.
 Emulating it via 2 instructions is expected to have significant performance impact.
-The `.vv` form of the instruction is what is needed for SHA3; the `.vx` form was added for completeness.
+The insn:*.vv[] form of the instruction is what is needed for SHA3; the insn:*.vx[] form was added for completeness.
 ====
 
 [NOTE]
 ====
-There is no .vi version of this instruction because the same functionality can be achieved by using an inversion
-of the immediate value with the `vand.vi` instruction.
+There is no insn:*.vi[] version of this instruction because the same functionality can be achieved by using an inversion
+of the immediate value with the insn:vand.vi[] instruction.
 ====
 
 Operation::
@@ -2045,13 +2192,13 @@ extlink:zvksc[], extlink:zvksg[]
 <<<
 
 [[insns-vbrev, Vector Reverse Bits in Elements]]
-===== vbrev.v
+===== insn:vbrev.v[]
 
 Synopsis::
 Vector Reverse Bits in Elements
 
 Mnemonic::
-vbrev.v vd, vs2, vm
+insn:vbrev.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2076,8 +2223,8 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Elements with bits reversed
+| _vs2_ | input  | Input elements
+| _vd_  | output | Elements with bits reversed
 |===
 
 Description::
@@ -2105,13 +2252,13 @@ extlink:zvbb[]
 <<<
 
 [[insns-vbrev8, Vector Reverse Bits in Bytes]]
-===== vbrev8.v
+===== insn:vbrev8.v[]
 
 Synopsis::
 Vector Reverse Bits in Bytes
 
 Mnemonic::
-vbrev8.v vd, vs2, vm
+insn:vbrev8.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2136,8 +2283,8 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Elements with bit-reversed bytes
+| _vs2_ | input  | Input elements
+| _vd_  | output | Elements with bit-reversed bytes
 |===
 
 Description::
@@ -2175,14 +2322,14 @@ extlink:zvksc[], extlink:zvksg[]
 <<<
 
 [[insns-vclmul, Vector Carry-less Multiply]]
-===== vclmul.[vv,vx]
+===== insn:vclmul.vv[] and insn:vclmul.vx[]
 
 Synopsis::
 Vector Carry-less Multiply by vector or scalar - returning low half of product.
 
 Mnemonic::
-vclmul.vv vd, vs2, vs1, vm +
-vclmul.vx vd, vs2, rs1, vm
+insn:vclmul.vv[vd,vs2,vs1,vm] +
+insn:vclmul.vx[vd,vs2,rs1,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -2212,7 +2359,7 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vclmul_sewn64_rsv]#`SEW` is any value other than 64#
+* [#norm:vclmul_sewn64_rsv]#SEW is any value other than 64#
 
 Arguments::
 
@@ -2223,27 +2370,27 @@ Arguments::
 |Direction
 |Definition
 
-| Vs1/Rs1 | input  |  multiplier
-| Vs2 | input  |  multiplicand
-| Vd  | output | carry-less product low
+| _vs1_/_rs1_ | input  |  multiplier
+| _vs2_       | input  |  multiplicand
+| _vd_        | output | carry-less product low
 |===
 
 Description::
 Produces the low half of 128-bit carry-less product.
 
-[#norm:vclmul_op]#Each 64-bit element in the `vs2` vector register is carry-less multiplied by
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
-from integer register `rs1` (vector-scalar). The result is the least
+[#norm:vclmul_op]#Each 64-bit element in the _vs2_ vector register is carry-less multiplied by
+either each 64-bit element in _vs1_ (vector-vector), or the 64-bit value
+from integer register _rs1_ (vector-scalar). The result is the least
 significant 64 bits of the carry-less product.#
 
 [NOTE]
 ====
-The 64-bit carry-less multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
+The 64-bit carry-less multiply instructions can be used for implementing GCM in the absence of the ext:zvkg[] extension.
 We do not make these instructions exclusive as the 64-bit carry-less multiply is readily derived from the
-instructions in the `zvkg` extension and can have utility in other areas.
+instructions in the ext:zvkg[] extension and can have utility in other areas.
 Likewise, we treat other SEW values as reserved so as not to preclude
 future extensions from using this opcode with different element widths.
-For example, a future extension might define an `SEW`=32 version of this instruction to enable `Zve32*` implementations to have
+For example, a future extension might define an SEW=32 version of this instruction to enable ext:zve32*[] implementations to have
 vector carry-less multiplication instructions.
 ====
 
@@ -2279,14 +2426,14 @@ extlink:zvbc[], extlink:zvknc[], extlink:zvksc[]
 <<<
 
 [[insns-vclmulh, Vector Carry-less Multiply Return High Half]]
-===== vclmulh.[vv,vx]
+===== insn:vclmulh.vv[] and insn:vclmulh.vx[]
 
 Synopsis::
 Vector Carry-less Multiply by vector or scalar - returning high half of product.
 
 Mnemonic::
-vclmulh.vv vd, vs2, vs1, vm +
-vclmulh.vx vd, vs2, rs1, vm
+insn:vclmulh.vv[vd,vs2,vs1,vm] +
+insn:vclmulh.vx[vd,vs2,rs1,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -2316,7 +2463,7 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vclmulh_sewn64_rsv]#`SEW` is any value other than 64#
+* [#norm:vclmulh_sewn64_rsv]#SEW is any value other than 64#
 
 Arguments::
 
@@ -2327,17 +2474,17 @@ Arguments::
 |Direction
 |Definition
 
-| Vs1 | input  | multiplier
-| Vs2 | input  | multiplicand
-| Vd  | output | carry-less product high
+| _vs1_ | input  | multiplier
+| _vs2_ | input  | multiplicand
+| _vd_  | output | carry-less product high
 |===
 
 Description::
 Produces the high half of 128-bit carry-less product.
 
-[#norm:vclmulh_op]#Each 64-bit element in the `vs2` vector register is carry-less multiplied by
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
-from integer register `rs1` (vector-scalar). The result is the most
+[#norm:vclmulh_op]#Each 64-bit element in the _vs2_ vector register is carry-less multiplied by
+either each 64-bit element in _vs1_ (vector-vector), or the 64-bit value
+from integer register _rs1_ (vector-scalar). The result is the most
 significant 64 bits of the carry-less product.#
 
 // This instruction must always be implemented such that its execution latency does not depend
@@ -2374,13 +2521,13 @@ extlink:zvbc[], extlink:zvknc[], extlink:zvksc[]
 <<<
 
 [[insns-vclz, Vector Count Leading Zeros]]
-===== vclz.v
+===== insn:vclz.v[]
 
 Synopsis::
 Vector Count Leading Zeros
 
 Mnemonic::
-vclz.v vd, vs2, vm
+insn:vclz.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2405,8 +2552,8 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Count of leading zero bits
+| _vs2_ | input  | Input elements
+| _vd_  | output | Count of leading zero bits
 |===
 
 Description::
@@ -2433,13 +2580,13 @@ Included in::
 extlink:zvbb[]
 
 [[insns-vcpop, Vector Population Count]]
-===== vcpop.v
+===== insn:vcpop.v[]
 
 Synopsis::
 Count the number of bits set in each element
 
 Mnemonic::
-vcpop.v vd, vs2, vm
+insn:vcpop.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2464,8 +2611,8 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Count of bits set
+| _vs2_ | input  | Input elements
+| _vd_  | output | Count of bits set
 |===
 
 Description::
@@ -2491,13 +2638,13 @@ Included in::
 extlink:zvbb[]
 
 [[insns-vctz, Vector Count Trailing Zeros]]
-===== vctz.v
+===== insn:vctz.v[]
 
 Synopsis::
 Vector Count Trailing Zeros
 
 Mnemonic::
-vctz.v vd, vs2, vm
+insn:vctz.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2522,8 +2669,8 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Count of trailing zero bits
+| _vs2_ | input  | Input elements
+| _vd_  | output | Count of trailing zero bits
 |===
 
 Description::
@@ -2552,13 +2699,13 @@ extlink:zvbb[]
 <<<
 
 [[insns-vghsh, Vector GHASH Add-Multiply]]
-===== vghsh.vv
+===== insn:vghsh.vv[]
 
 Synopsis::
 Vector Add-Multiply over GHASH Galois-Field
 
 Mnemonic::
-vghsh.vv vd, vs2, vs1
+insn:vghsh.vv[vd,vs2,vs1]
 
 Encoding::
 [wavedrom, , svg]
@@ -2574,7 +2721,7 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vghsh-vv_sewn32_rsv]#`SEW` is any value other than 32#
+* [#norm:vghsh-vv_sewn32_rsv]#SEW is any value other than 32#
 
 Arguments::
 
@@ -2588,14 +2735,14 @@ Arguments::
 |SEW
 |Definition
 
-| Vd  | input  | 128  | 4 | 32 | Partial hash (Y~i~)
-| Vs1 | input  | 128  | 4 | 32 | Cipher text (X~i~)
-| Vs2 | input  | 128  | 4 | 32 | Hash Subkey (H)
-| Vd  | output | 128  | 4 | 32 | Partial-hash (Y~i+1~)
+| _vd_  | input  | 128  | 4 | 32 | Partial hash (Y~i~)
+| _vs1_ | input  | 128  | 4 | 32 | Cipher text (X~i~)
+| _vs2_ | input  | 128  | 4 | 32 | Hash Subkey (H)
+| _vd_  | output | 128  | 4 | 32 | Partial-hash (Y~i+1~)
 |===
 
 Description::
-A single "iteration" of the GHASH~H~ algorithm is performed.
+A single "`iteration`" of the GHASH~H~ algorithm is performed.
 
 [#norm:vghsh-vv_op]#This instruction treats all of the inputs and outputs as 128-bit polynomials and
 performs operations over GF[2].
@@ -2631,7 +2778,7 @@ swap bit positions and therefore do not require any logic.
 ====
 Since the same hash subkey `H` will typically be used repeatedly on a given message,
 a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
+_vs2_ is the scalar element group. This would help reduce register pressure when LMUL>1.
 ====
 
 Operation::
@@ -2680,13 +2827,13 @@ extlink:zvkg[], extlink:zvkng[], extlink:zvksg[]
 <<<
 
 [[insns-vgmul, Vector GHASH Multiply]]
-===== vgmul.vv
+===== insn:vgmul.vv[]
 
 Synopsis::
 Vector Multiply over GHASH Galois-Field
 
 Mnemonic::
-vgmul.vv vd, vs2
+insn:vgmul.vv[vd,vs2]
 
 Encoding::
 [wavedrom, , svg]
@@ -2702,7 +2849,7 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vgmul-vv_sewn32_rsv]#`SEW` is any value other than 32#
+* [#norm:vgmul-vv_sewn32_rsv]#SEW is any value other than 32#
 
 Arguments::
 
@@ -2716,9 +2863,9 @@ Arguments::
 |SEW
 |Definition
 
-| Vd  | input  | 128  | 4 | 32 | Multiplier
-| Vs2 | input  | 128  | 4 | 32 | Multiplicand
-| Vd  | output | 128  | 4 | 32 | Product
+| _vd_  | input  | 128  | 4 | 32 | Multiplier
+| _vs2_ | input  | 128  | 4 | 32 | Multiplicand
+| _vd_  | output | 128  | 4 | 32 | Product
 |===
 
 Description::
@@ -2752,16 +2899,16 @@ swap bit positions and therefore do not require any logic.
 ====
 Since the same multiplicand will typically be used repeatedly on a given message,
 a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
+_vs2_ is the scalar element group. This would help reduce register pressure when LMUL>1.
 ====
 
 [NOTE]
 ====
-This instruction is identical to `vghsh.vv` with vs1=0.
+This instruction is identical to insn:vghsh.vv[] with _vs1_=0.
 This instruction is often used in GHASH code. In some cases it is followed
 by an XOR to perform a multiply-add. Implementations may choose to fuse these
 two instructions to improve performance on GHASH code that
-doesn't use the add-multiply form of the `vghsh.vv` instruction.
+doesn't use the add-multiply form of the insn:vghsh.vv[] instruction.
 ====
 
 
@@ -2808,13 +2955,13 @@ extlink:zvkg[], extlink:zvkng[], extlink:zvksg[]
 <<<
 
 [[insns-vrev8, Vector Reverse Bytes]]
-===== vrev8.v
+===== insn:vrev8.v[]
 
 Synopsis::
 Vector Reverse Bytes
 
 Mnemonic::
-vrev8.v vd, vs2, vm
+insn:vrev8.v[vd,vs2,vm]
 
 Encoding (Vector)::
 [wavedrom, , svg]
@@ -2839,12 +2986,12 @@ Arguments::
 |Direction
 |Definition
 
-| Vs2 | input  | Input elements
-| Vd  | output | Byte-reversed elements
+| _vs2_ | input  | Input elements
+| _vd_  | output | Byte-reversed elements
 |===
 
 Description::
-[#norm:vrev8-v_op]#A byte reversal is performed on each element of `vs2`, effectively performing an endian swap.#
+[#norm:vrev8-v_op]#A byte reversal is performed on each element of _vs2_, effectively performing an endian swap.#
 
 // This instruction must always be implemented such that its execution latency does not depend
 // on the data being operated upon.
@@ -2878,14 +3025,14 @@ extlink:zvksc[], extlink:zvksg[]
 <<<
 
 [[insns-vrol, Vector Rotate Left]]
-===== vrol.[vv,vx]
+===== insn:vrol.vv[] and insn:vrol.vx[]
 
 Synopsis::
 Vector rotate left by vector/scalar.
 
 Mnemonic::
-vrol.vv vd, vs2, vs1, vm +
-vrol.vx vd, vs2, rs1, vm +
+insn:vrol.vv[vd,vs2,vs1,vm] +
+insn:vrol.vx[vd,vs2,rs1,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -2924,9 +3071,9 @@ Vector-Vector Arguments::
 |Direction
 |Definition
 
-| Vs1 | input  | Rotate amount
-| Vs2 | input  | Data
-| Vd  | output | Rotated data
+| _vs1_ | input  | Rotate amount
+| _vs2_ | input  | Data
+| _vd_  | output | Rotated data
 |===
 
 Vector-Scalar Arguments::
@@ -2938,18 +3085,18 @@ Vector-Scalar Arguments::
 |Direction
 |Definition
 
-| Rs1     | input  | Rotate amount
-| Vs2     | input  | Data
-| Vd      | output | Rotated data
+| _rs1_     | input  | Rotate amount
+| _vs2_     | input  | Data
+| _vd_      | output | Rotated data
 |===
 
 Description::
-A bitwise left rotation is performed on each element of `vs2`
+A bitwise left rotation is performed on each element of _vs2_
 
-[#norm:vrol_op]#The elements in `vs2` are rotated left by the rotate amount specified by either
-the corresponding elements of `vs1` (vector-vector), or integer register `rs1`
+[#norm:vrol_op]#The elements in _vs2_ are rotated left by the rotate amount specified by either
+the corresponding elements of _vs1_ (vector-vector), or integer register _rs1_
 (vector-scalar).
-Only the low log2(`SEW`) bits of the rotate-amount value are used, all other
+Only the low log2(SEW) bits of the rotate-amount value are used, all other
 bits are ignored.#
 
 // This instruction must always be implemented such that its execution latency does not depend
@@ -2957,8 +3104,8 @@ bits are ignored.#
 
 [NOTE]
 ====
-There is no immediate form of this instruction (i.e., `vrol.vi`) as the same result can be achieved by negating
-the rotate amount and using the immediate form of rotate right instruction (i.e., vror.vi).
+There is no immediate form of this instruction (i.e., insn:vrol.vi[]) as the same result can be achieved by negating
+the rotate amount and using the immediate form of rotate right instruction (i.e., insn:vror.vi[]).
 ====
 
 Operation::
@@ -2991,15 +3138,15 @@ extlink:zvksc[], extlink:zvksg[]
 <<<
 
 [[insns-vror, Vector Rotate Right]]
-===== vror.[vv,vx,vi]
+===== insn:vror.vv[], insn:vror.vx[], and insn:vror.vi[]
 
 Synopsis::
 Vector rotate right by vector/scalar/immediate.
 
 Mnemonic::
-vror.vv vd, vs2, vs1, vm +
-vror.vx vd, vs2, rs1, vm +
-vror.vi vd, vs2, uimm, vm
+insn:vror.vv[vd,vs2,vs1,vm] +
+insn:vror.vx[vd,vs2,rs1,vm] +
+insn:vror.vi[vd,vs2,uimm,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -3053,9 +3200,9 @@ Vector-Vector Arguments::
 |Direction
 |Definition
 
-| Vs1 | input  | Rotate amount
-| Vs2 | input  | Data
-| Vd  | output | Rotated data
+| _vs1_ | input  | Rotate amount
+| _vs2_ | input  | Data
+| _vd_  | output | Rotated data
 |===
 
 Vector-Scalar/Immediate Arguments::
@@ -3067,19 +3214,19 @@ Vector-Scalar/Immediate Arguments::
 |Direction
 |Definition
 
-| Rs1/imm | input  | Rotate amount
-| Vs2     | input  | Data
-| Vd      | output | Rotated data
+| _rs1_/_uimm_ | input  | Rotate amount
+| _vs2_        | input  | Data
+| _vd_         | output | Rotated data
 |===
 
 
 Description::
-A bitwise right rotation is performed on each element of `vs2`.
+A bitwise right rotation is performed on each element of _vs2_.
 
-[#norm:vror_op]#The elements in `vs2` are rotated right by the rotate amount specified by either
-the corresponding elements of `vs1` (vector-vector), integer register `rs1`
+[#norm:vror_op]#The elements in _vs2_ are rotated right by the rotate amount specified by either
+the corresponding elements of _vs1_ (vector-vector), integer register _rs1_
 (vector-scalar), or an immediate value (vector-immediate).
-Only the low log2(`SEW`) bits of the rotate-amount value are used, all other
+Only the low log2(SEW) bits of the rotate-amount value are used, all other
 bits are ignored.#
 
 // This instruction must always be implemented such that its execution latency does not depend
@@ -3123,14 +3270,14 @@ extlink:zvksc[], extlink:zvksg[]
 <<<
 
 [[insns-vsha2c, Vector SHA-2 Compression]]
-===== vsha2c[hl].vv
+===== insn:vsha2ch.vv[] and insn:vsha2cl.vv[]
 
 Synopsis::
 Vector SHA-2 two rounds of compression.
 
 Mnemonic::
-vsha2ch.vv vd, vs2, vs1 +
-vsha2cl.vv vd, vs2, vs1
+insn:vsha2ch.vv[vd,vs2,vs1] +
+insn:vsha2cl.vv[vd,vs2,vs1]
 
 Encoding (Vector-Vector) High part::
 [wavedrom, , svg]
@@ -3160,9 +3307,9 @@ Encoding (Vector-Vector) Low part::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsha2chl-vv_Zvknha_sewn32_rsv]#`zvknha`: `SEW` is any value other than 32#
-* [#norm:vsha2chl-vv_Zvknhb_sewn32or64_rsv]#`zvknhb`: `SEW` is any value other than 32 or 64#
-* [#norm:vsha2chl-vv_vdoverlapvs1vs2_rsv]#The `vd` register group overlaps with either `vs1` or `vs2`#
+* [#norm:vsha2chl-vv_Zvknha_sewn32_rsv]#ext:zvknha[]: SEW is any value other than 32#
+* [#norm:vsha2chl-vv_Zvknhb_sewn32or64_rsv]#ext:zvknhb[]: SEW is any value other than 32 or 64#
+* [#norm:vsha2chl-vv_vdoverlapvs1vs2_rsv]#The _vd_ register group overlaps with either _vs1_ or _vs2_#
 
 Arguments::
 
@@ -3176,18 +3323,18 @@ Arguments::
 |EEW
 |Definition
 
-| Vd  | input  | 4*SEW  | 4 | SEW | current state {c, d, g, h}
-| Vs1 | input  | 4*SEW  | 4 | SEW | MessageSched plus constant[3:0]
-| Vs2 | input  | 4*SEW  | 4 | SEW | current state {a, b, e, f}
-| Vd  | output | 4*SEW  | 4 | SEW | next state {a, b, e, f}
+| _vd_  | input  | 4*SEW  | 4 | SEW | current state {c, d, g, h}
+| _vs1_ | input  | 4*SEW  | 4 | SEW | MessageSched plus constant[3:0]
+| _vs2_ | input  | 4*SEW  | 4 | SEW | current state {a, b, e, f}
+| _vd_  | output | 4*SEW  | 4 | SEW | next state {a, b, e, f}
 |===
 
 Description::
-- [#norm:vsha2chl-vv_op_sew32]#`SEW`=32: 2 rounds of SHA-256 compression are performed (`zvknha` and `zvknhb`)#
-- [#norm:vsha2chl-vv_op_sew64]#`SEW`=64: 2 rounds of SHA-512 compression are performed (`zvknhb`)#
+- [#norm:vsha2chl-vv_op_sew32]#SEW=32: 2 rounds of SHA-256 compression are performed (ext:zvknha[] and ext:zvknhb[])#
+- [#norm:vsha2chl-vv_op_sew64]#SEW=64: 2 rounds of SHA-512 compression are performed (ext:zvknhb[])#
 
-[#norm:vsha2chl-vv_op]#Two words of `vs1` are processed with
-the 8 words of current state held in `vd` and `vs2` to perform two
+[#norm:vsha2chl-vv_op]#Two words of _vs1_ are processed with
+the 8 words of current state held in _vd_ and _vs2_ to perform two
 rounds of hash computation producing four words of the
 next state.#
 
@@ -3218,9 +3365,9 @@ after all of the message blocks have been processed.
 
 [NOTE]
 ====
-The `vsha2ch` version of this instruction uses the two most significant message schedule
-words from the element group in `vs1`
-while the `vsha2cl` version uses the two least significant message schedule words.
+The insn:vsha2ch[] version of this instruction uses the two most significant message schedule
+words from the element group in _vs1_
+while the insn:vsha2cl[] version uses the two least significant message schedule words.
 Otherwise, these versions of the instruction are identical.
 Having a high and low version of this instruction typically improves performance when
 interleaving independent hashing operations (i.e., when hashing several files at once).
@@ -3249,9 +3396,9 @@ interleaving independent hashing operations (i.e., when hashing several files at
 
 [NOTE]
 ====
-Preventing overlap between `vd` and `vs1` or `vs2` simplifies implementation with `VLEN < EGW`.
+Preventing overlap between _vd_ and _vs1_ or _vs2_ simplifies implementation with VLEN<EGW.
 This restriction does not have any coding impact since proper implementation of the algorithm requires
-that `vd`, `vs1` and `vs2` each are different registers.
+that _vd_, _vs1_ and _vs2_ each are different registers.
 ====
 
 
@@ -3336,13 +3483,13 @@ extlink:zvkn[], extlink:zvknc[], extlink:zvkng[], extlink:zvknha[], extlink:zvkn
 <<<
 
 [[insns-vsha2ms, Vector SHA-2 Message Schedule]]
-===== vsha2ms.vv
+===== insn:vsha2ms.vv[]
 
 Synopsis::
 Vector SHA-2 message schedule.
 
 Mnemonic::
-vsha2ms.vv vd, vs2, vs1
+insn:vsha2ms.vv[vd,vs2,vs1]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -3358,9 +3505,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsha2ms-vv_Zvknha_sewn32_rsv]#`zvknha`: `SEW` is any value other than 32#
-* [#norm:vsha2ms-vv_Zvknhb_sewn32or64_rsv]#`zvknhb`: `SEW` is any value other than 32 or 64#
-* [#norm:vsha2ms-vv_vdoverlapvs1vs2_rsv]#The `vd` register group overlaps with either `vs1` or `vs2`#
+* [#norm:vsha2ms-vv_Zvknha_sewn32_rsv]#ext:zvknha[]: SEW is any value other than 32#
+* [#norm:vsha2ms-vv_Zvknhb_sewn32or64_rsv]#ext:zvknhb[]: SEW is any value other than 32 or 64#
+* [#norm:vsha2ms-vv_vdoverlapvs1vs2_rsv]#The _vd_ register group overlaps with either _vs1_ or _vs2_#
 Arguments::
 
 [%autowidth]
@@ -3373,18 +3520,18 @@ Arguments::
 |EEW
 |Definition
 
-| Vd  | input  | 4*SEW  | 4 | SEW | Message words {W[3],  W[2],  W[1],  W[0]}
-| Vs2 | input  | 4*SEW  | 4 | SEW | Message words {W[11], W[10], W[9],  W[4]}
-| Vs1 | input  | 4*SEW  | 4 | SEW | Message words {W[15], W[14], -, W[12]}
-| Vd  | output | 4*SEW  | 4 | SEW | Message words {W[19], W[18], W[17], W[16]}
+| _vd_  | input  | 4*SEW  | 4 | SEW | Message words {W[3],  W[2],  W[1],  W[0]}
+| _vs2_ | input  | 4*SEW  | 4 | SEW | Message words {W[11], W[10], W[9],  W[4]}
+| _vs1_ | input  | 4*SEW  | 4 | SEW | Message words {W[15], W[14], --, W[12]}
+| _vd_  | output | 4*SEW  | 4 | SEW | Message words {W[19], W[18], W[17], W[16]}
 |===
 
 Description::
-- [#norm:vsha2ms-vv_op_sew32]#`SEW`=32: Four rounds of SHA-256 message schedule expansion are performed (`zvknha` and `zvknhb`)#
-- [#norm:vsha2ms-vv_op_sew64]#`SEW`=64: Four rounds of SHA-512 message schedule expansion are performed (`zvknhb`)#
+- [#norm:vsha2ms-vv_op_sew32]#SEW=32: Four rounds of SHA-256 message schedule expansion are performed (ext:zvknha[] and ext:zvknhb[])#
+- [#norm:vsha2ms-vv_op_sew64]#SEW=64: Four rounds of SHA-512 message schedule expansion are performed (ext:zvknhb[])#
 
-[#norm:vsha2ms-vv_op]#Eleven of the last 16 `SEW`-sized message-schedule words from `vd` (oldest), `vs2`,
-and `vs1` (most recent) are processed to produce the
+[#norm:vsha2ms-vv_op]#Eleven of the last 16 SEW-sized message-schedule words from _vd_ (oldest), _vs2_,
+and _vs1_ (most recent) are processed to produce the
 next 4 message-schedule words.#
 
 [NOTE]
@@ -3432,7 +3579,7 @@ lower indices indicating older words.
 .Note to software developers
 ====
 The {W~11~, W~10~, W~9~, W~4~} element group can easily be formed by using a vector
-vmerge instruction with the appropriate mask (for example with `vl=4` and `4b0001`
+vmerge instruction with the appropriate mask (for example with csr:vl[]=4 and `4b0001`
 as the 4 mask bits)
 
 `vmerge.vvm {W~11~, W~10~, W~9~, W~4~}, {W~11~, W~10~, W~9~, W~8~}, {W~7~, W~6~, W~5~, W~4~}, V0`
@@ -3445,9 +3592,9 @@ as the 4 mask bits)
 
 [NOTE]
 ====
-Preventing overlap between `vd` and `vs1` or `vs2` simplifies implementation with `VLEN < EGW`.
+Preventing overlap between _vd_ and _vs1_ or _vs2_ simplifies implementation with VLEN<EGW.
 This restriction does not have any coding impact since proper implementation of the algorithm requires
-that `vd`, `vs1` and `vs2` each contain different portions of the message schedule.
+that _vd_, _vs1_ and _vs2_ each contain different portions of the message schedule.
 ====
 
 // This instruction is not masked. If any element groups are not to be processed, the _vl_
@@ -3521,13 +3668,13 @@ Included in::
 <<<
 
 [[insns-vsm3c, SM3 Compression]]
-===== vsm3c.vi
+===== insn:vsm3c.vi[]
 
 Synopsis::
 Vector SM3 Compression
 
 Mnemonic::
-vsm3c.vi vd, vs2, uimm
+insn:vsm3c.vi[vd,vs2,uimm]
 
 Encoding::
 [wavedrom, , svg]
@@ -3543,8 +3690,8 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsm3c-vi_sewn32_rsv]#`SEW` is any value other than 32#
-* [#norm:vsm3c-vi_vdoverlapvs2_rsv]#The `vd` register group overlaps with the `vs2` register group#
+* [#norm:vsm3c-vi_sewn32_rsv]#SEW is any value other than 32#
+* [#norm:vsm3c-vi_vdoverlapvs2_rsv]#The _vd_ register group overlaps with the _vs2_ register group#
 
 Arguments::
 
@@ -3558,32 +3705,32 @@ Arguments::
 |EEW
 |Definition
 
-| Vd   | input  | 256  | 8 | 32 | Current state {H,G.F,E,D,C,B,A}
-| uimm | input  | -    | - | -  | round number (rnds)
-| Vs2  | input  | 256  | 8 | 32 | Message words {-,-,w[5],w[4],-,-,w[1],w[0]}
-| Vd   | output | 256  | 8 | 32 | Next state {H,G.F,E,D,C,B,A}
+| _vd_   | input  | 256  | 8 | 32 | Current state {H,G.F,E,D,C,B,A}
+| _uimm_ | input  | -    | - | -  | round number
+| _vs2_  | input  | 256  | 8 | 32 | Message words {-,-,w[5],w[4],-,-,w[1],w[0]}
+| _vd_   | output | 256  | 8 | 32 | Next state {H,G.F,E,D,C,B,A}
 |===
 
 Description::
 [#norm:vsm3c-vi_op]#Two rounds of SM3 compression are performed.#
 
-[#norm:vsm3c-vi_op_sm3]#The current state of eight 32-bit words is read in as an element group from `vd`. Eight 32-bit
-message words are read in as an element group from `vs2`, although only four of them are used.
+[#norm:vsm3c-vi_op_sm3]#The current state of eight 32-bit words is read in as an element group from _vd_. Eight 32-bit
+message words are read in as an element group from _vs2_, although only four of them are used.
 All of the 32-bit input words are byte-swapped from big endian to little endian.
-These inputs are processed somewhat differently based on the round group (as specified in rnds),
+These inputs are processed somewhat differently based on the round group (as specified in _uimm_),
 and the next state is generated as an element group of eight 32-bit words.
 The next state of eight 32-bit words are generated,
 swapped from little endian to big endian, and are returned in
 an eight-element group.#
 
-[#norm:vsm3c-vi_op_rnd]#The round number is provided by the 5-bit `rnds` unsigned immediate. Legal values are 0 - 31
-and indicate which group of two rounds are being performed. For example, if rnds=1,
+[#norm:vsm3c-vi_op_rnd]#The round number is provided by the 5-bit _uimm_ unsigned immediate. Legal values are 0{endash}31
+and indicate which group of two rounds are being performed. For example, if _uimm_=1,
 then rounds 2 and 3 are being performed.#
 
 [NOTE]
 ====
 The round number is used in the rotation of the constant as well to inform the
-behavior which differs between rounds 0-15 and rounds 16-63.
+behavior which differs between rounds 0{endash}15 and rounds 16{endash}63.
 ====
 
 [NOTE]
@@ -3594,9 +3741,9 @@ specification without requiring that software perform these swaps.
 
 [NOTE]
 ====
-Preventing overlap between `vd` and `vs2` simplifies implementation with `VLEN < EGW`.
+Preventing overlap between _vd_ and _vs2_ simplifies implementation with VLEN<EGW.
 This restriction does not have any coding impact since proper implementation of the algorithm requires
-that `vd` and `vs2` each are different registers.
+that _vd_ and _vs2_ each are different registers.
 ====
 
 // The elements are listed here in the order they appear in the register, with the most significant
@@ -3714,13 +3861,13 @@ extlink:zvks[], extlink:zvksc[], extlink:zvksg[], extlink:zvksh[]
 <<<
 
 [[insns-vsm3me, SM3 Message Expansion]]
-===== vsm3me.vv
+===== insn:vsm3me.vv[]
 
 Synopsis::
 Vector SM3 Message Expansion
 
 Mnemonic::
-vsm3me.vv vd, vs2, vs1
+insn:vsm3me.vv[vd,vs2,vs1]
 
 Encoding::
 [wavedrom, , svg]
@@ -3736,8 +3883,8 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsm3me-vv_sewn32_rsv]#`SEW` is any value other than 32#
-* [#norm:vsm3me-vv_vdoverlapvs2_rsv]#The `vd` register group overlaps with the `vs2` register group.#
+* [#norm:vsm3me-vv_sewn32_rsv]#SEW is any value other than 32#
+* [#norm:vsm3me-vv_vdoverlapvs2_rsv]#The _vd_ register group overlaps with the _vs2_ register group.#
 
 Arguments::
 
@@ -3751,9 +3898,9 @@ Arguments::
 |EEW
 |Definition
 
-| Vs1 | input  | 256  | 8 | 32 | Message words W[7:0]
-| Vs2 | input  | 256  | 8 | 32 | Message words W[15:8]
-| Vd  | output | 256  | 8 | 32 | Message words W[23:16]
+| _vs1_ | input  | 256  | 8 | 32 | Message words W[7:0]
+| _vs2_ | input  | 256  | 8 | 32 | Message words W[15:8]
+| _vd_  | output | 256  | 8 | 32 | Message words W[23:16]
 |===
 
 Description::
@@ -3761,7 +3908,7 @@ Description::
 
 
 [#norm:vsm3me-vv_op_sm3]#The sixteen most recent 32-bit message words are read in as two
-eight-element groups from `vs1` and `vs2`. Each of these words is
+eight-element groups from _vs1_ and _vs2_. Each of these words is
 swapped from big endian to little endian.
 The next eight 32-bit message words are generated,
 swapped from little endian to big endian, and are returned in
@@ -3872,7 +4019,7 @@ Synopsis::
 Vector SM4 KeyExpansion
 
 Mnemonic::
-vsm4k.vi vd, vs2, uimm
+insn:vsm4k.vi[vd,vs2,uimm]
 
 Encoding::
 [wavedrom, , svg]
@@ -3888,7 +4035,7 @@ Encoding::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsm4k-vi_sewn32_rsv]#`SEW` is any value other than 32#
+* [#norm:vsm4k-vi_sewn32_rsv]#SEW is any value other than 32#
 
 Arguments::
 
@@ -3902,23 +4049,23 @@ Arguments::
 |EEW
 |Definition
 
-| uimm | input  | -    | - | -  | Round group (rnd)
-| Vs2  | input  | 128  | 4 | 32 | Current 4 round keys rK[0:3]
-| Vd   | output | 128  | 4 | 32 | Next 4 round keys rK'[0:3]
+| _uimm_ | input  | -    | - | -  | Round group
+| _vs2_  | input  | 128  | 4 | 32 | Current 4 round keys rK[0:3]
+| _vd_   | output | 128  | 4 | 32 | Next 4 round keys rK'[0:3]
 |===
 
 Description::
 [#norm:vsm4k-vi_op]#Four rounds of the SM4 Key Expansion are performed.#
 
-[#norm:vsm4k-vi_op_sm4k]#Four round keys are read in as a 4-element group from `vs2`. Each of the next four round keys are generated
+[#norm:vsm4k-vi_op_sm4k]#Four round keys are read in as a 4-element group from _vs2_. Each of the next four round keys are generated
 by iteratively XORing the last three round keys with a constant that is indexed by the Round Group Number,
 performing a byte-wise substitution, and then performing XORs between rotated versions of this value
 and the corresponding current round key.#
 
-[#norm:vsm4k-vi_op_rnd]#The Round group number (`rnd`) comes from `uimm[2:0]`; the bits in `uimm[4:3]` are ignored.
+[#norm:vsm4k-vi_op_rnd]#The Round group number comes from _uimm[2:0]_; the bits in _uimm[4:3]_ are ignored.
 Round group numbers range from 0 to 7 and indicate which
-group of four round keys are being generated. Round Keys range from 0-31.
-For example, if `rnd`=1, then round keys 4, 5, 6, and 7 are being generated.#
+group of four round keys are being generated. Round Keys range from 0{endash}31.
+For example, if _uimm_=1, then round keys 4, 5, 6, and 7 are being generated.#
 
 //  vs2 = {rK[i-4], rK[i-3],rK[i-2], rK[i-1]} // last 4 round keys
 //  rnd = 0 to 7; // group of 4 rounds
@@ -4083,14 +4230,14 @@ extlink:zvks[], extlink:zvksc[], extlink:zvksed[], extlink:zvksg[]
 <<<
 
 [[insns-vsm4r, SM4 Block Cipher Rounds]]
-===== vsm4r.[vv,vs]
+===== insn:vsm4r.vv[] and insn:vsm4r.vs[]
 
 Synopsis::
 Vector SM4 Rounds
 
 Mnemonic::
-vsm4r.vv vd, vs2 +
-vsm4r.vs vd, vs2
+insn:vsm4r.vv[vd,vs2] +
+insn:vsm4r.vs[vd,vs2]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -4120,8 +4267,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* [#norm:vsm4r_sewn32_rsv]#`SEW` is any value other than 32#
-* [#norm:vsm4r-vs_vdoverlapvs2_rsv]#Only for the `.vs` form: the `vd` register group overlaps the `vs2` register#
+* [#norm:vsm4r_sewn32_rsv]#SEW is any value other than 32#
+* [#norm:vsm4r-vs_vdoverlapvs2_rsv]#Only for the insn:*.vs[] form: the _vd_ register group overlaps the _vs2_ register#
 
 Arguments::
 
@@ -4135,17 +4282,17 @@ Arguments::
 |EEW
 |Definition
 
-| Vd   | input  | 128  | 4 | 32 | Current state X[0:3]
-| Vs2  | input  | 128  | 4 | 32 | Round keys rk[0:3]
-| Vd   | output | 128  | 4 | 32 | Next state X'[0:3]
+| _vd_   | input  | 128  | 4 | 32 | Current state X[0:3]
+| _vs2_  | input  | 128  | 4 | 32 | Round keys rk[0:3]
+| _vd_   | output | 128  | 4 | 32 | Next state X'[0:3]
 |===
 
 Description::
 [#norm:vsm4r_op]#Four rounds of SM4 Encryption/Decryption are performed.#
 
-[#norm:vsm4r_op_sm4encdec]#The four words of current state are read as a 4-element group from `vd`
+[#norm:vsm4r_op_sm4encdec]#The four words of current state are read as a 4-element group from _vd_
 and the round keys are read from either the corresponding 4-element group
-in `vs2` (vector-vector form) or the scalar element group in `vs2`
+in _vs2_ (vector-vector form) or the scalar element group in _vs2_
 (vector-scalar form).
 The next four words of state are generated
 by iteratively XORing the last three words of the state with
@@ -4240,15 +4387,15 @@ extlink:zvks[], extlink:zvksc[], extlink:zvksed[], extlink:zvksg[]
 <<<
 
 [[insns-vwsll, Vector Widening Shift Left Logical]]
-===== vwsll.[vv,vx,vi]
+===== insn:vwsll.vv[], insn:vwsll.vx[], and insn:vwsll.vi[]
 
 Synopsis::
 Vector widening shift left logical by vector/scalar/immediate.
 
 Mnemonic::
-vwsll.vv vd, vs2, vs1, vm +
-vwsll.vx vd, vs2, rs1, vm +
-vwsll.vi vd, vs2, uimm, vm
+insn:vwsll.vv[vd,vs2,vs1,vm] +
+insn:vwsll.vx[vd,vs2,rs1,vm] +
+insn:vwsll.vi[vd,vs2,uimm,vm]
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -4301,9 +4448,9 @@ Vector-Vector Arguments::
 |Direction
 |Definition
 
-| Vs1 | input  | Shift amount
-| Vs2 | input  | Data
-| Vd  | output | Shifted data
+| _vs1_ | input  | Shift amount
+| _vs2_ | input  | Data
+| _vd_  | output | Shifted data
 |===
 
 Vector-Scalar/Immediate Arguments::
@@ -4316,20 +4463,20 @@ Vector-Scalar/Immediate Arguments::
 |EEW
 |Definition
 
-| Rs1/imm | input  | SEW   | Shift amount
-| Vs2     | input  | SEW   | Data
-| Vd      | output | 2*SEW | Shifted data
+| _rs1_/_uimm_ | input  | SEW   | Shift amount
+| _vs2_        | input  | SEW   | Data
+| _vd_         | output | 2*SEW | Shifted data
 |===
 
 
 Description::
-A widening logical shift left is performed on each element of `vs2`.
+A widening logical shift left is performed on each element of _vs2_.
 
-[#norm:vwsll_op]#The elements in `vs2` are zero-extended to 2*`SEW` bits, then shifted left
+[#norm:vwsll_op]#The elements in _vs2_ are zero-extended to 2{times}SEW bits, then shifted left
 by the shift amount specified by either
-the corresponding elements of `vs1` (vector-vector), integer register `rs1`
+the corresponding elements of _vs1_ (vector-vector), integer register _rs1_
 (vector-scalar), or an immediate value (vector-immediate).
-Only the low log2(2*`SEW`) bits of the shift-amount value are used, all other
+Only the low log2(2{times}SEW) bits of the shift-amount value are used, all other
 bits are ignored.#
 
 Operation::
@@ -4373,7 +4520,7 @@ extlink:zvbb[]
 ==== Crypto Vector Cryptographic Instructions
 
 OP-VE (0x77)
-Crypto Vector instructions except Zvbb and Zvbc
+Crypto Vector instructions except ext:zvbb[] and ext:zvbc[]
 
 // [cols="4,1,1,1,8,4,1,1,8,4,1,1,8"]
 [cols="4,1,1,1,1,4,1,1,1,4,1,1,1"]
@@ -4431,7 +4578,7 @@ Crypto Vector instructions except Zvbb and Zvbc
 ==== Vector Bitmanip and Carry-less Multiply Instructions
 
 OP-V (0x57)
-*Zvbb*, *Zvkb*, and *Zvbc* Vector instructions *in bold*
+ext:zvbb[], ext:zvkb[], and ext:zvbc[] Vector instructions *in bold*
 //[%auto-width]
 [%autowidth,cols="4,1,1,1,8,4,1,1,8,4,1,1,8"]
 |===


### PR DESCRIPTION
With this change, we have converted the most of Volume I (except `qty`).

Note that this addresses the none of <https://github.com/riscv/riscv-isa-manual/issues/3107>, <https://github.com/riscv/riscv-isa-manual/issues/3108>, <https://github.com/riscv/riscv-isa-manual/issues/3109>, <https://github.com/riscv/riscv-isa-manual/issues/3110>, <https://github.com/riscv/riscv-isa-manual/issues/3111> and <https://github.com/riscv/riscv-isa-manual/issues/3112>.