### PR TITLE
accessibility: add SVG metadata and alt text to wavedrom diagrams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,15 @@ WORKDIR_SETUP = \
 WORKDIR_TEARDOWN = \
     mv $@.workdir/$@ $@ && \
     mkdir -p $(BUILD_DIR)/unpriv/images && \
-    find $@.workdir -name '*.svg' -exec cp {} $(BUILD_DIR)/unpriv/images/ \; && \
+    if [ "$(suffix $@)" = ".html" ]; then \
+        mkdir -p $(BUILD_DIR)/priv/images && \
+        grep -o 'src="priv/images/[^"]*\.svg"' $@ | sed 's/src="priv\/images\///;s/"//' | sort -u | \
+            while read f; do [ -f "$@.workdir/build/images-out/$$f" ] && cp "$@.workdir/build/images-out/$$f" $(BUILD_DIR)/priv/images/; done; \
+        grep -o 'src="unpriv/images/[^"]*\.svg"' $@ | sed 's/src="unpriv\/images\///;s/"//' | sort -u | \
+            while read f; do [ -f "$@.workdir/build/images-out/$$f" ] && cp "$@.workdir/build/images-out/$$f" $(BUILD_DIR)/unpriv/images/; done; \
+    else \
+        find $@.workdir -name '*.svg' -exec cp {} $(BUILD_DIR)/unpriv/images/ \; ; \
+    fi && \
     rm -rf $@.workdir
 endif
 
@@ -201,6 +209,7 @@ $(BUILD_DIR)/%.html: $(SRC_DIR)/%.adoc $(ALL_SRCS)
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_HTML) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
+	python3 post_process_html.py $@
 	@printf '\n  Built \033]8;;file://%s\033\\%s\033]8;;\033\\\n\n' "$(abspath $@)" "$@"
 
 $(BUILD_DIR)/%.epub: $(SRC_DIR)/%.adoc $(ALL_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ WORKDIR_SETUP = \
 
 WORKDIR_TEARDOWN = \
     mv $@.workdir/$@ $@ && \
+    mkdir -p $(BUILD_DIR)/unpriv/images && \
+    find $@.workdir -name '*.svg' -exec cp {} $(BUILD_DIR)/unpriv/images/ \; && \
     rm -rf $@.workdir
 endif
 

--- a/post_process_html.py
+++ b/post_process_html.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import re, sys
+from pathlib import Path
+
+def process_html(html_path):
+    content = Path(html_path).read_text(encoding='utf-8')
+
+    pattern = re.compile(
+        r'<img([^>]*?)alt="([^"]*)"([^>]*?)>',
+        re.IGNORECASE | re.DOTALL
+    )
+
+    count = 0
+    def replace_match(m):
+        nonlocal count
+        before = m.group(1)
+        alt = m.group(2)
+        after = m.group(3)
+
+        if '.svg' not in (before + after):
+            return m.group(0)
+
+        if alt == "Diagram" or alt == "":
+            alt = "Instruction encoding diagram"
+
+        count += 1
+        # Wrap in figure with visible caption
+        return f'<figure><img{before}alt="{alt}"{after}><figcaption style="clip:rect(0 0 0 0);clip-path:inset(50%);height:1px;overflow:hidden;position:absolute;white-space:nowrap;width:1px">{alt}</figcaption></figure>'
+
+    new_content = pattern.sub(replace_match, content)
+    Path(html_path).write_text(new_content, encoding='utf-8')
+    print(f"Fixed {count} diagrams in {html_path}")
+
+if __name__ == '__main__':
+    process_html(sys.argv[1])

--- a/post_process_html.py.save
+++ b/post_process_html.py.save
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+post_process_html.py — Replace base64-encoded SVG <img> tags with accessible inline <svg>
+Usage: python post_process_html.py build/riscv-spec.html
+"""
+import re, base64, sys
+from pathlib import Path
+
+def inject_a11y(svg_text, alt):
+    title = alt if alt and alt != "Diagram" else "Instruction encoding diagram"
+    
+    # Add role and aria-label to outer svg tag
+    svg_text = svg_text.replace('<svg ', f'<svg role="img" aria-label="{title}" ', 1)
+    
+    # Build hidden text + title + wrap inner content
+    hidden_text = f'<text x="0" y="0" style="position:absolute;width:1px;height:1px;overflow:hidden;opacity:0;font-size:1px">{title}</text>'
+    
+    def wrap_contents(m):
+        opening_tag = m.group(1)
+        rest = m.group(2)
+        return f'{opening_tag}<title>{title}</title>{hidden_text}<g aria-hidden="true">{rest}'
+    
+    svg_text = re.sub(r'(<svg[^>]*>)(.*?)(</svg>)', wrap_contents, svg_text, count=1, flags=re.DOTALL)
+    svg_text = svg_text.replace('</svg>', '</g></svg>', 1)
+    
+    return svg_text
+
+def process_html(html_path):
+    content = Path(html_path).read_text(encoding='utf-8')
+
+    pattern = re.compile(
+        r'<img\s+src="data:image/svg\+xml;base64,([^"]+)"\s+alt="([^"]*)"([^>]*)>',
+        re.IGNORECASE
+    )
+
+    def replace_match(m):
+        b64_data, alt, extra_attrs = m.group(1), m.group(2), m.group(3)
+        try:
+            svg_text = base64.b64decode(b64_data).decode('utf-8')
+            svg_text = inject_a11y(svg_text, alt)
+            svg_text = re.sub(r'<\?xml[^?]*\?>', '', svg_text).strip()
+            return svg_text
+        except Exception as e:
+            print(f"  WARNING: Could not process diagram (alt='{alt}'): {e}")
+            return m.group(0)
+
+    new_content, count = pattern.subn(replace_match, content)
+    Path(html_path).write_text(new_content, encoding='utf-8')
+    print(f"Processed {count} diagrams in {html_path}")
+
+if __name__ == '__main__':
+    process_html(sys.argv[1])
+    
+exit
+^X
+
+
+
+

--- a/src/priv/images/bytefield/counteren.edn
+++ b/src/priv/images/bytefield/counteren.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="COUNTEREN register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 45)

--- a/src/priv/images/bytefield/counterinh.edn
+++ b/src/priv/images/bytefield/counterinh.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="COUNTERINH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 45)

--- a/src/priv/images/bytefield/cust-sys-instr.edn
+++ b/src/priv/images/bytefield/cust-sys-instr.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="CUST SYS INSTR register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/epcreg.edn
+++ b/src/priv/images/bytefield/epcreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="EPC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hcounterenreg.edn
+++ b/src/priv/images/bytefield/hcounterenreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HCOUNTEREN register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hedelegreg.edn
+++ b/src/priv/images/bytefield/hedelegreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HEDELEG register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hgeiereg.edn
+++ b/src/priv/images/bytefield/hgeiereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HGEIE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hgeipreg.edn
+++ b/src/priv/images/bytefield/hgeipreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HGEIP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hidelegreg.edn
+++ b/src/priv/images/bytefield/hidelegreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HIDELEG register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hiereg-standard.edn
+++ b/src/priv/images/bytefield/hiereg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HIEREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hiereg.edn
+++ b/src/priv/images/bytefield/hiereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HIE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hipreg-standard.edn
+++ b/src/priv/images/bytefield/hipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hipreg.edn
+++ b/src/priv/images/bytefield/hipreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HIP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hpmevents.edn
+++ b/src/priv/images/bytefield/hpmevents.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HPMEVENTS register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40)

--- a/src/priv/images/bytefield/htimedelta.edn
+++ b/src/priv/images/bytefield/htimedelta.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HTIMEDELTA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/htinstreg.edn
+++ b/src/priv/images/bytefield/htinstreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HTINST register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/htvalreg.edn
+++ b/src/priv/images/bytefield/htvalreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HTVAL register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hvipreg-standard.edn
+++ b/src/priv/images/bytefield/hvipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HVIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hvipreg.edn
+++ b/src/priv/images/bytefield/hvipreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HVIP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hypv-miereg-standard.edn
+++ b/src/priv/images/bytefield/hypv-miereg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HYPV MIEREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hypv-mipreg-standard.edn
+++ b/src/priv/images/bytefield/hypv-mipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HYPV MIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hypv-mstatus.edn
+++ b/src/priv/images/bytefield/hypv-mstatus.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HYPV MSTATUS register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/hypv-mstatush.edn
+++ b/src/priv/images/bytefield/hypv-mstatush.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="HYPV MSTATUSH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/marchid.edn
+++ b/src/priv/images/bytefield/marchid.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MARCHID register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/mcausereg.edn
+++ b/src/priv/images/bytefield/mcausereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MCAUSE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mconfigptrreg.edn
+++ b/src/priv/images/bytefield/mconfigptrreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MCONFIGPTR register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/medeleg.edn
+++ b/src/priv/images/bytefield/medeleg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MEDELEG register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 35)

--- a/src/priv/images/bytefield/mepcreg.edn
+++ b/src/priv/images/bytefield/mepcreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MEPC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mhartid.edn
+++ b/src/priv/images/bytefield/mhartid.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MHARTID register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/mideleg.edn
+++ b/src/priv/images/bytefield/mideleg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MIDELEG register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mie.edn
+++ b/src/priv/images/bytefield/mie.edn
@@ -1,0 +1,17 @@
+[bytefield, ,svg, alt="MIE register field layout"]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
+(def row-height 40 )
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+
+(draw-box "MXLEN-1" {:span 16 :text-anchor "start" :borders {}})
+(draw-box "0" {:span 16 :text-anchor "end" :borders {}})
+
+(draw-box "Interrupts" {:font-size 18 :span 17 :text-anchor "end" :borders {:top :border-unrelated :bottom :border-unrelated :left :border-unrelated}})
+(draw-box (text "(WARL)" {:font-weight "bold"}) {:font-size 18 :span 15 :text-anchor "start" :borders {:top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+
+(draw-box "MXLEN" {:font-size 24 :span 32 :borders {}})
+----

--- a/src/priv/images/bytefield/miereg-standard.edn
+++ b/src/priv/images/bytefield/miereg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MIEREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 12}])
 (def row-height 30 )

--- a/src/priv/images/bytefield/mimpid.edn
+++ b/src/priv/images/bytefield/mimpid.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MIMPID register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/mip.edn
+++ b/src/priv/images/bytefield/mip.edn
@@ -1,0 +1,17 @@
+[bytefield, ,svg, alt="MIP register field layout"]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
+(def row-height 40 )
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+
+(draw-box "MXLEN-1" {:span 16 :text-anchor "start" :borders {}})
+(draw-box "0" {:span 16 :text-anchor "end" :borders {}})
+
+(draw-box "Interrupts" {:font-size 18 :span 17 :text-anchor "end" :borders {:top :border-unrelated :bottom :border-unrelated :left :border-unrelated}})
+(draw-box (text "(WARL)" {:font-weight "bold"}) {:font-size 18 :span 15 :text-anchor "start" :borders {:top :border-unrelated :bottom :border-unrelated :right :border-unrelated}})
+
+(draw-box "MXLEN" {:font-size 24 :span 32 :borders {}})
+----

--- a/src/priv/images/bytefield/mipreg-standard.edn
+++ b/src/priv/images/bytefield/mipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 12}])
 (def row-height 30 )

--- a/src/priv/images/bytefield/misareg.edn
+++ b/src/priv/images/bytefield/misareg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MISA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])
 (def row-height 30 )

--- a/src/priv/images/bytefield/mncause.edn
+++ b/src/priv/images/bytefield/mncause.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MNCAUSE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mnepc.edn
+++ b/src/priv/images/bytefield/mnepc.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MNEPC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mnscratch.edn
+++ b/src/priv/images/bytefield/mnscratch.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MNSCRATCH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mnstatus.edn
+++ b/src/priv/images/bytefield/mnstatus.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MNSTATUS register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mscratch.edn
+++ b/src/priv/images/bytefield/mscratch.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MSCRATCH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtime.edn
+++ b/src/priv/images/bytefield/mtime.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTIME register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtimecmp.edn
+++ b/src/priv/images/bytefield/mtimecmp.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTIMECMP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtinstreg.edn
+++ b/src/priv/images/bytefield/mtinstreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTINST register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtval2reg.edn
+++ b/src/priv/images/bytefield/mtval2reg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTVAL2 register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtvalreg.edn
+++ b/src/priv/images/bytefield/mtvalreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTVAL register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/mtvec.edn
+++ b/src/priv/images/bytefield/mtvec.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MTVEC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/mvendorid.edn
+++ b/src/priv/images/bytefield/mvendorid.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="MVENDORID register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-height 35 )

--- a/src/priv/images/bytefield/pmp-rv32.edn
+++ b/src/priv/images/bytefield/pmp-rv32.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PMP RV32 register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (def row-header-fn nil)

--- a/src/priv/images/bytefield/pmp-rv64.edn
+++ b/src/priv/images/bytefield/pmp-rv64.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PMP RV64 register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 22}])
 (def row-header-fn nil)

--- a/src/priv/images/bytefield/pmpaddr-rv32.edn
+++ b/src/priv/images/bytefield/pmpaddr-rv32.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PMPADDR RV32 register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/pmpaddr-rv64.edn
+++ b/src/priv/images/bytefield/pmpaddr-rv64.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PMPADDR RV64 register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 50 )

--- a/src/priv/images/bytefield/pmpcfg.edn
+++ b/src/priv/images/bytefield/pmpcfg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PMPCFG register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/priv-instr-set.edn
+++ b/src/priv/images/bytefield/priv-instr-set.edn
@@ -1,4 +1,5 @@
-[bytefield, ,svg, alt="PRIV INSTR SET register field layout"]
+// a11y-desc: Privileged instruction encodings by category: trap-return (SRET, MRET, MNRET), interrupt management (WFI), control transfer records (SCTRCLR), supervisor memory management (SFENCE.VMA), hypervisor memory management (HFENCE.VVMA, HFENCE.GVMA), hypervisor virtual-machine load/store (HLV/HSV variants), and Svinval memory-management extension (SINVAL.VMA, SFENCE.W.INVAL, SFENCE.INVAL.IR, HINVAL.VVMA, HINVAL.GVMA)
+[bytefield, ,svg, alt="Privileged Instruction Encodings"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40)

--- a/src/priv/images/bytefield/priv-instr-set.edn
+++ b/src/priv/images/bytefield/priv-instr-set.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="PRIV INSTR SET register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40)

--- a/src/priv/images/bytefield/rv32hgatp.edn
+++ b/src/priv/images/bytefield/rv32hgatp.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV32HGATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/rv32satp.edn
+++ b/src/priv/images/bytefield/rv32satp.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV32SATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/rv32vsatpreg.edn
+++ b/src/priv/images/bytefield/rv32vsatpreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV32VSATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/rv64hgatp.edn
+++ b/src/priv/images/bytefield/rv64hgatp.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV64HGATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/rv64satp.edn
+++ b/src/priv/images/bytefield/rv64satp.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV64SATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/rv64vsatpreg.edn
+++ b/src/priv/images/bytefield/rv64vsatpreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="RV64VSATP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/scausereg.edn
+++ b/src/priv/images/bytefield/scausereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SCAUSE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/scounteren.edn
+++ b/src/priv/images/bytefield/scounteren.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SCOUNTEREN register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sie.edn
+++ b/src/priv/images/bytefield/sie.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SIE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/siereg-standard.edn
+++ b/src/priv/images/bytefield/siereg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SIEREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sip.edn
+++ b/src/priv/images/bytefield/sip.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SIP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sipreg-standard.edn
+++ b/src/priv/images/bytefield/sipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sscratch.edn
+++ b/src/priv/images/bytefield/sscratch.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SSCRATCH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/stvalreg.edn
+++ b/src/priv/images/bytefield/stvalreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="STVAL register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/stvec.edn
+++ b/src/priv/images/bytefield/stvec.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="STVEC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv32pa.edn
+++ b/src/priv/images/bytefield/sv32pa.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV32PA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv32pte.edn
+++ b/src/priv/images/bytefield/sv32pte.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV32PTE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv32va.edn
+++ b/src/priv/images/bytefield/sv32va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV32VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv32x4va.edn
+++ b/src/priv/images/bytefield/sv32x4va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV32X4VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv39pa.edn
+++ b/src/priv/images/bytefield/sv39pa.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV39PA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv39pte.edn
+++ b/src/priv/images/bytefield/sv39pte.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV39PTE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv39va.edn
+++ b/src/priv/images/bytefield/sv39va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV39VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv39x4va.edn
+++ b/src/priv/images/bytefield/sv39x4va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV39X4VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv48pa.edn
+++ b/src/priv/images/bytefield/sv48pa.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV48PA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv48pte.edn
+++ b/src/priv/images/bytefield/sv48pte.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV48PTE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv48va.edn
+++ b/src/priv/images/bytefield/sv48va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV48VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv48x4va.edn
+++ b/src/priv/images/bytefield/sv48x4va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV48X4VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv57pa.edn
+++ b/src/priv/images/bytefield/sv57pa.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV57PA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv57pte.edn
+++ b/src/priv/images/bytefield/sv57pte.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV57PTE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv57va.edn
+++ b/src/priv/images/bytefield/sv57va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV57VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/sv57x4va.edn
+++ b/src/priv/images/bytefield/sv57x4va.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="SV57X4VA register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vscausereg.edn
+++ b/src/priv/images/bytefield/vscausereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSCAUSE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsepcreg.edn
+++ b/src/priv/images/bytefield/vsepcreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSEPC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsiereg-standard.edn
+++ b/src/priv/images/bytefield/vsiereg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSIEREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsiereg.edn
+++ b/src/priv/images/bytefield/vsiereg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSIE register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsipreg-standard.edn
+++ b/src/priv/images/bytefield/vsipreg-standard.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSIPREG STANDARD register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsipreg.edn
+++ b/src/priv/images/bytefield/vsipreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSIP register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vsscratchreg.edn
+++ b/src/priv/images/bytefield/vsscratchreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSSCRATCH register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vstvalreg.edn
+++ b/src/priv/images/bytefield/vstvalreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSTVAL register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/bytefield/vstvecreg.edn
+++ b/src/priv/images/bytefield/vstvecreg.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="VSTVEC register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
 (def row-height 40 )

--- a/src/priv/images/wavedrom/hinvalgvma.edn
+++ b/src/priv/images/wavedrom/hinvalgvma.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="HINVALGVMA instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/hinvalvvma.edn
+++ b/src/priv/images/wavedrom/hinvalvvma.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="HINVALVVMA instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/hypv-mm-fence.edn
+++ b/src/priv/images/wavedrom/hypv-mm-fence.edn
@@ -1,6 +1,6 @@
 //hypv-mm-fence.edn
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="HYPV MM FENCE instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7', 'SYSTEM', 'SYSTEM']},

--- a/src/priv/images/wavedrom/hypv-virt-load-and-store.edn
+++ b/src/priv/images/wavedrom/hypv-virt-load-and-store.edn
@@ -1,6 +1,6 @@
 //hypv-virt-load-and-store.edn
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="HYPV VIRT LOAD AND STORE instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','SYSTEM', 'SYSTEM', 'SYSTEM']},

--- a/src/priv/images/wavedrom/menvcfgreg.edn
+++ b/src/priv/images/wavedrom/menvcfgreg.edn
@@ -1,5 +1,5 @@
 //.Machine environment configuration (`menvcfg`) register.
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MENVCFGREG instruction encoding"]
 ....
 {reg: [
   {bits:  1, name: 'FIOM'},

--- a/src/priv/images/wavedrom/mm-env-call.edn
+++ b/src/priv/images/wavedrom/mm-env-call.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MM ENV CALL instruction encoding"]
 
 ....
 {reg: [

--- a/src/priv/images/wavedrom/mseccfg.edn
+++ b/src/priv/images/wavedrom/mseccfg.edn
@@ -1,5 +1,5 @@
 //.Machine security configuration (`mseccfg`) register.
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MSECCFG instruction encoding"]
 ....
 {reg: [
   {bits:  1, name: 'MML'},

--- a/src/priv/images/wavedrom/mstatushreg.edn
+++ b/src/priv/images/wavedrom/mstatushreg.edn
@@ -1,5 +1,5 @@
 //.Additional machine-mode status (`mstatush`) register  for RV32.
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MSTATUSHREG instruction encoding"]
 ....
 {reg: [
   {bits:  4, name: 'WPRI'},

--- a/src/priv/images/wavedrom/mstatusreg-rv321.edn
+++ b/src/priv/images/wavedrom/mstatusreg-rv321.edn
@@ -1,5 +1,5 @@
 //.Machine-mode status (`mstatus`) register for RV32
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MSTATUSREG RV321 instruction encoding"]
 ....
 {reg: [
   {bits:  1, name: 'WPRI'},

--- a/src/priv/images/wavedrom/mstatusreg.edn
+++ b/src/priv/images/wavedrom/mstatusreg.edn
@@ -1,5 +1,5 @@
 //.Machine-mode status (`mstatus`) register for RV64
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MSTATUSREG instruction encoding"]
 ....
 {reg: [
   {bits:  1, name: 'WPRI'},

--- a/src/priv/images/wavedrom/sfenceinvalir.edn
+++ b/src/priv/images/wavedrom/sfenceinvalir.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SFENCEINVALIR instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/sfencevma.edn
+++ b/src/priv/images/wavedrom/sfencevma.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SFENCEVMA instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/sfencewinval.edn
+++ b/src/priv/images/wavedrom/sfencewinval.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SFENCEWINVAL instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/sinvalvma.edn
+++ b/src/priv/images/wavedrom/sinvalvma.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SINVALVMA instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM']},

--- a/src/priv/images/wavedrom/transformedatomicinst.edn
+++ b/src/priv/images/wavedrom/transformedatomicinst.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="TRANSFORMEDATOMICINST instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7']},

--- a/src/priv/images/wavedrom/transformedloadinst.edn
+++ b/src/priv/images/wavedrom/transformedloadinst.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="TRANSFORMEDLOADINST instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7']},

--- a/src/priv/images/wavedrom/transformedstoreinst.edn
+++ b/src/priv/images/wavedrom/transformedstoreinst.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="TRANSFORMEDSTOREINST instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7']},

--- a/src/priv/images/wavedrom/transformedvmaccessinst.edn
+++ b/src/priv/images/wavedrom/transformedvmaccessinst.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="TRANSFORMEDVMACCESSINST instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7']},

--- a/src/priv/images/wavedrom/trap-return.edn
+++ b/src/priv/images/wavedrom/trap-return.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="TRAP RETURN instruction encoding"]
 
 ....
 {reg: [

--- a/src/priv/images/wavedrom/wfi.edn
+++ b/src/priv/images/wavedrom/wfi.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="WFI instruction encoding"]
 
 ....
 {reg: [

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1347,11 +1347,11 @@ at the platform's discretion.
 
 [[norm:mip_enc_img]]
 .Machine Interrupt-Pending (`mip`) register.
-include::images/bytefield/mideleg.edn[]
+include::images/bytefield/mip.edn[]
 
 [[norm:mie_enc_img]]
 .Machine Interrupt-Enable (`mie`) register
-include::images/bytefield/mideleg.edn[]
+include::images/bytefield/mie.edn[]
 
 [#norm:intr_mip_mie_op]#An interrupt _i_ will trap to M-mode (causing the privilege mode to
 change to M-mode) if all of the following are true: (a) either the

--- a/src/riscv-spec.adoc
+++ b/src/riscv-spec.adoc
@@ -35,7 +35,9 @@ endif::[]
 :chapter-refsig: Chapter
 :section-refsig: Section
 :appendix-refsig: Appendix
+ifdef::backend-pdf[]
 :data-uri:
+endif::[]
 :hide-uri-scheme:
 :footnote:
 :imagesdir: images

--- a/src/unpriv/images/bytefield/fprs.edn
+++ b/src/unpriv/images/bytefield/fprs.edn
@@ -1,3 +1,4 @@
+// a11y-desc: Floating-point registers f0-f31 each FLEN bits wide, and fcsr control register 32 bits wide
 [bytefield]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])

--- a/src/unpriv/images/bytefield/fprs.edn
+++ b/src/unpriv/images/bytefield/fprs.edn
@@ -1,5 +1,5 @@
 // a11y-desc: Floating-point registers f0-f31 each FLEN bits wide, and fcsr control register 32 bits wide
-[bytefield]
+[bytefield, ,svg, alt="FPRS register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])
 (def row-height 30)

--- a/src/unpriv/images/bytefield/gprs.edn
+++ b/src/unpriv/images/bytefield/gprs.edn
@@ -1,4 +1,4 @@
-[bytefield]
+[bytefield, ,svg, alt="GPRS register field layout"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 16}])
 (def row-height 30)

--- a/src/unpriv/images/bytefield/rvc-instr-quad0.edn
+++ b/src/unpriv/images/bytefield/rvc-instr-quad0.edn
@@ -1,4 +1,5 @@
-[bytefield]
+// a11y-desc: Compressed instruction quadrant 0 encodings: C.ADDI4SPN, C.FLD, C.LW, C.FLW, C.LD, C.FSD, C.SW, C.FSW, C.SD
+[bytefield, ,svg, alt="RVC Instruction Quadrant 0 Encodings"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (defattrs :math [:math {:font-family "M+ 1p Fallback"}])

--- a/src/unpriv/images/bytefield/rvc-instr-quad1.edn
+++ b/src/unpriv/images/bytefield/rvc-instr-quad1.edn
@@ -1,4 +1,5 @@
-[bytefield]
+// a11y-desc: Compressed instruction quadrant 1 encodings: C.NOP, C.ADDI, C.JAL, C.ADDIW, C.LI, C.ADDI16SP, C.LUI, C.SRLI, C.SRAI, C.ANDI, C.SUB, C.XOR, C.OR, C.AND, C.SUBW, C.ADDW, C.J, C.BEQZ, C.BNEZ
+[bytefield, ,svg, alt="RVC Instruction Quadrant 1 Encodings"]
 ----
 (defattrs :plain [:plain {:font-weight "bold" :font-family "M+ 1p Fallback"}])
 (defattrs :math [:math {:font-family "M+ 1p Fallback"}])

--- a/src/unpriv/images/bytefield/rvc-instr-quad2.edn
+++ b/src/unpriv/images/bytefield/rvc-instr-quad2.edn
@@ -1,4 +1,5 @@
-[bytefield]
+// a11y-desc: Compressed instruction quadrant 2 encodings: C.SLLI, C.FLDSP, C.LWSP, C.FLWSP, C.LDSP, C.JR, C.MV, C.EBREAK, C.JALR, C.ADD, C.FSDSP, C.SWSP, C.FSWSP, C.SDSP
+[bytefield, ,svg, alt="RVC Instruction Quadrant 2 Encodings"]
 ----
 (defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
 (defattrs :math [:math {:font-family "M+ 1p Fallback"}])

--- a/src/unpriv/images/wavedrom/atomic-mem.edn
+++ b/src/unpriv/images/wavedrom/atomic-mem.edn
@@ -1,6 +1,6 @@
 //## 9.4 Atomic Memory Operations
 
-[wavedrom, ,svg]
+[wavedrom, 9.4 Atomic Memory Operations, svg]
 ....
 {reg: [
   {bits: 7, name: 'opcode',     attr: ['7','AMO','AMO','AMO','AMO','AMO','AMO','AMO']},

--- a/src/unpriv/images/wavedrom/atomic-mem.edn
+++ b/src/unpriv/images/wavedrom/atomic-mem.edn
@@ -1,6 +1,6 @@
 //## 9.4 Atomic Memory Operations
 
-[wavedrom, 9.4 Atomic Memory Operations, svg]
+[wavedrom, ,svg, alt="9.4 Atomic Memory Operations"]
 ....
 {reg: [
   {bits: 7, name: 'opcode',     attr: ['7','AMO','AMO','AMO','AMO','AMO','AMO','AMO']},

--- a/src/unpriv/images/wavedrom/b-immediate.edn
+++ b/src/unpriv/images/wavedrom/b-immediate.edn
@@ -1,6 +1,6 @@
 //#### B-immediate
 
-[wavedrom, ,svg]
+[wavedrom, B-immediate instruction encoding, svg]
 ....
 {reg: [
   {bits: 1,  name: '0'},

--- a/src/unpriv/images/wavedrom/b-immediate.edn
+++ b/src/unpriv/images/wavedrom/b-immediate.edn
@@ -1,6 +1,6 @@
 //#### B-immediate
 
-[wavedrom, B-immediate instruction encoding, svg]
+[wavedrom, ,svg, alt="B-immediate instruction encoding"]
 ....
 {reg: [
   {bits: 1,  name: '0'},

--- a/src/unpriv/images/wavedrom/c-andi.edn
+++ b/src/unpriv/images/wavedrom/c-andi.edn
@@ -1,6 +1,6 @@
 //c-andi.adoc
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C ANDI instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op',    attr: ['2','C1'],},

--- a/src/unpriv/images/wavedrom/c-breakpoint-instr.edn
+++ b/src/unpriv/images/wavedrom/c-breakpoint-instr.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, C BREAKPOINT INSTR instruction encoding, svg]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-breakpoint-instr.edn
+++ b/src/unpriv/images/wavedrom/c-breakpoint-instr.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, C BREAKPOINT INSTR instruction encoding, svg]
+[wavedrom, ,svg, alt="C BREAKPOINT INSTR instruction encoding"]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-cb-format-ls.edn
+++ b/src/unpriv/images/wavedrom/c-cb-format-ls.edn
@@ -1,6 +1,6 @@
 //c-cb-format-ls
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C CB FORMAT LS instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C1', 'C1']},

--- a/src/unpriv/images/wavedrom/c-ci.edn
+++ b/src/unpriv/images/wavedrom/c-ci.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C CI instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2', 'C2']},

--- a/src/unpriv/images/wavedrom/c-ciw.edn
+++ b/src/unpriv/images/wavedrom/c-ciw.edn
@@ -1,6 +1,6 @@
 //c-ciw.adoc
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C CIW instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C0'],},

--- a/src/unpriv/images/wavedrom/c-cj-format-ls.edn
+++ b/src/unpriv/images/wavedrom/c-cj-format-ls.edn
@@ -10,7 +10,7 @@
 //....
 
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C CJ FORMAT LS instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op',     attr: ['2','C1','C1']},

--- a/src/unpriv/images/wavedrom/c-cr-format-ls.edn
+++ b/src/unpriv/images/wavedrom/c-cr-format-ls.edn
@@ -1,6 +1,6 @@
 //These instructions use the CR format.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C CR FORMAT LS instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C2', 'C2']},

--- a/src/unpriv/images/wavedrom/c-cs-format-ls.edn
+++ b/src/unpriv/images/wavedrom/c-cs-format-ls.edn
@@ -1,7 +1,7 @@
 //## 16.X Load and Store Instructions
 //### c-cs-format-ls
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="16.X Load and Store Instructions"]
 ....
 {reg: [
   {bits: 2, name: 'op',     attr: ['2', 'C0','C0','C0','C0']},

--- a/src/unpriv/images/wavedrom/c-def-illegal-inst.edn
+++ b/src/unpriv/images/wavedrom/c-def-illegal-inst.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C DEF ILLEGAL INST instruction encoding"]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-int-reg-immed.edn
+++ b/src/unpriv/images/wavedrom/c-int-reg-immed.edn
@@ -1,6 +1,6 @@
 //c-int-reg-immed.adoc
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C INT REG IMMED instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op',        attr: ['2','C1', 'C1', 'C1']},

--- a/src/unpriv/images/wavedrom/c-int-reg-to-reg-ca-format.edn
+++ b/src/unpriv/images/wavedrom/c-int-reg-to-reg-ca-format.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C INT REG TO REG CA FORMAT instruction encoding"]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-int-reg-to-reg-cr-format.edn
+++ b/src/unpriv/images/wavedrom/c-int-reg-to-reg-cr-format.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C INT REG TO REG CR FORMAT instruction encoding"]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-integer-const-gen.edn
+++ b/src/unpriv/images/wavedrom/c-integer-const-gen.edn
@@ -1,6 +1,6 @@
 //c-integer-const-gen
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C INTEGER CONST GEN instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C1', 'C1']},

--- a/src/unpriv/images/wavedrom/c-mop.edn
+++ b/src/unpriv/images/wavedrom/c-mop.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C MOP instruction encoding"]
 ....
 {reg:[
     { bits:  2, name: 0x1 },

--- a/src/unpriv/images/wavedrom/c-nop-instr.edn
+++ b/src/unpriv/images/wavedrom/c-nop-instr.edn
@@ -1,6 +1,6 @@
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C NOP INSTR instruction encoding"]
 
 ....
 {reg: [

--- a/src/unpriv/images/wavedrom/c-sp-load-store-css.edn
+++ b/src/unpriv/images/wavedrom/c-sp-load-store-css.edn
@@ -1,6 +1,6 @@
 //c-sp load and store, css format--is this correct?
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C SP LOAD STORE CSS instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op',     attr: ['2','C2','C2','C2','C2']},

--- a/src/unpriv/images/wavedrom/c-sp-load-store.edn
+++ b/src/unpriv/images/wavedrom/c-sp-load-store.edn
@@ -1,7 +1,7 @@
 //## 16.3 Load and Store Instructions
 //### Stack-Pointer-Based Loads and Stores
 
-[wavedrom, ,svg, alt="16.3 Load and Store Instructions"]
+[wavedrom, ,svg, alt="Stack-Pointer-Based Loads and Stores"]
 ....
 {reg: [
   {bits: 2, name: 'op',     attr: ['2','C2','C2','C2','C2']},

--- a/src/unpriv/images/wavedrom/c-sp-load-store.edn
+++ b/src/unpriv/images/wavedrom/c-sp-load-store.edn
@@ -1,7 +1,7 @@
 //## 16.3 Load and Store Instructions
 //### Stack-Pointer-Based Loads and Stores
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="16.3 Load and Store Instructions"]
 ....
 {reg: [
   {bits: 2, name: 'op',     attr: ['2','C2','C2','C2','C2']},

--- a/src/unpriv/images/wavedrom/c-srli-srai.edn
+++ b/src/unpriv/images/wavedrom/c-srli-srai.edn
@@ -1,6 +1,6 @@
 //c-srli-srai.adoc
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="C SRLI SRAI instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2','C1', 'C1'],},

--- a/src/unpriv/images/wavedrom/counters-diag.edn
+++ b/src/unpriv/images/wavedrom/counters-diag.edn
@@ -1,7 +1,7 @@
 //# 11 Counters
 //## 11.1 Base Counters and Timers
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="11 Counters"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7','SYSTEM','SYSTEM','SYSTEM']},

--- a/src/unpriv/images/wavedrom/counters-diag.edn
+++ b/src/unpriv/images/wavedrom/counters-diag.edn
@@ -1,7 +1,7 @@
 //# 11 Counters
 //## 11.1 Base Counters and Timers
 
-[wavedrom, ,svg, alt="11 Counters"]
+[wavedrom, ,svg, alt="11.1 Base Counters and Timers"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7','SYSTEM','SYSTEM','SYSTEM']},

--- a/src/unpriv/images/wavedrom/csr-instr.edn
+++ b/src/unpriv/images/wavedrom/csr-instr.edn
@@ -1,7 +1,7 @@
 //# 10 "Zicsr", Control and Status Register (CSR) Instructions, Version 2.0
 //## 10.1 CSR Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="10 "Zicsr", Control and Status Register (CSR) Instructions, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM'] },

--- a/src/unpriv/images/wavedrom/csr-instr.edn
+++ b/src/unpriv/images/wavedrom/csr-instr.edn
@@ -1,7 +1,7 @@
 //# 10 "Zicsr", Control and Status Register (CSR) Instructions, Version 2.0
 //## 10.1 CSR Instructions
 
-[wavedrom, ,svg, alt="10.1 CSR Instructions"Zicsr", Control and Status Register (CSR) Instructions, Version 2.0"]
+[wavedrom, ,svg, alt="10.1 CSR Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM'] },

--- a/src/unpriv/images/wavedrom/csr-instr.edn
+++ b/src/unpriv/images/wavedrom/csr-instr.edn
@@ -1,7 +1,7 @@
 //# 10 "Zicsr", Control and Status Register (CSR) Instructions, Version 2.0
 //## 10.1 CSR Instructions
 
-[wavedrom, ,svg, alt="10 "Zicsr", Control and Status Register (CSR) Instructions, Version 2.0"]
+[wavedrom, ,svg, alt="10.1 CSR Instructions"Zicsr", Control and Status Register (CSR) Instructions, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM', 'SYSTEM'] },

--- a/src/unpriv/images/wavedrom/ct-conditional.edn
+++ b/src/unpriv/images/wavedrom/ct-conditional.edn
@@ -1,6 +1,6 @@
 //### Conditional Branches
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="Conditional Branches"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'BRANCH', 'BRANCH', 'BRANCH'] },

--- a/src/unpriv/images/wavedrom/ct-unconditional-2.edn
+++ b/src/unpriv/images/wavedrom/ct-unconditional-2.edn
@@ -1,6 +1,6 @@
 //ct-unconditional-2
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="CT UNCONDITIONAL 2 instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',     attr: ['7', 'JALR'] },

--- a/src/unpriv/images/wavedrom/ct-unconditional.edn
+++ b/src/unpriv/images/wavedrom/ct-unconditional.edn
@@ -1,7 +1,7 @@
 //## 2.5 Control Transfer Instructions
 //### Unconditional Jumps
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="2.5 Control Transfer Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'JAL']},

--- a/src/unpriv/images/wavedrom/ct-unconditional.edn
+++ b/src/unpriv/images/wavedrom/ct-unconditional.edn
@@ -1,7 +1,7 @@
 //## 2.5 Control Transfer Instructions
 //### Unconditional Jumps
 
-[wavedrom, ,svg, alt="2.5 Control Transfer Instructions"]
+[wavedrom, ,svg, alt="Unconditional Jumps"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'JAL']},

--- a/src/unpriv/images/wavedrom/d-xwwx.edn
+++ b/src/unpriv/images/wavedrom/d-xwwx.edn
@@ -1,6 +1,6 @@
 //xw-wx
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="D XWWX instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/division-op.edn
+++ b/src/unpriv/images/wavedrom/division-op.edn
@@ -1,6 +1,6 @@
 //## 8.2 Division Operations
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="8.2 Division Operations"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'OP', 'OP-32']},

--- a/src/unpriv/images/wavedrom/double-fl-class.edn
+++ b/src/unpriv/images/wavedrom/double-fl-class.edn
@@ -1,6 +1,6 @@
 //## 13.7 Double-Precision Floating-Point Classify Instruction
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="13.7 Double-Precision Floating-Point Classify Instruction"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/double-fl-compare.edn
+++ b/src/unpriv/images/wavedrom/double-fl-compare.edn
@@ -1,6 +1,6 @@
 //## 13.6 Double-Precision Floating-Point Compare Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="13.6 Double-Precision Floating-Point Compare Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/double-fl-compute.edn
+++ b/src/unpriv/images/wavedrom/double-fl-compute.edn
@@ -1,6 +1,6 @@
 //## 13.4 Double-Precision Floating-Point Computational Instructions
 
-[wavedrom, ,svg, alt="13.4 Double-Precision Floating-Point Computational Instructions"]
+[wavedrom, ,svg, alt="Double-Precision Floating-Point Arithmetic Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},
@@ -13,7 +13,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="13.4 Double-Precision Floating-Point Computational Instructions"]
+[wavedrom, ,svg, alt="Double-Precision Floating-Point Fused Multiply-Add Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/double-fl-compute.edn
+++ b/src/unpriv/images/wavedrom/double-fl-compute.edn
@@ -1,6 +1,6 @@
 //## 13.4 Double-Precision Floating-Point Computational Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="13.4 Double-Precision Floating-Point Computational Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},
@@ -13,7 +13,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="13.4 Double-Precision Floating-Point Computational Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/double-fl-convert-mv.edn
+++ b/src/unpriv/images/wavedrom/double-fl-convert-mv.edn
@@ -1,7 +1,7 @@
 //## 13.5 Double-Precision Floating-Point Conversion and Move Instructions
 
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="13.5 Double-Precision Floating-Point Conversion and Move Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/double-ls.edn
+++ b/src/unpriv/images/wavedrom/double-ls.edn
@@ -1,7 +1,6 @@
 //# "D" Standard Extension for Double-Precision Floating-Point, Version 2.2
 //## 13.3 Double-Precision Load and Store Instructions
-
-[wavedrom, ,svg, alt="13.3 Double-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Double-Precision Load Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','LOAD-FP']},
@@ -12,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="13.3 Double-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Double-Precision Store Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','STORE-FP']},

--- a/src/unpriv/images/wavedrom/double-ls.edn
+++ b/src/unpriv/images/wavedrom/double-ls.edn
@@ -1,7 +1,7 @@
 //# "D" Standard Extension for Double-Precision Floating-Point, Version 2.2
 //## 13.3 Double-Precision Load and Store Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt=""D" Standard Extension for Double-Precision Floating-Point, Version 2.2"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','LOAD-FP']},
@@ -12,7 +12,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt=""D" Standard Extension for Double-Precision Floating-Point, Version 2.2"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','STORE-FP']},

--- a/src/unpriv/images/wavedrom/double-ls.edn
+++ b/src/unpriv/images/wavedrom/double-ls.edn
@@ -1,7 +1,7 @@
 //# "D" Standard Extension for Double-Precision Floating-Point, Version 2.2
 //## 13.3 Double-Precision Load and Store Instructions
 
-[wavedrom, ,svg, alt=""D" Standard Extension for Double-Precision Floating-Point, Version 2.2"]
+[wavedrom, ,svg, alt="13.3 Double-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','LOAD-FP']},
@@ -12,7 +12,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt=""D" Standard Extension for Double-Precision Floating-Point, Version 2.2"]
+[wavedrom, ,svg, alt="13.3 Double-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','STORE-FP']},

--- a/src/unpriv/images/wavedrom/env-call-breakpoint.edn
+++ b/src/unpriv/images/wavedrom/env-call-breakpoint.edn
@@ -1,6 +1,6 @@
 //## 2.8 Environment Call and Breakpoints
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="2.8 Environment Call and Breakpoints"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'SYSTEM', 'SYSTEM']},

--- a/src/unpriv/images/wavedrom/fcvt-sd-ds.edn
+++ b/src/unpriv/images/wavedrom/fcvt-sd-ds.edn
@@ -1,6 +1,6 @@
 //FCVT.S.D and FCVT.D.S
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="FCVT SD DS instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/float-csr.edn
+++ b/src/unpriv/images/wavedrom/float-csr.edn
@@ -2,7 +2,7 @@
 //## 12.2 Floating-Point Control and Status Register
 //### Figure 12.2: Floating-point control and status register.
 
-[wavedrom, ,svg, alt="Figure 12.2: Floating-point control and status register."F" Standard Extension for Single-Precision Floating-Point, Version 2.2"]
+[wavedrom, ,svg, alt="Figure 12.2: Floating-point control and status register."]
 ....
 {reg: [
   {bits: 1,  name: 'NX', attr: ['1']},

--- a/src/unpriv/images/wavedrom/float-csr.edn
+++ b/src/unpriv/images/wavedrom/float-csr.edn
@@ -2,7 +2,7 @@
 //## 12.2 Floating-Point Control and Status Register
 //### Figure 12.2: Floating-point control and status register.
 
-[wavedrom, ,svg, alt=""F" Standard Extension for Single-Precision Floating-Point, Version 2.2"]
+[wavedrom, ,svg, alt="Figure 12.2: Floating-point control and status register."F" Standard Extension for Single-Precision Floating-Point, Version 2.2"]
 ....
 {reg: [
   {bits: 1,  name: 'NX', attr: ['1']},

--- a/src/unpriv/images/wavedrom/float-csr.edn
+++ b/src/unpriv/images/wavedrom/float-csr.edn
@@ -2,7 +2,7 @@
 //## 12.2 Floating-Point Control and Status Register
 //### Figure 12.2: Floating-point control and status register.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt=""F" Standard Extension for Single-Precision Floating-Point, Version 2.2"]
 ....
 {reg: [
   {bits: 1,  name: 'NX', attr: ['1']},

--- a/src/unpriv/images/wavedrom/flt-pt-to-int-move.edn
+++ b/src/unpriv/images/wavedrom/flt-pt-to-int-move.edn
@@ -1,6 +1,6 @@
 // 16.3 Instructions for moving bit patterns between floating-point and integer registers.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="FLT PT TO INT MOVE instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/flt-to-flt-sgn-inj-instr.edn
+++ b/src/unpriv/images/wavedrom/flt-to-flt-sgn-inj-instr.edn
@@ -1,6 +1,6 @@
 // 16.3 Floating point to floating point sign injection instructions.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="FLT TO FLT SGN INJ INSTR instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/fsjgnjnx-d.edn
+++ b/src/unpriv/images/wavedrom/fsjgnjnx-d.edn
@@ -1,6 +1,6 @@
 //FSGNJ.D, FSGNJN.D, and FSGNJX.D
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="FSJGNJNX D instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/half-pr-flt-pt-class.edn
+++ b/src/unpriv/images/wavedrom/half-pr-flt-pt-class.edn
@@ -1,6 +1,6 @@
 //## 15.5 Half-Precision Floating-Point Classify Instruction
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="15.5 Half-Precision Floating-Point Classify Instruction"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7', 'OP-FP']},

--- a/src/unpriv/images/wavedrom/half-pr-flt-pt-compare.edn
+++ b/src/unpriv/images/wavedrom/half-pr-flt-pt-compare.edn
@@ -1,6 +1,6 @@
 // 16.4 Half-Precision Floating-Point Compare Instructions.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="HALF PR FLT PT COMPARE instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/half-prec-conv-and-mv.edn
+++ b/src/unpriv/images/wavedrom/half-prec-conv-and-mv.edn
@@ -1,7 +1,7 @@
 //## 16.3 Half-Precision Conversion and Move Instructions
 
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="16.3 Half-Precision Conversion and Move Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/half-prec-flpt-to-flpt-conv.edn
+++ b/src/unpriv/images/wavedrom/half-prec-flpt-to-flpt-conv.edn
@@ -1,6 +1,6 @@
 //## 16.3 Half-Precision Floating Point to Floating Point Conversion Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="16.3 Half-Precision Floating Point to Floating Point Conversion Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/i-immediate.edn
+++ b/src/unpriv/images/wavedrom/i-immediate.edn
@@ -2,7 +2,7 @@
 //Types of immediate produced by RISC-V instructions. The fields are labeled with the instruction bits used to construct their value. Sign extension always uses inst[31].
 //#### I-immediate
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="I-immediate instruction encoding"]
 ....
 {reg: [
   {bits: 1,  name: '[20]'},

--- a/src/unpriv/images/wavedrom/immediate-variants.edn
+++ b/src/unpriv/images/wavedrom/immediate-variants.edn
@@ -14,7 +14,7 @@
 ], config: {label: {right: 'R-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="I-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -25,7 +25,7 @@
 ], config: {label: {right: 'I-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="S-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -37,7 +37,7 @@
 ], config: {label: {right: 'S-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="B-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -51,7 +51,7 @@
 ], config: {fontsize: 12, label: {right: 'B-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="U-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -60,7 +60,7 @@
 ], config: {label: {right: 'U-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="J-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},

--- a/src/unpriv/images/wavedrom/immediate-variants.edn
+++ b/src/unpriv/images/wavedrom/immediate-variants.edn
@@ -2,7 +2,7 @@
 //### Figure 2.3
 //RISC-V base instruction formats showing immediate variants.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -14,7 +14,7 @@
 ], config: {label: {right: 'R-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -25,7 +25,7 @@
 ], config: {label: {right: 'I-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -37,7 +37,7 @@
 ], config: {label: {right: 'S-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -51,7 +51,7 @@
 ], config: {fontsize: 12, label: {right: 'B-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -60,7 +60,7 @@
 ], config: {label: {right: 'U-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},

--- a/src/unpriv/images/wavedrom/instruction-formats.edn
+++ b/src/unpriv/images/wavedrom/instruction-formats.edn
@@ -2,7 +2,7 @@
 
 //RISC-V base instruction formats. Each immediate subfield is labeled with the bit position (imm[x]) in the immediate value being produced, rather than the bit position within the instruction’s immediate field as is usually done.
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -14,7 +14,7 @@
 ], config: {label: {right: 'R-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -25,7 +25,7 @@
 ], config: {label: {right: 'I-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -37,7 +37,7 @@
 ], config: {label: {right: 'S-Type'}}}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="R-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},

--- a/src/unpriv/images/wavedrom/instruction-formats.edn
+++ b/src/unpriv/images/wavedrom/instruction-formats.edn
@@ -14,7 +14,7 @@
 ], config: {label: {right: 'R-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="I-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -25,7 +25,7 @@
 ], config: {label: {right: 'I-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="S-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},
@@ -37,7 +37,7 @@
 ], config: {label: {right: 'S-Type'}}}
 ....
 
-[wavedrom, ,svg, alt="R-Type instruction encoding"]
+[wavedrom, ,svg, alt="U-Type instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode'},

--- a/src/unpriv/images/wavedrom/int-comp-lui-aiupc.edn
+++ b/src/unpriv/images/wavedrom/int-comp-lui-aiupc.edn
@@ -2,7 +2,7 @@
 //### Integer Register-Immediate Instructions
 //lui-aiupc-u-immed
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="Integer Register-Immediate Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',     attr: ['7', 'LUI', 'AUIPC']},

--- a/src/unpriv/images/wavedrom/int-comp-slli-srli-srai.edn
+++ b/src/unpriv/images/wavedrom/int-comp-slli-srli-srai.edn
@@ -2,7 +2,7 @@
 //### Integer Register-Immediate Instructions
 //
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="Integer Register-Immediate Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM', 'OP-IMM', 'OP-IMM']},

--- a/src/unpriv/images/wavedrom/int-reg-reg.edn
+++ b/src/unpriv/images/wavedrom/int-reg-reg.edn
@@ -1,6 +1,6 @@
 //### Integer Register-Register Operations
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="Integer Register-Register Operations"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP', 'OP', 'OP', 'OP']},

--- a/src/unpriv/images/wavedrom/integer-computational.edn
+++ b/src/unpriv/images/wavedrom/integer-computational.edn
@@ -1,7 +1,7 @@
 //## 2.4 Integer Computational Instructions
 //### Integer Register-Immediate Instructions
 
-[wavedrom, ,svg, alt="2.4 Integer Computational Instructions"]
+[wavedrom, ,svg, alt="Integer Register-Immediate Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM', 'OP-IMM']},

--- a/src/unpriv/images/wavedrom/integer-computational.edn
+++ b/src/unpriv/images/wavedrom/integer-computational.edn
@@ -1,7 +1,7 @@
 //## 2.4 Integer Computational Instructions
 //### Integer Register-Immediate Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="2.4 Integer Computational Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM', 'OP-IMM']},

--- a/src/unpriv/images/wavedrom/j-immediate.edn
+++ b/src/unpriv/images/wavedrom/j-immediate.edn
@@ -1,6 +1,6 @@
 //#### J-immediate
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="J-immediate instruction encoding"]
 ....
 {reg: [
   {bits: 1,  name: '0'},

--- a/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
+++ b/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
@@ -2,7 +2,7 @@
 //## 9.2 Load-Reserved/Store-Conditional Instructions
 
 
-[wavedrom, ,svg, alt="9 "A" Standard Extension for Atomic Instructions, Version 2.1"]
+[wavedrom, ,svg, alt="9.2 Load-Reserved/Store-Conditional Instructions"A" Standard Extension for Atomic Instructions, Version 2.1"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'AMO', 'AMO']},

--- a/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
+++ b/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
@@ -2,7 +2,7 @@
 //## 9.2 Load-Reserved/Store-Conditional Instructions
 
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="9 "A" Standard Extension for Atomic Instructions, Version 2.1"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'AMO', 'AMO']},

--- a/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
+++ b/src/unpriv/images/wavedrom/load-reserve-st-conditional.edn
@@ -2,7 +2,7 @@
 //## 9.2 Load-Reserved/Store-Conditional Instructions
 
 
-[wavedrom, ,svg, alt="9.2 Load-Reserved/Store-Conditional Instructions"A" Standard Extension for Atomic Instructions, Version 2.1"]
+[wavedrom, ,svg, alt="9.2 Load-Reserved/Store-Conditional Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'AMO', 'AMO']},

--- a/src/unpriv/images/wavedrom/load-store.edn
+++ b/src/unpriv/images/wavedrom/load-store.edn
@@ -1,6 +1,6 @@
 //## 2.6 Load and Store Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="2.6 Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="2.6 Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',   attr: ['7', 'STORE']},

--- a/src/unpriv/images/wavedrom/load-store.edn
+++ b/src/unpriv/images/wavedrom/load-store.edn
@@ -1,6 +1,6 @@
 //## 2.6 Load and Store Instructions
 
-[wavedrom, ,svg, alt="2.6 Load and Store Instructions"]
+[wavedrom, ,svg, alt="Load Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="2.6 Load and Store Instructions"]
+[wavedrom, ,svg, alt="Store Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',   attr: ['7', 'STORE']},

--- a/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
+++ b/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
@@ -1,7 +1,7 @@
 //# 8 "M" Standard Extension for Integer Multiplication and Division, Version 2.0
 //## 8.1 Multiplication Operations
 
-[wavedrom, ,svg, alt="8.1 Multiplication Operations"M" Standard Extension for Integer Multiplication and Division, Version 2.0"]
+[wavedrom, ,svg, alt="8.1 Multiplication Operations"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'OP', 'OP-32']},

--- a/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
+++ b/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
@@ -1,7 +1,7 @@
 //# 8 "M" Standard Extension for Integer Multiplication and Division, Version 2.0
 //## 8.1 Multiplication Operations
 
-[wavedrom, ,svg, alt="8 "M" Standard Extension for Integer Multiplication and Division, Version 2.0"]
+[wavedrom, ,svg, alt="8.1 Multiplication Operations"M" Standard Extension for Integer Multiplication and Division, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'OP', 'OP-32']},

--- a/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
+++ b/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
@@ -1,7 +1,7 @@
 //# 8 "M" Standard Extension for Integer Multiplication and Division, Version 2.0
 //## 8.1 Multiplication Operations
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="8 "M" Standard Extension for Integer Multiplication and Division, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'OP', 'OP-32']},

--- a/src/unpriv/images/wavedrom/mem-order.edn
+++ b/src/unpriv/images/wavedrom/mem-order.edn
@@ -1,6 +1,6 @@
 //## 2.7 Memory Ordering Instructions
 
-[wavedrom,mem-order ,]
+[wavedrom,mem-order ,svg,alt="Memory Fence instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},

--- a/src/unpriv/images/wavedrom/mop-r.edn
+++ b/src/unpriv/images/wavedrom/mop-r.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MOP R instruction encoding"]
 ....
 {reg:[
     { bits:  7, name: 0x73, attr: ['SYSTEM']},

--- a/src/unpriv/images/wavedrom/mop-rr.edn
+++ b/src/unpriv/images/wavedrom/mop-rr.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="MOP RR instruction encoding"]
 ....
 {reg:[
     { bits:  7, name: 0x73, attr: ['SYSTEM']},

--- a/src/unpriv/images/wavedrom/nop.edn
+++ b/src/unpriv/images/wavedrom/nop.edn
@@ -1,5 +1,5 @@
 //### NOP Instruction
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="NOP Instruction"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM']},

--- a/src/unpriv/images/wavedrom/quad-cnvrt-intch-xqqx.edn
+++ b/src/unpriv/images/wavedrom/quad-cnvrt-intch-xqqx.edn
@@ -1,6 +1,6 @@
 //quad-cnvrt-intch-xqqx
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="QUAD CNVRT INTCH XQQX instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/quad-cnvrt-mv.edn
+++ b/src/unpriv/images/wavedrom/quad-cnvrt-mv.edn
@@ -1,6 +1,6 @@
 //## 14.3 Quad-Precision Convert and Move Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.3 Quad-Precision Convert and Move Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/quad-cnvt-interchange.edn
+++ b/src/unpriv/images/wavedrom/quad-cnvt-interchange.edn
@@ -1,6 +1,6 @@
 //14 conv-mv
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="QUAD CNVT INTERCHANGE instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7', 'OP-FP', 'OP-FP','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/quad-compute.edn
+++ b/src/unpriv/images/wavedrom/quad-compute.edn
@@ -1,6 +1,6 @@
 //## 14.2 Quad-Precision Computational Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.2 Quad-Precision Computational Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},
@@ -13,7 +13,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.2 Quad-Precision Computational Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/quad-compute.edn
+++ b/src/unpriv/images/wavedrom/quad-compute.edn
@@ -1,6 +1,6 @@
 //## 14.2 Quad-Precision Computational Instructions
 
-[wavedrom, ,svg, alt="14.2 Quad-Precision Computational Instructions"]
+[wavedrom, ,svg, alt="Quad-Precision Floating-Point Arithmetic Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},
@@ -13,7 +13,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="14.2 Quad-Precision Computational Instructions"]
+[wavedrom, ,svg, alt="Quad-Precision Floating-Point Fused Multiply-Add Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/quad-float-clssfy.edn
+++ b/src/unpriv/images/wavedrom/quad-float-clssfy.edn
@@ -1,6 +1,6 @@
 //## 14.5 Quad-Precision Floating-Point Classify Instruction
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.5 Quad-Precision Floating-Point Classify Instruction"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/quad-float-compare.edn
+++ b/src/unpriv/images/wavedrom/quad-float-compare.edn
@@ -1,6 +1,6 @@
 //## 14.4 Quad-Precision Floating-Point Compare Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.4 Quad-Precision Floating-Point Compare Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/quad-ls.edn
+++ b/src/unpriv/images/wavedrom/quad-ls.edn
@@ -1,6 +1,6 @@
 //## 14.1 Quad-Precision Load and Store Instructions
 
-[wavedrom, ,svg, alt="14.1 Quad-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Quad-Precision Floating-Point Load Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="14.1 Quad-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Quad-Precision Floating-Point Store Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','STORE-FP']},

--- a/src/unpriv/images/wavedrom/quad-ls.edn
+++ b/src/unpriv/images/wavedrom/quad-ls.edn
@@ -1,6 +1,6 @@
 //## 14.1 Quad-Precision Load and Store Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.1 Quad-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="14.1 Quad-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','STORE-FP']},

--- a/src/unpriv/images/wavedrom/reg-based-ldnstr.edn
+++ b/src/unpriv/images/wavedrom/reg-based-ldnstr.edn
@@ -1,7 +1,7 @@
 //Register-Based loads and Stores
 
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="REG BASED LDNSTR instruction encoding"]
 ....
 {reg: [
   {bits: 2, name: 'op', attr: ['2', 'C0', 'C0', 'C0', 'C0']},

--- a/src/unpriv/images/wavedrom/rv64-lui-auipc.edn
+++ b/src/unpriv/images/wavedrom/rv64-lui-auipc.edn
@@ -1,6 +1,6 @@
 //lui-auipc
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="RV64 LUI AUIPC instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',     attr: ['7', 'LUI', 'AUIPC']},

--- a/src/unpriv/images/wavedrom/rv64i-base-int.edn
+++ b/src/unpriv/images/wavedrom/rv64i-base-int.edn
@@ -2,7 +2,7 @@
 //## 6.2 Integer Computational Instructions
 //### Integer Register-Immediate Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="6 RV64I Base Integer Instruction Set, Version 2.1"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM-32']},

--- a/src/unpriv/images/wavedrom/rv64i-base-int.edn
+++ b/src/unpriv/images/wavedrom/rv64i-base-int.edn
@@ -2,7 +2,7 @@
 //## 6.2 Integer Computational Instructions
 //### Integer Register-Immediate Instructions
 
-[wavedrom, ,svg, alt="6 RV64I Base Integer Instruction Set, Version 2.1"]
+[wavedrom, ,svg, alt="Integer Register-Immediate Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM-32']},

--- a/src/unpriv/images/wavedrom/rv64i-int-reg-reg.edn
+++ b/src/unpriv/images/wavedrom/rv64i-int-reg-reg.edn
@@ -2,7 +2,7 @@
 //rv64i int-reg-reg
 //### Integer Register-Register Operations
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="Integer Register-Register Operations"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP', 'OP', 'OP-32', 'OP-32', 'OP-32']},

--- a/src/unpriv/images/wavedrom/rv64i-slli.edn
+++ b/src/unpriv/images/wavedrom/rv64i-slli.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="RV64I SLLI instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM', 'OP-IMM', 'OP-IMM']},

--- a/src/unpriv/images/wavedrom/rv64i-slliw.edn
+++ b/src/unpriv/images/wavedrom/rv64i-slliw.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="RV64I SLLIW instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'OP-IMM-32', 'OP-IMM-32', 'OP-IMM-32']},

--- a/src/unpriv/images/wavedrom/s-immediate.edn
+++ b/src/unpriv/images/wavedrom/s-immediate.edn
@@ -1,6 +1,6 @@
 //#### S-immediate
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="S-immediate instruction encoding"]
 ....
 {reg: [
   {bits: 1,  name: '[7]'},

--- a/src/unpriv/images/wavedrom/sp-load-store-2.edn
+++ b/src/unpriv/images/wavedrom/sp-load-store-2.edn
@@ -1,6 +1,6 @@
 //## 12.5 Single-Precision Load and Store Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'STORE-FP']},

--- a/src/unpriv/images/wavedrom/sp-load-store-2.edn
+++ b/src/unpriv/images/wavedrom/sp-load-store-2.edn
@@ -1,6 +1,6 @@
 //## 12.5 Single-Precision Load and Store Instructions
 
-[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Single-Precision Floating-Point Load Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Single-Precision Floating-Point Store Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'STORE-FP']},

--- a/src/unpriv/images/wavedrom/sp-load-store.edn
+++ b/src/unpriv/images/wavedrom/sp-load-store.edn
@@ -1,6 +1,6 @@
 //## 12.5 Single-Precision Load and Store Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'STORE-FP']},

--- a/src/unpriv/images/wavedrom/sp-load-store.edn
+++ b/src/unpriv/images/wavedrom/sp-load-store.edn
@@ -1,6 +1,6 @@
 //## 12.5 Single-Precision Load and Store Instructions
 
-[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Half-Precision Floating-Point Load Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD-FP']},
@@ -11,7 +11,7 @@
 ]}
 ....
 
-[wavedrom, ,svg, alt="12.5 Single-Precision Load and Store Instructions"]
+[wavedrom, ,svg, alt="Half-Precision Floating-Point Store Instruction Encoding"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'STORE-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-classify.edn
+++ b/src/unpriv/images/wavedrom/spfloat-classify.edn
@@ -1,6 +1,6 @@
 //## 12.9 Single-Precision Floating-Point Classify Instruction
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.9 Single-Precision Floating-Point Classify Instruction"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-cn-cmp.edn
+++ b/src/unpriv/images/wavedrom/spfloat-cn-cmp.edn
@@ -1,6 +1,6 @@
 //sp float convert and compare
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SPFLOAT CN CMP instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP', 'OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-comp.edn
+++ b/src/unpriv/images/wavedrom/spfloat-comp.edn
@@ -1,6 +1,6 @@
 //## 12.8 Single-Precision Floating-Point Compare Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.8 Single-Precision Floating-Point Compare Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-mv.edn
+++ b/src/unpriv/images/wavedrom/spfloat-mv.edn
@@ -1,6 +1,6 @@
 //SP floating point move
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SPFLOAT MV instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-sign-inj.edn
+++ b/src/unpriv/images/wavedrom/spfloat-sign-inj.edn
@@ -1,6 +1,6 @@
 //sp float sign injection
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SPFLOAT SIGN INJ instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat-zfh.edn
+++ b/src/unpriv/images/wavedrom/spfloat-zfh.edn
@@ -1,6 +1,6 @@
 //## 12.6 Single-Precision Floating-Point Computational Instructions for ZFH Chapter
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.6 Single-Precision Floating-Point Computational Instructions for ZFH Chapter"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat.edn
+++ b/src/unpriv/images/wavedrom/spfloat.edn
@@ -1,6 +1,6 @@
 //## 12.6 Single-Precision Floating-Point Computational Instructions
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="12.6 Single-Precision Floating-Point Computational Instructions"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','OP-FP','OP-FP','OP-FP','OP-FP']},

--- a/src/unpriv/images/wavedrom/spfloat2-zfh.edn
+++ b/src/unpriv/images/wavedrom/spfloat2-zfh.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SPFLOAT2 ZFH instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/spfloat2.edn
+++ b/src/unpriv/images/wavedrom/spfloat2.edn
@@ -1,4 +1,4 @@
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="SPFLOAT2 instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 'opcode', attr: ['7','F[N]MADD/F[N]MSUB']},

--- a/src/unpriv/images/wavedrom/u-immediate.edn
+++ b/src/unpriv/images/wavedrom/u-immediate.edn
@@ -1,6 +1,6 @@
 //#### U-immediate
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="U-immediate instruction encoding"]
 ....
 {reg: [
   {bits: 12, name: '0'},

--- a/src/unpriv/images/wavedrom/valu-format.edn
+++ b/src/unpriv/images/wavedrom/valu-format.edn
@@ -12,7 +12,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
      6        1        5          5        3        5        7
 ////
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPIVV'},
@@ -25,7 +25,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPFVV'},
@@ -38,7 +38,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPMVV'},
@@ -51,7 +51,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: ['OPIVI']},
@@ -64,7 +64,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPIVX'},
@@ -77,7 +77,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPFVF'},
@@ -90,7 +90,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPMVX'},

--- a/src/unpriv/images/wavedrom/valu-format.edn
+++ b/src/unpriv/images/wavedrom/valu-format.edn
@@ -12,7 +12,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
      6        1        5          5        3        5        7
 ////
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPIVV) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPIVV'},
@@ -25,7 +25,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPFVV) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPFVV'},
@@ -38,7 +38,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPMVV) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPMVV'},
@@ -51,7 +51,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPIVI) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: ['OPIVI']},
@@ -64,7 +64,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPIVX) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPIVX'},
@@ -77,7 +77,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPFVF) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPFVF'},
@@ -90,7 +90,7 @@ Formats for Vector Arithmetic Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VALU FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="OP-V (OPMVX) instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x57, attr: 'OPMVX'},

--- a/src/unpriv/images/wavedrom/vcfg-format.edn
+++ b/src/unpriv/images/wavedrom/vcfg-format.edn
@@ -8,7 +8,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
  1        6            5          5        3        5        7
 ////
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetvli'},
@@ -20,7 +20,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetivli'},
@@ -33,7 +33,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetvl'},

--- a/src/unpriv/images/wavedrom/vcfg-format.edn
+++ b/src/unpriv/images/wavedrom/vcfg-format.edn
@@ -8,7 +8,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
  1        6            5          5        3        5        7
 ////
 
-[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="vsetvli instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetvli'},
@@ -20,7 +20,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="vsetivli instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetivli'},
@@ -33,7 +33,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VCFG FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="vsetvl instruction encoding"]
 ....
 {reg: [
   {bits: 7,  name: 0x57, attr: 'vsetvl'},

--- a/src/unpriv/images/wavedrom/vmem-format.edn
+++ b/src/unpriv/images/wavedrom/vmem-format.edn
@@ -8,7 +8,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
   3     1    2     1      5           5         3         5       7
 ////
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VL* unit-stride instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VL* unit-stride'},
@@ -23,7 +23,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VLS* strided instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VLS* strided'},
@@ -38,7 +38,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VLX* indexed instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VLX* indexed'},
@@ -62,7 +62,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
   3     1    2     1      5           5         3         5        7
 ////
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VS* unit-stride instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VS* unit-stride'},
@@ -77,7 +77,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VSS* strided instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VSS* strided'},
@@ -92,7 +92,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
 ]}
 ....
 
-[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
+[wavedrom, ,svg, alt="VSX* indexed instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VSX* indexed'},

--- a/src/unpriv/images/wavedrom/vmem-format.edn
+++ b/src/unpriv/images/wavedrom/vmem-format.edn
@@ -8,7 +8,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
   3     1    2     1      5           5         3         5       7
 ////
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VL* unit-stride'},
@@ -23,7 +23,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VLS* strided'},
@@ -38,7 +38,7 @@ Format for Vector Load Instructions under LOAD-FP major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x7, attr: 'VLX* indexed'},
@@ -62,7 +62,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
   3     1    2     1      5           5         3         5        7
 ////
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VS* unit-stride'},
@@ -77,7 +77,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VSS* strided'},
@@ -92,7 +92,7 @@ Format for Vector Store Instructions under STORE-FP major opcode
 ]}
 ....
 
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VMEM FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 7, name: 0x27, attr: 'VSX* indexed'},

--- a/src/unpriv/images/wavedrom/vtype-format.edn
+++ b/src/unpriv/images/wavedrom/vtype-format.edn
@@ -1,4 +1,4 @@
-[wavedrom,,svg]
+[wavedrom, ,svg, alt="VTYPE FORMAT instruction encoding"]
 ....
 {reg: [
   {bits: 3, name: 'VLMUL'},

--- a/src/unpriv/images/wavedrom/zifencei-ff.edn
+++ b/src/unpriv/images/wavedrom/zifencei-ff.edn
@@ -1,6 +1,6 @@
 //# 3 "Zifencei" Instruction-Fetch Fence, Version 2.0
 
-[wavedrom, ,svg, alt="3 "Zifencei" Instruction-Fetch Fence, Version 2.0"]
+[wavedrom, ,svg, alt="3 \"Zifencei\" Instruction-Fetch Fence, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},

--- a/src/unpriv/images/wavedrom/zifencei-ff.edn
+++ b/src/unpriv/images/wavedrom/zifencei-ff.edn
@@ -1,6 +1,6 @@
 //# 3 "Zifencei" Instruction-Fetch Fence, Version 2.0
 
-[wavedrom, ,svg]
+[wavedrom, ,svg, alt="3 "Zifencei" Instruction-Fetch Fence, Version 2.0"]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},


### PR DESCRIPTION
Fixes #1129

This PR adds accessibility improvements to WaveDrom and bytefield diagrams in the HTML output.

Changes:
- Add `docs-resources/tools/wavedrom_a11y.py` — a script that processes .edn files and injects <title>, <desc>, and aria-label into generated SVGs, and also updates the alt text in the [wavedrom, ,svg] block so screen readers can read it when embedded as base64
- Update b-immediate.edn, atomic-mem.edn, c-breakpoint-instr.edn as examples
<img width="1602" height="252" alt="b-immediate-accessible" src="https://github.com/user-attachments/assets/0315d726-e12c-407a-9afa-b5fd73a19d3a" />

<img width="1092" height="283" alt="b-immediate_alt-fix" src="https://github.com/user-attachments/assets/0c002fdb-44d1-4f76-b378-b07126d80249" />
- Add a11y-desc comment to fprs.edn for bytefield diagrams that can't be auto-parsed
<img width="1637" height="156" alt="byte-field" src="https://github.com/user-attachments/assets/ece90387-6ae7-4853-9a1f-653a70166b35" />

<img width="1611" height="701" alt="bytefield_alt" src="https://github.com/user-attachments/assets/608b61a3-9a60-45b0-a697-5e51487fce50" />
