### PR TITLE
Bring back fprs to F

### DIFF
--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -7,9 +7,32 @@ compliant with the IEEE 754-2008 arithmetic standard's binary32 format and
 operations.# [#norm:f_depends_zicsr]#The ext:f[] extension depends on the
 ext:zicsr[] extension.#
 
-[[norm:flen]]
-The ext:f[] extension adds 32 floating-point registers, `f0`{endash}``f31``, each 32 bits
-wide, i.e., FLEN=32.
+==== Floating-Point Register State
+
+[#norm:flen]#The ext:f[] extension adds 32 floating-point registers,
+`f0`{endash}``f31``, each 32 bits wide, i.e., FLEN=32.# The ext:f[] extension
+also adds a floating-point CSR csr:fcsr[] that contains the operating mode and
+exception status of the floating-point unit. The floating-point register state
+is shown in <<fprs>>.
+
+[[fprs]]
+.RISC-V floating-point register state
+include::images/bytefield/fprs.edn[]
+
+Most floating-point instructions operate on values in the floating-point
+register file. Floating-point load and store instructions transfer
+floating-point values between registers and memory. Instructions to transfer
+floating-point values to and from the integer register file are also provided.
+
+[NOTE]
+====
+For simple and low-cost implementations, the ext:zfinx[], ext:zdinx[], and
+ext:zhinx[] extensions provide computational instructions analogous to those in
+the ext:f[], ext:d[], and ext:zfh[] extensions that operate on the `x` registers
+instead.
+====
+
+The details of csr:fcsr[] are described in <<sec:fcsr>>.
 
 [[sec:fcsr]]
 ==== Floating-Point Control and Status Register

--- a/src/unpriv/zf.adoc
+++ b/src/unpriv/zf.adoc
@@ -10,6 +10,9 @@ instructions for computation on single-precision floating-point values.
 The extlink:d[] and extlink:q[] extensions widen those registers to
 hold double- and quad-precision floating-point values, respectively, and add
 instructions for computation on those formats.
+We use the term ((FLEN)) to describe the width of the floating-point registers.
+FLEN can be 32, 64, or 128 depending on which of the ext:f[], ext:d[], and
+ext:q[] extensions are supported.
 Several additional extensions with the ext:zf[] prefix provide
 additional computational instructions.
 
@@ -47,38 +50,6 @@ While the BF16 cite:[bfloat16], E4M3, and E5M2 formats are not defined in IEEE
 754-2008, the structure and operations of these formats are compatible with the
 standard. E4M3 and E5M2 are specified by the Open Compute Project (OCP) as the
 OCP FP8 (OFP8) formats cite:[ocp-fp8].
-
-:sectnums!:
-[discrete]
-=== Floating-Point Register State
-:sectnums:
-
-The ext:f[], ext:d[], and ext:q[] standard extensions use 32 floating-point
-registers, `f0`{endash}``f31``, and a floating-point CSR, csr:fcsr[], that contains the
-operating mode and exception status of the floating-point unit. The
-floating-point register state is shown in <<fprs>>.
-We use the term FLEN to describe the width of the floating-point registers. FLEN
-can be 32, 64, or 128 depending on which of the ext:f[], ext:d[], and ext:q[]
-extensions are supported.
-
-[[fprs]]
-.RISC-V floating-point register state
-include::images/bytefield/fprs.edn[]
-
-Most floating-point instructions operate on values in the floating-point
-register file. Floating-point load and store instructions transfer
-floating-point values between registers and memory. Instructions to transfer
-floating-point values to and from the integer register file are also provided.
-
-[NOTE]
-====
-For simple and low-cost implementations, the ext:zfinx[], ext:zdinx[], and
-ext:zhinx[] extensions provide computational instructions analogous to those in
-the ext:f[], ext:d[], and ext:zfh[] extensions that operate on the `x` registers
-instead.
-====
-
-The details of csr:fcsr[] are described in <<sec:fcsr>>.
 
 include::f-st-ext.adoc[]
 include::d-st-ext.adoc[]


### PR DESCRIPTION
I had moved the floating-point register state section to the introduction part, but now I thought that adding only the definition of FLEN to the introduction part would provide a better flow. In the end, the relevant main text was mostly reverted to the last ratified one with minor changes.