### PR TITLE
Rearrange priv priface table

### DIFF
--- a/src/priv/preface.adoc
+++ b/src/priv/preface.adoc
@@ -20,12 +20,12 @@ all of which have been ratified:
 
 h|Extension h|Version
 
-|ext:smstateen[]/ext:ssstateen[] |1.0
-|ext:smcsrind[]/ext:sscsrind[] |1.0
+|ext:smstateen[] |1.0
+|ext:smcsrind[] |1.0
 |ext:smepmp[] |1.0
 |ext:smcntrpmf[] |1.0
 |ext:smrnmi[] |1.0
-|ext:smcdeleg[]/ext:ssccfg[] |1.0
+|ext:smcdeleg[] |1.0
 |ext:smdbltrp[] |1.0
 |ext:smctr[] |1.0
 |Control-flow Integrity |1.0
@@ -39,6 +39,9 @@ h|Extension h|Version
 |ext:svvptc[] |1.0
 |ext:svrsw60t59b[] |1.0
 
+|ext:ssstateen[] |1.0
+|ext:sscsrind[] |1.0
+|ext:ssccfg[] |1.0
 |ext:ssqosid[] |1.0
 |ext:ssu64xl[] |1.0
 |ext:ssccptr[] |1.0


### PR DESCRIPTION
For unknown reasons, multiple extensions in one cell render with a different background color. To workaround it, enforce one-extension-per-row.

<img width="295" height="186" alt="Screenshot" src="https://github.com/user-attachments/assets/4e935a7b-d898-4e1e-8f30-065a025d86f9" />
