### PR TITLE
Add permissions and try/catch guard.

### DIFF
--- a/.github/workflows/signing_check.yml
+++ b/.github/workflows/signing_check.yml
@@ -56,7 +56,7 @@ jobs:
                 body: comment,
                 });
               } catch (e) {
-                core.warning('Unable to post PR comment: ${e.message}');
+                core.warning(`Unable to post PR comment: ${e instanceof Error ? e.message : String(e)}`);
               }
 
               core.setFailed('Commit signing check failed. One or more commits are not signed.');

--- a/.github/workflows/signing_check.yml
+++ b/.github/workflows/signing_check.yml
@@ -10,8 +10,7 @@ on:
       - converted_to_draft
 
 permissions:
-  contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 jobs:
   signing_check:

--- a/.github/workflows/signing_check.yml
+++ b/.github/workflows/signing_check.yml
@@ -9,6 +9,10 @@ on:
       - synchronize
       - converted_to_draft
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 jobs:
   signing_check:
     runs-on: ubuntu-latest
@@ -44,11 +48,16 @@ jobs:
 
                 Once you have signed your commits, you will need to force-push your changes.
               `;
+              try {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
                 body: comment,
-              });
+                });
+              } catch (e) {
+                core.warning('Unable to post PR comment: ${e.message}');
+              }
+
               core.setFailed('Commit signing check failed. One or more commits are not signed.');
             }


### PR DESCRIPTION
Adds the explicit permissions required to comment on PRs. Add a createComment wrapper with try/catch to allow failure even when comment creation is blocked. Signed-off-by: Bill Traynor wmat@riscv.org