### PR TITLE
Fix typo in timeout description in zawrs.adoc

### DIFF
--- a/src/unpriv/zawrs.adoc
+++ b/src/unpriv/zawrs.adoc
@@ -30,7 +30,7 @@ Sometimes the program waiting on a memory update may also need to carry out a
 task at a future time or otherwise place an upper bound on the wait. To support
 such use cases a second instruction [#norm:Zawrs_wrs-sto_stall_duration]#insn:wrs.sto[] (WRS-with-short-timeout) is
 provided that works like insn:wrs.nto[] but bounds the stall duration to an
-implementation-define short timeout such that the stall is terminated on the
+implementation-defined short timeout such that the stall is terminated on the
 timeout if no other conditions have occurred to terminate the stall.# The
 program using this instruction may then determine if its deadline has been
 reached.


### PR DESCRIPTION
Older fix for this went stale, so fixing it myself.