### PR TITLE
Add RVController marchid

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -70,3 +70,4 @@ River         | Midstall Software               | [Inquiry](mailto:inquire@midst
 Raptor        | Yu Jin                          | [Yu Jin](mailto:lambda.jinyu@gmail.com)                     | 50               | https://github.com/Kingfish404/raptor-chip
 Sargantana    | BSC-LOCA                        | [Narcís Rodas](mailto:narcis.rodaquiroga@bsc.es)            | 51               | https://github.com/bsc-loca/sargantana
 KianV Stealth | Hirosh Dabui                    | [Hirosh Dabui](mailto:hirosh@dabui.de)                      | 52               | https://github.com/splinedrive/kianRiscV
+RVController  | April Kolwey (cheapie)          | [April Kolwey](mailto:cheapiephp@gmail.com)                 | 53               | https://cheapiesystems.com/git/rvcontroller/


### PR DESCRIPTION
I have no idea if this project is actually worthy of an marchid assignment. I figured I might as well try and the worst that can happen is that the answer is "no"...

RVController is something I've been working on for a while now (longer than the history on its repo suggests - it only recently got that), it's an emulator that runs on an existing microcontroller in a game (Luanti) and emulates a 32-bit RISC-V processor. Currently it supports RV32IMACB and a whole bunch of Z extensions, as well as switchable endianness (writable MBE bit) and a few other things.

Here's a short video of it in action, doing a sort of embedded task in the game - in this case, controlling some railroad crossing equipment using the big-endian version of the "rrxing.c" sample: https://cheapiesystems.com/media/2026-05-27%2004-30-37.webm

Hopefully I got the signing right, this is the first time I've ever submitted a PR to a repository that needs that.

