### PR TITLE
Update IEEE 754 specification reference

### DIFF
--- a/src/unpriv/preface.adoc
+++ b/src/unpriv/preface.adoc
@@ -489,7 +489,7 @@ floating-point instructions in the 2-bit _fmt_ field.
 * Defined the signed-zero behavior of insn:fmin[] and insn:fmax[], and
 changed their behavior on signaling-NaN inputs to conform to the
 `minimumNumber` and `maximumNumber` operations in the IEEE 754-2019
-specification cite:[ieee754-2019].
+arithmetic standard cite:[ieee754-2019].
 * The memory consistency model, RVWMO, has been defined.
 * The ext:zam[] extension, which permits misaligned AMOs and specifies
 their semantics, has been defined.

--- a/src/unpriv/preface.adoc
+++ b/src/unpriv/preface.adoc
@@ -488,8 +488,8 @@ inaccuracies.
 floating-point instructions in the 2-bit _fmt_ field.
 * Defined the signed-zero behavior of insn:fmin[] and insn:fmax[], and
 changed their behavior on signaling-NaN inputs to conform to the
-`minimumNumber` and `maximumNumber` operations in the proposed IEEE 754-201x
-specification.
+`minimumNumber` and `maximumNumber` operations in the IEEE 754-2019
+specification cite:[ieee754-2019].
 * The memory consistency model, RVWMO, has been defined.
 * The ext:zam[] extension, which permits misaligned AMOs and specifies
 their semantics, has been defined.

--- a/src/unpriv/preface.adoc
+++ b/src/unpriv/preface.adoc
@@ -488,8 +488,8 @@ inaccuracies.
 floating-point instructions in the 2-bit _fmt_ field.
 * Defined the signed-zero behavior of insn:fmin[] and insn:fmax[], and
 changed their behavior on signaling-NaN inputs to conform to the
-`minimumNumber` and `maximumNumber` operations in the IEEE 754-2019
-arithmetic standard cite:[ieee754-2019].
+`minimumNumber` and `maximumNumber` operations in the <<ieee754-2019, IEEE
+754-2019 arithmetic standard>>.
 * The memory consistency model, RVWMO, has been defined.
 * The ext:zam[] extension, which permits misaligned AMOs and specifies
 their semantics, has been defined.


### PR DESCRIPTION
In the unpriv preface, updated reference to the IEEE 754 specification to reflect the 2019 version.