### PR TITLE
Remove note about changing MXL in pointer masking

### DIFF
--- a/src/priv/zpm.adoc
+++ b/src/priv/zpm.adoc
@@ -185,11 +185,11 @@ In addition, the pointer masking standard defines two extensions that describe a
 
 The precise nature of these facilities is left to the respective execution environment.
 
-[#norm:pm_rv64_only]#Pointer masking only applies to RV64.# [#norm:pm_rv32_illegal]#In RV32, trying to enable pointer masking will result in an illegal WARL write and not update the pointer masking configuration bits# (see <<sec:mseccfg>>, <<sec:menvcfg>>, <<sec:henvcfg>>, and <<sec:senvcfg>> for details). The same is the case on RV64 or larger systems when UXL/SXL/MXL is set to 1 for the corresponding privilege mode. Note that in RV32, the CSR bits introduced by pointer masking are still present, for compatibility between RV32 and larger systems with UXL/SXL/MXL set to 1. [#norm:pm_uxl_clear]#Setting UXL/SXL/MXL to 1 will clear the corresponding pointer masking configuration bits.#
+[#norm:pm_rv64_only]#Pointer masking only applies to RV64.# [#norm:pm_rv32_illegal]#In RV32, trying to enable pointer masking will result in an illegal WARL write and not update the pointer masking configuration bits# (see <<sec:mseccfg>>, <<sec:menvcfg>>, <<sec:henvcfg>>, and <<sec:senvcfg>> for details). The same is the case on RV64 or larger systems when UXL/SXL is set to 1 for the corresponding privilege mode. Note that in RV32, the CSR bits introduced by pointer masking are still present, for compatibility between RV32 and larger systems with UXL/SXL set to 1. [#norm:pm_uxl_clear]#Setting UXL/SXL to 1 will clear the corresponding pointer masking configuration bits.#
 
 [NOTE]
 ====
-Note that setting UXL/SXL/MXL to 1 and back to 0 does not preserve the previous values of the PMM bits. This includes the case of entering an RV32 virtual machine from an RV64 hypervisor and returning.
+Note that setting UXL/SXL to 1 and back to 0 does not preserve the previous values of the PMM bits. This includes the case of entering an RV32 virtual machine from an RV64 hypervisor and returning.
 ====
 
 [NOTE]


### PR DESCRIPTION
MXL is read-only.  Delete mention of changing it in pointer-masking section.