### PR TITLE
Sscofpmf cleanup

### DIFF
--- a/src/priv/sscofpmf.adoc
+++ b/src/priv/sscofpmf.adoc
@@ -1,8 +1,8 @@
 [[Sscofpmf]]
 === ext:sscofpmf[] Extension for Count Overflow and Mode-Based Filtering
 
-The current Privileged specification defines mhpmevent CSRs to select and
-control event counting by the associated hpmcounter CSRs, but provides no
+The current Privileged specification defines `mhpmevent` CSRs to select and
+control event counting by the associated `hpmcounter` CSRs, but provides no
 standardization of any fields within these CSRs. For at least Linux-class
 rich-OS systems it is desirable to standardize certain basic features that are
 broadly desired (and have come up over the past year plus on RISC-V lists, as
@@ -10,7 +10,7 @@ well as have been the subject of past proposals). This enables there to be
 standard upstream software support that eliminates the need for implementations
 to provide their own custom software support.
 
-This extension serves to accomplish exactly this within the existing mhpmevent
+This extension serves to accomplish exactly this within the existing `mhpmevent`
 CSRs (and correspondingly avoids the unnecessary creation of whole new sets of
 CSRs - past just one new CSR).
 
@@ -24,7 +24,7 @@ The extension name is "Sscofpmf" ('Ss' for Privileged arch and Supervisor-level
 extensions, and 'cofpmf' for Count OverFlow and Privilege Mode Filtering).
 
 Note that the new count overflow interrupt will be treated as a standard local
-interrupt that is assigned to bit 13 in the mip/mie/sip/sie registers.
+interrupt that is assigned to bit 13 in the `mip`/`mie`/`sip`/`sie` registers.
 
 ==== Count Overflow Control
 
@@ -57,24 +57,24 @@ Each of the five ``x``INH bits, when set, inhibit counting of events while in
 privilege mode ``x``. All-zeroes for these bits results in counting of events in
 all modes.
 
-[#norm:mhpmevent_of_op]#The OF bit is set when the corresponding hpmcounter overflows, and remains set
-until written by software.# [#norm:hpmcounter_overflow]#Since hpmcounter values are unsigned values,
+[#norm:mhpmevent_of_op]#The OF bit is set when the corresponding `hpmcounter` overflows, and remains set
+until written by software.# [#norm:hpmcounter_overflow]#Since `hpmcounter` values are unsigned values,
 overflow is defined as unsigned overflow of the implemented counter bits.# Note
 that there is no loss of information after an overflow since the counter wraps
 around and keeps counting while the sticky OF bit remains set.
 
-If supervisor mode is implemented, the 32-bit scountovf register contains
-read-only shadow copies of the OF bits in all 29 mhpmevent registers.
+The 32-bit `scountovf` register contains
+read-only shadow copies of the OF bits in all 29 `mhpmevent` registers.
 
 [[norm:count_overflow_interrupt]]
-If an hpmcounter overflows while the associated OF bit is zero, then a "`count
+If an `hpmcounter` overflows while the associated OF bit is zero, then a "`count
 overflow interrupt request`" is generated. If the OF bit is one, then no
 interrupt request is generated. Consequently the OF bit also functions as a
-count overflow interrupt disable for the associated hpmcounter.
+count overflow interrupt disable for the associated `hpmcounter`.
 
 [[norm:count_overflow_trigger]]
-Count overflow never results from writes to the mhpmcounter__n__ or
-mhpmevent__n__ registers, only from hardware increments of counter registers.
+Count overflow never results from writes to the `mhpmcounter`__n__ or
+`mhpmevent`__n__ registers, only from hardware increments of counter registers.
 
 This count-overflow-interrupt-request signal is treated as a standard local
 interrupt that corresponds to bit 13 in the `mip`/`mie`/`sip`/`sie` registers.
@@ -113,17 +113,17 @@ eventually overflow.
 [[norm:scountovf_op]]
 This extension adds the `scountovf` CSR,
 a 32-bit read-only register that contains shadow copies of
-the OF bits in the 29 mhpmevent CSRs (mhpmevent__3__ - mhpmevent__31__) - where
-scountovf bit _X_ corresponds to mhpmevent__X__.
+the OF bits in the 29 `mhpmevent` CSRs (`mhpmevent3` - `mhpmevent31`) - where
+`scountovf` bit _X_ corresponds to mhpmevent__X__.
 
 This register enables supervisor-level overflow interrupt handler software to
 quickly and easily determine which counter(s) have overflowed (without needing
 to make an execution environment call or series of calls ultimately up to
 M-mode).
 
-[#norm:scountovf_smode_read_access_control]#Read access to bit _X_ is subject to the same mcounteren (or mcounteren and
-hcounteren) CSRs that mediate access to the hpmcounter CSRs by S-mode (or
-VS-mode).# [#norm:scountovf_mmode_read_access]#In M-mode, scountovf bit _X_ is always readable.# [#norm:scountovf_smode_read_access]#In S/HS-mode, scountovf bit _X_ is readable when mcounteren bit
-_X_ is set, and otherwise reads as zero.# [#norm:scountovf_vsmode_read_access]#Similarly, in VS mode, scountovf bit
-_X_ is readable when mcounteren bit _X_ and hcounteren bit _X_ are both set,
+[#norm:scountovf_smode_read_access_control]#Read access to bit _X_ is subject to the same  `mcounteren` (or `mcounteren` and
+`hcounteren`) CSRs that mediate access to the `hpmcounter` CSRs by S-mode (or
+VS-mode).# [#norm:scountovf_mmode_read_access]#In M-mode, `scountovf` bit _X_ is always readable.# [#norm:scountovf_smode_read_access]#In S/HS-mode, `scountovf` bit _X_ is readable when `mcounteren` bit
+_X_ is set, and otherwise reads as zero.# [#norm:scountovf_vsmode_read_access]#Similarly, in VS mode, `scountovf` bit
+_X_ is readable when `mcounteren` bit _X_ and `hcounteren` bit _X_ are both set,
 and otherwise reads as zero.#

--- a/src/priv/sscofpmf.adoc
+++ b/src/priv/sscofpmf.adoc
@@ -114,7 +114,7 @@ eventually overflow.
 This extension adds the `scountovf` CSR,
 a 32-bit read-only register that contains shadow copies of
 the OF bits in the 29 `mhpmevent` CSRs (`mhpmevent3` - `mhpmevent31`) - where
-`scountovf` bit _X_ corresponds to mhpmevent__X__.
+`scountovf` bit _X_ corresponds to `mhpmevent`__X__.
 
 This register enables supervisor-level overflow interrupt handler software to
 quickly and easily determine which counter(s) have overflowed (without needing


### PR DESCRIPTION
Removed a clause about "if supervisor mode is implemented" because the extension name and preamble state that Sscofpmf is a supervisor-level extension.

Clean up CSR name font to be more consistent with the rest of the ISA manual.