### PR TITLE
Clarify sip can contain machine interrupts even though diagram shows 0s

### DIFF
--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -411,7 +411,11 @@ become pending. Bits of `sie` that are not writable are read-only zero.#
 [[norm:sip_sie_bits_sz]]
 The standard portions (bits 15:0) of registers `sip` and `sie` are
 formatted as shown in Figures <<sipreg-standard>>
-and <<siereg-standard>> respectively.
+and <<siereg-standard>> respectively. Although MEI, MTI, and MSI
+are not shown because a SBI typically does not delegate machine
+interrupts, they may be nonzero in `sip` and `sie` if the corresponding
+fields of `mideleg` are not read-only-zero.  If they can be nonzero, they
+are read-only in `sip`.
 
 [[sipreg-standard]]
 .Standard portion (bits 15:0) of `sip`.


### PR DESCRIPTION
Clarify the explanation regarding MEI, MTI, and MSI in the context of registers `sip` and `sie`.