### PR TITLE
Add v0.7.1 Frozen version of RVA23.1 and RVB23.1

### DIFF
--- a/src/profiles/profiles.adoc
+++ b/src/profiles/profiles.adoc
@@ -9,7 +9,9 @@ include::rvi20.adoc[]
 include::rva20.adoc[]
 include::rva22.adoc[]
 include::rva23.adoc[]
+include::rva23p1.adoc[]
 include::rvb23.adoc[]
+include::rvb23p1.adoc[]
 
 // Appendices
 :appendix-number: @

--- a/src/profiles/rva23p1.adoc
+++ b/src/profiles/rva23p1.adoc
@@ -1,0 +1,54 @@
+== RVA23.1 Profiles
+
+The RVA23.1 profiles are intended to expand upon
+the RVA23 major release of the RVA Family of RISC-V Application
+Processor Profile.
+
+This is a minor release of the RVA23 Profile Family. As such, Minor
+Profiles do not contain any new mandatory extensions and are expected to be
+built on top of the extensions listed in the RVA23 profiles. For
+the sake of simplicity when referring to this profile in code or
+use in a command line argument, all instances of the period will
+be replaced with the lower case letter 'p', as in `rva23p1s64`.
+
+Only supervisor-mode (`rva23p1s64`) profiles are specified in this
+family.
+
+==== `rva23p1s64` Optional Extensions
+
+The `rva23p1s64` profile specifies the ISA features available to a
+supervisor-mode execution environment in 64-bit applications
+processors.  `rva23p1s64` is designed to be added on to and requires
+and implementation of `rva23s64` for Mandatory Base and Mandatory
+Extensions. `rva23p1s64` only provides new Development Options and
+Expansion Options on top of the `rva23s64`.
+
+===== Localized Options
+
+There are no privileged localized options in RVA23S64.
+
+===== Development Options
+
+The following are new privileged development options in RVA23.1S64:
+
+- <<svrsw60t59b,**Svrsw60t59b**>> PTE reserved-for-software bits.
+
+- <<ssdbltrap,**Ssdbltrap**>> Double Trap.
+
+- <<sscfg,**Sscfg**>> Supervisor Counter Delegation.
+
+===== Expansion Options
+
+The following are new privileged expansion options in RVA23.1S64:
+
+- <<ssctr,**Ssctr**>> Control Transfer Records, CTR.
+
+NOTE: *Ssctr* also implies inclusion of *Sscsrind* (indirect CSR access)
+
+- <<ssqosid,**Ssqosid**>> QoS identifiers.
+
+===== Transitory Options
+
+There are no privileged transitory options in RVA23S64.
+
+//

--- a/src/profiles/rvb23p1.adoc
+++ b/src/profiles/rvb23p1.adoc
@@ -1,0 +1,57 @@
+== RVB23.1 Profiles
+
+This chapter specifies the RVB23 Profile Family. RVB23.1 is the
+first minor release intended to expand upon the RVB23 major release
+of the RVB23 Family of RISC-V Application Processor Profile.
+
+This is a minor release of the RVB23 Profile Family. As such, Minor Profiles
+do not contain any new mandatory extensions and are expected to be
+built on top of the extensions listed in the RVB23 profiles. For
+the sake of simplicity when referring to this profile in code or
+use in a command line argument, all instances of the period will
+be replaced with the lower case letter 'p', as in `rvb23p1s64`
+
+Only supervisor-mode (`rvb23p1s64`) profiles are
+specified in this family.
+
+=== `rvb23p1s64` Profile
+
+The `rvb23p1s64` profile specifies the ISA features available to a
+supervisor-mode execution environment in 64-bit applications
+processors.  `rvb23p1s64` is based on and requires an `rvb23s64`
+implementation.
+
+==== `rvb23p1s64` Optional Extensions
+
+`rvb23p1s64` has the same unprivileged options as `rvb23u64`,
+
+The privileged options in `rvb23p1s64` are listed in the following
+sections and are additional options to the `rvb23s64` Profile.
+
+===== Localized Options
+
+There are no privileged localized options in `rvb23p1s64`.
+
+===== Development Options
+
+The following are new privileged development options in `rvb23p1s64`:
+
+- <<svrsw60t59b,**Svrsw60t59b**>> PTE reserved-for-software bits.
+
+NOTE: *Svrsw60t59b* is used to avoid optionality in Linux kernel page tables
+
+- <<ssdbltrap,**Ssdbltrap**>> Double Trap, which is included to make trap handling more robust
+
+===== Expansion Options
+
+The following are new privileged expansion options in `rvb23p1s64`:
+
+- <<sscfg,**Sscfg**>> Supervisor Counter Delegation.
+
+- <<ssctr,**Ssctr**>> Control Transfer Records, CTR.
+
+NOTE: *Ssctr* also implies inclusion of *Sscsrind* (indirect CSR access)
+
+- <<ssqosid,**Ssqosid**>> QoS identifiers.
+
+//


### PR DESCRIPTION
Intended for TSC review and approval

This has no changes to the normative text contents of the old v0.7 release before the ISA Manual integration of the Profiles as archived at https://github.com/riscv/riscv-profiles/tree/rva23p1-rvb23p1