### PR TITLE
GH Action build updates.

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -41,10 +41,45 @@ jobs:
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
+    # Cache generated diagram SVGs across runs. Key on all source files so any
+    # content change that could affect diagrams invalidates the cache. The
+    # restore-key fallback gives a partial hit when only some files changed,
+    # which still skips generation for unchanged diagrams.
+      - name: Cache diagram images
+        uses: actions/cache@v4
+        with:
+          path: build/images-out-cache
+          key: diagrams-${{ hashFiles('src/**') }}
+          restore-keys: |
+            diagrams-
+
+    # Cache the Docker image to avoid a full pull on every run.
+      - name: Cache Docker image
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/riscv-docs-image.tar
+          key: docker-${{ hashFiles('.github/workflows/isa-build.yml') }}
+
+      - name: Load or pull Docker image
+        run: |
+          if [ -f /tmp/riscv-docs-image.tar ]; then
+            docker load < /tmp/riscv-docs-image.tar
+          else
+            docker pull ghcr.io/riscv/riscv-docs-base-container-image:latest
+            docker save ghcr.io/riscv/riscv-docs-base-container-image:latest > /tmp/riscv-docs-image.tar
+          fi
+
     # Build PDF and HTML ISA manual versions and normative rule files using the container
       - name: Build Files
         id: build_files
         run: make -j$(nproc)
+
+    # Check cross-references (removed from default build target to avoid a
+    # redundant full HTML pass locally, but kept here for CI validation).
+      - name: Check cross-references
+        if: steps.build_files.outcome == 'success'
+        run: make check-xrefs
 
     # Upload the riscv-spec PDF file
       - name: Upload riscv-spec.pdf

--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -41,18 +41,6 @@ jobs:
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-    # Cache generated diagram SVGs across runs. Key on all source files so any
-    # content change that could affect diagrams invalidates the cache. The
-    # restore-key fallback gives a partial hit when only some files changed,
-    # which still skips generation for unchanged diagrams.
-      - name: Cache diagram images
-        uses: actions/cache@v4
-        with:
-          path: build/images-out-cache
-          key: diagrams-${{ hashFiles('src/**') }}
-          restore-keys: |
-            diagrams-
-
     # Cache the Docker image to avoid a full pull on every run.
       - name: Cache Docker image
         id: docker-cache

--- a/Makefile
+++ b/Makefile
@@ -90,20 +90,16 @@ WORKDIR_TEARDOWN = mv $@.workdir/$@ $@
 else
 WORKDIR_SETUP = \
     rm -rf $@.workdir && \
-    mkdir -p $@.workdir/build/images-out && \
-    mkdir -p $(SHARED_IMAGES_CACHE) && \
-    cp -n $(SHARED_IMAGES_CACHE)/* $@.workdir/build/images-out/ 2>/dev/null; true && \
+    mkdir -p $@.workdir && \
     ln -sfn ../../src ../../normative_rule_defs ../../docs-resources $@.workdir/
 
 WORKDIR_TEARDOWN = \
-    cp -n $@.workdir/build/images-out/* $(SHARED_IMAGES_CACHE)/ 2>/dev/null; true && \
     mv $@.workdir/$@ $@ && \
     rm -rf $@.workdir
 endif
 
 SRC_DIR := src
 BUILD_DIR := build
-SHARED_IMAGES_CACHE := $(BUILD_DIR)/images-out-cache
 NORM_RULE_DEF_DIR := normative_rule_defs
 DOC_NORM_TAG_SUFFIX := -norm-tags.json
 
@@ -243,5 +239,5 @@ docker-pull-latest:
 
 clean:
 	@echo "Cleaning up generated files..."
-	rm -rf $(BUILD_DIR) $(SHARED_IMAGES_CACHE)
+	rm -rf $(BUILD_DIR)
 	@echo "Cleanup completed."

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 RELEASE_DESCRIPTION_HTML := $(RELEASE_DESCRIPTION).  © RISC-V International, $(YEAR).
 
 DOCKER_BIN ?= docker
-DOCKER_INTERACTIVE=$(shell [ -t 0 ] && echo "-it --init")
+DOCKER_INTERACTIVE=--init $(shell [ -t 0 ] && echo "-t")
 SKIP_DOCKER ?= $(shell if command -v ${DOCKER_BIN}  >/dev/null 2>&1 ; then echo false; else echo true; fi)
 DOCKER_IMG := ghcr.io/riscv/riscv-docs-base-container-image:latest
 ifneq ($(SKIP_DOCKER),true)
@@ -90,16 +90,20 @@ WORKDIR_TEARDOWN = mv $@.workdir/$@ $@
 else
 WORKDIR_SETUP = \
     rm -rf $@.workdir && \
-    mkdir -p $@.workdir && \
+    mkdir -p $@.workdir/build/images-out && \
+    mkdir -p $(SHARED_IMAGES_CACHE) && \
+    cp -n $(SHARED_IMAGES_CACHE)/* $@.workdir/build/images-out/ 2>/dev/null; true && \
     ln -sfn ../../src ../../normative_rule_defs ../../docs-resources $@.workdir/
 
 WORKDIR_TEARDOWN = \
+    cp -n $@.workdir/build/images-out/* $(SHARED_IMAGES_CACHE)/ 2>/dev/null; true && \
     mv $@.workdir/$@ $@ && \
     rm -rf $@.workdir
 endif
 
 SRC_DIR := src
 BUILD_DIR := build
+SHARED_IMAGES_CACHE := $(BUILD_DIR)/images-out-cache
 NORM_RULE_DEF_DIR := normative_rule_defs
 DOC_NORM_TAG_SUFFIX := -norm-tags.json
 
@@ -173,7 +177,7 @@ update-ref: $(DOCS_NORM_TAGS)
 build-norm-rules-json: $(NORM_RULES_JSON)
 build-norm-rules-html: $(NORM_RULES_HTML)
 build-norm-rules: build-norm-rules-json build-norm-rules-html check-tags
-build: build-pdf build-html build-epub build-tags build-norm-rules-json build-norm-rules-html check-xrefs
+build: build-pdf build-html build-epub build-tags build-norm-rules-json build-norm-rules-html
 
 ALL_SRCS := $(shell git ls-files $(SRC_DIR))
 
@@ -239,5 +243,5 @@ docker-pull-latest:
 
 clean:
 	@echo "Cleaning up generated files..."
-	rm -rf $(BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(SHARED_IMAGES_CACHE)
 	@echo "Cleanup completed."


### PR DESCRIPTION
Cache the diagram images between runs.  Any PRs with just text changes all the entire diagram cache to be skipped. Cache the docker image.
Re-add the check-xrefs as a CI step.

Signed-off-by: Bill Traynor wmat@riscv.org