### PR TITLE
Fix bit-manipulation reference pseudocode

### DIFF
--- a/src/unpriv/zb.adoc
+++ b/src/unpriv/zb.adoc
@@ -872,7 +872,7 @@ function HighestSetBit32 x = {
 }
 
 let rs = X(rs);
-X[rd] = 31 - HighestSetBit(rs);
+X[rd] = 31 - HighestSetBit32(rs);
 --
 
 Included in::
@@ -1033,7 +1033,7 @@ Operation::
 val LowestSetBit : forall ('N : Int), 'N >= 0. bits('N) -> int
 
 function LowestSetBit x = {
-  foreach (i from 0 to (xlen - 1) by 1 in dec)
+  foreach (i from 0 to (xlen - 1) by 1 in inc)
     if [x[i]] == 0b1 then return(i) else ();
   return xlen;
 }
@@ -1088,7 +1088,7 @@ Operation::
 val LowestSetBit32 : forall ('N : Int), 'N >= 0. bits('N) -> int
 
 function LowestSetBit32 x = {
-  foreach (i from 0 to 31 by 1 in dec)
+  foreach (i from 0 to 31 by 1 in inc)
     if [x[i]] == 0b1 then return(i) else ();
   return 32;
 }
@@ -1713,7 +1713,7 @@ Operation::
 [source,sail]
 --
 result : xlenbits = EXTZ(0b0);
-foreach (i from 0 to sizeof(xlen) by 8) {
+foreach (i from 0 to (xlen - 8) by 8) {
     result[i+7..i] = reverse_bits_in_byte(X(rs1)[i+7..i]);
 };
 X(rd) = result;
@@ -2666,7 +2666,7 @@ function xperm8_lookup (idx, lut) = {
 
 function clause execute ( XPERM8 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
-    foreach(i from 0 to xlen by 8) {
+    foreach(i from 0 to (xlen - 8) by 8) {
         result[i+7..i] = xperm8_lookup(X(rs2)[i+7..i], X(rs1));
     };
     X(rd) = result;
@@ -2728,7 +2728,7 @@ function xperm4_lookup (idx, lut) = {
 
 function clause execute ( XPERM4 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
-    foreach(i from 0 to xlen by 4) {
+    foreach(i from 0 to (xlen - 4) by 4) {
         result[i+3..i] = xperm4_lookup(X(rs2)[i+3..i], X(rs1));
     };
     X(rd) = result;

--- a/src/unpriv/zk.adoc
+++ b/src/unpriv/zk.adoc
@@ -1231,7 +1231,7 @@ Operation::
 [source,sail]
 --
 result : xlenbits = EXTZ(0b0);
-foreach (i from 0 to sizeof(xlen) by 8) {
+foreach (i from 0 to (xlen - 8) by 8) {
     result[i+7..i] = reverse_bits_in_byte(X(rs1)[i+7..i]);
 };
 X(rd) = result;
@@ -3387,7 +3387,7 @@ function xperm8_lookup (idx, lut) = {
 
 function clause execute ( XPERM8 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
-    foreach(i from 0 to xlen by 8) {
+    foreach(i from 0 to (xlen - 8) by 8) {
         result[i+7..i] = xperm8_lookup(X(rs2)[i+7..i], X(rs1));
     };
     X(rd) = result;
@@ -3449,7 +3449,7 @@ function xperm4_lookup (idx, lut) = {
 
 function clause execute ( XPERM4 (rs2,rs1,rd)) = {
     result : xlenbits = EXTZ(0b0);
-    foreach(i from 0 to xlen by 4) {
+    foreach(i from 0 to (xlen - 4) by 4) {
         result[i+3..i] = xperm4_lookup(X(rs2)[i+3..i], X(rs1));
     };
     X(rd) = result;


### PR DESCRIPTION

This fixes a few small mistakes in the bit-manipulation reference pseudocode:

- stop the `brev8` and `xperm8`/`xperm4` loops at the last in-range byte/nibble
- make `clzw` call the 32-bit helper it defines, instead of the XLEN-wide helper
- make the `ctz`/`ctzw` loops count upward, matching the prose and the `cpop`/`cpopw` pattern

These are text/pseudocode corrections only; they do not change the intended architectural behavior.

