### PR TITLE
[RVBNA] Fixing typo on mask variables in comparison of RVBNA pseudo-code

### DIFF
--- a/src/unpriv/rvbna.adoc
+++ b/src/unpriv/rvbna.adoc
@@ -130,10 +130,10 @@ BulkNormalizedDotProduct(A[n], B[n]) {
         let prod_isZero = A_i_isZero || B_i_isZero
 
         // detecting corner cases
-        let A_i_isInf = (A_i_exp == maskExp) && (A_i_mant == 0)
-        let B_i_isInf = (B_i_exp == maskExp) && (B_i_mant == 0)
-        let A_i_isNaN = (A_i_exp == maskExp) && (A_i_mant != 0)
-        let B_i_isNaN = (B_i_exp == maskExp) && (B_i_mant != 0)
+        let A_i_isInf = (A_i_exp == maskExpLHS) && (A_i_mant == 0)
+        let B_i_isInf = (B_i_exp == maskExpRHS) && (B_i_mant == 0)
+        let A_i_isNaN = (A_i_exp == maskExpLHS) && (A_i_mant != 0)
+        let B_i_isNaN = (B_i_exp == maskExpRHS) && (B_i_mant != 0)
         let A_i_isSNaN = A_i_isNaN && (A_i_mant & (1 << (m_l - 1))) == 0
         let B_i_isSNaN = B_i_isNaN && (B_i_mant & (1 << (m_r - 1))) == 0
 


### PR DESCRIPTION
A and B no longer need to have the same format since the update of RVBNA description to support asymmetric formats. An update to exponent values used do detect Infs and NaNs was missing; this patch correct it.

Fixing issue reported in https://github.com/aswaterman/riscv-misc/issues/23 by @jrahmeh 