### PR TITLE
Clarify "otherwise" case in logic for no matching PMP

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -3579,8 +3579,8 @@ or U, then the operation succeeds only if the R, W, or X bit corresponding
 to the access type is set.#
 
 [#norm:pmp_no_entry_match]#If no PMP entry matches an M-mode memory operation, the operation succeeds.
-If no PMP entry matches an S-mode or U-mode memory operation, but at least
-one PMP entry is implemented, the operation fails.#
+If no PMP entry matches an S-mode or U-mode memory operation, the operation
+fails if at least one PMP entry is implemented and succeeds otherwise.#
 
 [NOTE]
 ====


### PR DESCRIPTION
Fixes #3187