### PR TITLE
style: uniform binary literal notation to 0b prefix

### DIFF
--- a/src/priv/cfi.adoc
+++ b/src/priv/cfi.adoc
@@ -277,9 +277,9 @@ either a store, an AMO, or a shadow stack instruction.
 ====
 
 Shadow stack instructions are restricted to accessing shadow stack
-(`pte.xwr=010b`) pages. [#norm:ssmp_ss_page_illegeal_access]#Should a shadow stack instruction access a page that is
+(`pte.xwr=0b010`) pages. [#norm:ssmp_ss_page_illegeal_access]#Should a shadow stack instruction access a page that is
 not designated as a shadow stack page and is not marked as read-only
-(`pte.xwr=001`), a store/AMO access-fault exception will be invoked.# [#norm:ssmp_ss_read_only_page]#Conversely,
+(`pte.xwr=0b001`), a store/AMO access-fault exception will be invoked.# [#norm:ssmp_ss_read_only_page]#Conversely,
 if the page being accessed by a shadow stack instruction is a read-only page, a
 store/AMO page-fault exception will be triggered.#
 
@@ -290,7 +290,7 @@ Shadow stack loads and stores will trigger a store/AMO page-fault if the
 accessed page is read-only, to support copy-on-write (COW) of a shadow stack
 page. If the page has been marked read-only for COW tracking, the page-fault
 handler responds by creating a copy of the page and updates the `pte.xwr` to
-`010b`, thereby designating each copy as a shadow stack page. Conversely, if
+`0b010`, thereby designating each copy as a shadow stack page. Conversely, if
 the access targets a genuinely read-only page, the fault being reported as a
 store/AMO page-fault signals to the operating system that the fault is fatal
 and non-recoverable. Reporting the fault as a store/AMO page-fault, even for
@@ -350,7 +350,7 @@ affect read access to a shadow stack page as the shadow stack page is always
 readable by all instructions that load from memory.
 
 The G-stage address translation and protections remain unaffected by the
-ext:zicfiss[] extension. The `xwr == 010b` encoding in the G-stage PTE remains reserved.
+ext:zicfiss[] extension. The `xwr == 0010` encoding in the G-stage PTE remains reserved.
 [#norm:active_g_stage_pte]#When G-stage page tables are active, the shadow stack instructions that access memory
 require the G-stage page table to have read-write permission for the accessed
 memory; else a store/AMO guest-page-fault exception is raised.#

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -773,23 +773,23 @@ not implemented, `CBCFE` is read-only zero.
 The Zicbom extension adds the `CBIE` (Cache Block Invalidate instruction Enable)
 WARL field to `henvcfg`. The `CBIE` field controls execution of the cache block
 invalidate instruction (`CBO.INVAL`) in privilege modes VS and VU. The encoding
-`10b` is reserved. When the Zicbom extension is not implemented, `CBIE` is
+`0b10` is reserved. When the Zicbom extension is not implemented, `CBIE` is
 read-only zero.
 
 [[norm:cbo-inval_h-mode_veq1_op]]
 When V=1, if the `CBO.INVAL` instruction is not HS-qualified, it raises an
 illegal-instruction exception. If the instruction is HS-qualified and the
-`CBIE` field is set to `01b` or `11b`, the instruction is enabled for execution;
+`CBIE` field is set to `0b01` or `0b11`, the instruction is enabled for execution;
 otherwise, it raises a virtual-instruction exception.
 
 [#norm:cbo-inval_h-mode_op0]#If `CBO.INVAL` is enabled in HS-mode to perform a flush operation, then when the
 instruction is enabled in VS- or VU-mode it performs a flush operation, even if
-`CBIE` is set to `11b`. Otherwise, when the instruction is enabled for
+`CBIE` is set to `0b11`. Otherwise, when the instruction is enabled for
 execution, its behavior depends on the `CBIE` encoding, as follows:#
 
-* [[norm:cbo-inval_h-mode_op1]]`01b` -- The instruction is executed and performs a flush operation, even if
+* [[norm:cbo-inval_h-mode_op1]]`0b01` -- The instruction is executed and performs a flush operation, even if
   configured by VS-mode to perform an invalidate operation.
-* [[norm:cbo-inval_h-mode_op2]]`11b` -- The instruction is executed and performs an invalidate operation,
+* [[norm:cbo-inval_h-mode_op2]]`0b11` -- The instruction is executed and performs an invalidate operation,
   unless configured by VS-mode to perform a flush operation.
 
 [[norm:henvcfg_pmm_op]]
@@ -827,7 +827,7 @@ apply when `V=1`:
 
 * 32-bit Zicfiss instructions will revert to their behavior as defined by Zimop.
 * 16-bit Zicfiss instructions will revert to their behavior as defined by Zcmop.
-* The `pte.xwr=010b` encoding in VS-stage page tables becomes reserved.
+* The `pte.xwr=0b010` encoding in VS-stage page tables becomes reserved.
 * The `senvcfg.SSE` field is read-only zero.
 * When `menvcfg.SSE` is one, `SSAMOSWAP.W/D` raises a virtual-instruction
   exception.

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2244,18 +2244,18 @@ instructions raise an illegal-instruction exception in modes less privileged tha
 [#norm:menvcfg_cbie_warl_op]#The Zicbom extension adds the `CBIE` (Cache Block Invalidate instruction Enable)
 WARL field to `menvcfg` to control execution of the cache block invalidate
 instruction (`CBO.INVAL`) in modes less privileged than M. When `CBIE` is set to
-`00b`, the instruction raises an illegal-instruction exception in modes less
+`0b00`, the instruction raises an illegal-instruction exception in modes less
 privileged than M.#
 [#norm:menvcfg_cbie_rdonly0]#When the Zicbom extension is not implemented, `CBIE` is read-only zero.#
-The encoding `10b` is reserved.
-[#norm:menvcfg_cbie_cbo-inval_op_lead-in]#When `CBIE` is set to `01b`
-or `11b`, and when enabled for execution in modes less privileged than M, it
+The encoding `0b10` is reserved.
+[#norm:menvcfg_cbie_cbo-inval_op_lead-in]#When `CBIE` is set to `0b01`
+or `0b11`, and when enabled for execution in modes less privileged than M, it
 behaves as follows:#
 
 [[norm:menvcfg_cbie_cbo-inval_op_list]]
-* `01b` -- The instruction is executed and performs a flush operation, even if
+* `0b01` -- The instruction is executed and performs a flush operation, even if
   configured by a mode less privileged than M to perform an invalidate operation.
-* `11b` -- The instruction is executed and performs an invalidate operation,
+* `0b11` -- The instruction is executed and performs an invalidate operation,
   unless configured by a mode less privileged than M to perform a flush
   operation.
 
@@ -2295,7 +2295,7 @@ the following rules apply to privilege modes that are less than M:#
 [[norm:menvcfg_sse_op_list]]
 * 32-bit Zicfiss instructions will revert to their behavior as defined by Zimop.
 * 16-bit Zicfiss instructions will revert to their behavior as defined by Zcmop.
-* The `pte.xwr=010b` encoding in VS/S-stage page tables becomes reserved.
+* The `pte.xwr=0b010` encoding in VS/S-stage page tables becomes reserved.
 * `SSAMOSWAP.W/D` raises an illegal-instruction exception.
 
 [#norm:menvcfg_sse_rdonly0]#When `menvcfg.SSE` is 0, the `henvcfg.SSE` and `senvcfg.SSE` fields are

--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -910,19 +910,19 @@ the Zicbom extension is not implemented, `CBCFE` is read-only zero.
 [[norm:senvcfg_cbie]]
 The Zicbom extension adds the `CBIE` (Cache Block Invalidate instruction Enable)
 WARL field to `senvcfg` to control execution of the `CBO.INVAL` instruction in
-U-mode. The encoding `10b` is reserved. When the Zicbom extension is not
+U-mode. The encoding `0b10` is reserved. When the Zicbom extension is not
 implemented, `CBIE` is read-only zero. Execution of `CBO.INVAL` in U-mode is
 enabled only if execution of the instruction is enabled for use in S-mode and
-`CBIE` is set to `01b` or `11b`; otherwise, an illegal-instruction exception is
+`CBIE` is set to `0b01` or `0b11`; otherwise, an illegal-instruction exception is
 raised.
 
 [#norm:cbo-inval_s-mode_op0]#If `CBO.INVAL` is enabled in S-mode to perform a flush operation, then when the
 instruction is enabled in U-mode it performs a flush operation, even if `CBIE`
-is set to `11b`. Otherwise, the instruction behaves as follows, depending on the
+is set to `0b11`. Otherwise, the instruction behaves as follows, depending on the
 `CBIE` encoding:#
 
-* [[norm:cbo-inval_s-mode_op1]]`01b` -- The instruction is executed and performs a flush operation.
-* [[norm:cbo-inval_s-mode_op2]]`11b` -- The instruction is executed and performs an invalidate operation.
+* [[norm:cbo-inval_s-mode_op1]]`0b01` -- The instruction is executed and performs a flush operation.
+* [[norm:cbo-inval_s-mode_op2]]`0b11` -- The instruction is executed and performs an invalidate operation.
 
 [[norm:senvcfg_pmm_Ssnpm]]
 If the Ssnpm extension is implemented, the `PMM` field enables or disables

--- a/src/unpriv/vector-common.adoc
+++ b/src/unpriv/vector-common.adoc
@@ -2257,7 +2257,7 @@ a misspeculation-recovery mechanism.
 ==== Vector Arithmetic Instruction Formats
 
 The vector arithmetic instructions use a new major opcode (OP-V =
-1010111~2~) which neighbors OP-FP.  The three-bit `funct3` field is
+0b1010111) which neighbors OP-FP.  The three-bit `funct3` field is
 used to define sub-categories of vector instructions.
 
 include::images/wavedrom/valu-format.edn[]


### PR DESCRIPTION
Made a few changes to uniform the notation for binary literal to 0b prefix from 01, 10, 10b or (10)₂ wherever encountered to address the formatting inconsistency mentioned in issue #3137