### PR TITLE
Improve HTML rendering a bit

### DIFF
--- a/src/docinfo.html
+++ b/src/docinfo.html
@@ -1,27 +1,27 @@
 <style>
-  /* Only apply indicators to the first level of items with submenus */
-  #toc ul.sectlevel1 > li.has-children > a::before {
+  /* Apply indicators across all nested list layers */
+  #toc li.has-children > a::before {
     content: "▼ ";
     font-size: 0.8em;
     cursor: pointer;
   }
 
-  #toc ul.sectlevel1 > li.has-children.collapsed > a::before {
+  #toc li.has-children.collapsed > a::before {
     content: "▶ ";
   }
 
-  /* Only hide the direct submenu under the first level */
-  #toc ul.sectlevel1 > li.collapsed > ul {
+  /* Hide the local child list when its specific parent is collapsed */
+  #toc li.collapsed > ul {
     display: none;
   }
 </style>
 
 <script>
   document.addEventListener("DOMContentLoaded", function() {
-    // Target strictly the list items at the very first level
-    const topLevelItems = document.querySelectorAll("#toc ul.sectlevel1 > li");
+    // Universal selector targets all items within the table of contents
+    const allItems = document.querySelectorAll("#toc li");
 
-    topLevelItems.forEach(function(item) {
+    allItems.forEach(function(item) {
       const subList = item.querySelector(":scope > ul");
 
       if (subList) {

--- a/src/docinfo.html
+++ b/src/docinfo.html
@@ -1,4 +1,11 @@
 <style>
+/* Strip default gray background from typewriter font */
+code {
+  background:transparent !important;
+  padding:0 !important;
+  border:none !important;
+}
+
 /*
 Any ID starting with 'norm:' is a snippet of specification text
 that has been specifically tagged to allow referencing it robustly,

--- a/src/docinfo.html
+++ b/src/docinfo.html
@@ -1,4 +1,45 @@
 <style>
+  /* Only apply indicators to the first level of items with submenus */
+  #toc ul.sectlevel1 > li.has-children > a::before {
+    content: "▼ ";
+    font-size: 0.8em;
+    cursor: pointer;
+  }
+
+  #toc ul.sectlevel1 > li.has-children.collapsed > a::before {
+    content: "▶ ";
+  }
+
+  /* Only hide the direct submenu under the first level */
+  #toc ul.sectlevel1 > li.collapsed > ul {
+    display: none;
+  }
+</style>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    // Target strictly the list items at the very first level
+    const topLevelItems = document.querySelectorAll("#toc ul.sectlevel1 > li");
+
+    topLevelItems.forEach(function(item) {
+      const subList = item.querySelector(":scope > ul");
+
+      if (subList) {
+        item.classList.add("has-children");
+        item.classList.add("collapsed"); // Collapsed by default on load
+
+        const link = item.querySelector(":scope > a");
+        if (link) {
+          link.addEventListener("click", function(e) {
+            item.classList.toggle("collapsed");
+          });
+        }
+      }
+    });
+  });
+</script>
+
+<style>
 /* Strip default gray background from typewriter font */
 code {
   background:transparent !important;


### PR DESCRIPTION
First of all, make the ToC collapsable:

<img width="296" height="208" alt="Screenshot 2026-06-19 at 5 36 25 PM" src="https://github.com/user-attachments/assets/6329f8af-9ac7-4fb9-921d-ef2a659fdca6" />

<img width="296" height="1275" alt="Screenshot 2026-06-19 at 5 38 16 PM" src="https://github.com/user-attachments/assets/37bad373-4ef3-40e8-a6ad-b99e99d62dfb" />


Second, the light gray background and extra padding around typewriter font `foo` is pretty ugly.  Override the default formatting.  No change to PDF backend.  No change to multi-line code blocks.

Before:

<img width="972" height="56" alt="Screenshot 2026-06-11 at 6 50 59 PM" src="https://github.com/user-attachments/assets/d16879c2-433c-4f74-ad27-6fbdeab7c316" />

After:

<img width="967" height="53" alt="Screenshot 2026-06-11 at 6 47 17 PM" src="https://github.com/user-attachments/assets/16b88646-d604-49a1-a060-4c6b2c529049" />
