### PR TITLE
Don't use sed to satisfy pre-commit for generated files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 ---
+# Exclude ref/*.json files from pre-commit because they are automatically generated.
+exclude: |
+  (?x)^(
+    ref/.*\.json
+  )$
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -163,12 +163,9 @@ check-xref-fallbacks: $(DOCS_HTML)
 check-tags:
 	@bash ./scripts/check-tag-changes.sh
 
-# Copy built normative tags JSON files to ref directory and use sed to ensure they end with a newline.
-# Required by GitHub pre-commit checks for this repo.
+# Copy built normative tags JSON files to ref directory.
 update-ref: $(DOCS_NORM_TAGS)
-	cp -f $(DOCS_NORM_TAGS) ref
-	sed -i .bak -e '$$a\' ref/*.json
-	rm ref/*.bak
+	cp -f $(DOCS_NORM_TAGS) ref/
 
 build-norm-rules-json: $(NORM_RULES_JSON)
 build-norm-rules-html: $(NORM_RULES_HTML)


### PR DESCRIPTION
Instead of hackily using `sed` to remove a newline to make pre-commit happy about the tags JSON, just exclude that file from pre-commit checks because it's generated anyway.