### PR TITLE
Clarify silent-store optimization for spinlocks

### DIFF
--- a/src/unpriv/mm-explanatory.adoc
+++ b/src/unpriv/mm-explanatory.adoc
@@ -1707,6 +1707,7 @@ are redundant with other PPO rules under RVTSO assumptions
 
 Other general notes:
 
+[[sec:silent-stores]]
 * Silent stores (i.e., stores that write the same value that already
 exists at a memory location) behave like any other store from a memory
 model point of view. Likewise, AMOs which do not actually change the

--- a/src/unpriv/zaamo.adoc
+++ b/src/unpriv/zaamo.adoc
@@ -49,9 +49,7 @@ implementation can guarantee the AMO eventually completes. More complex
 implementations might also implement AMOs at memory controllers, and can
 optimize away fetching the original value when the destination is `x0`.
 Implementations that detect silent stores may reduce write traffic for
-AMOs such as insn:amomax[] or insn:amoor[] when they do not change the
-value in memory. This can be beneficial for spinlocks, where lower store
-traffic reduces contention (see <<sec:silent-stores, silent stores>>).
+AMOs when they do not change the value in memory (see <<sec:silent-stores>>).
 
 The set of AMOs was chosen to support the C11/C++11 atomic memory
 operations efficiently, and also to support parallel reductions in

--- a/src/unpriv/zaamo.adoc
+++ b/src/unpriv/zaamo.adoc
@@ -48,6 +48,10 @@ can implement AMOs using the LR/SC primitives, provided the
 implementation can guarantee the AMO eventually completes. More complex
 implementations might also implement AMOs at memory controllers, and can
 optimize away fetching the original value when the destination is `x0`.
+Implementations that detect silent stores may reduce write traffic for
+AMOs such as insn:amomax[] or insn:amoor[] when they do not change the
+value in memory. This can be beneficial for spinlocks, where lower store
+traffic reduces contention (see <<sec:silent-stores, silent stores>>).
 
 The set of AMOs was chosen to support the C11/C++11 atomic memory
 operations efficiently, and also to support parallel reductions in


### PR DESCRIPTION
This PR adds a non-normative note describing an implementation optimization that is not obvious from any single section of the ISA. The note is explanatory only and does not introduce a new algorithm. In contended spinlocks, silent-store detection can reduce write traffic for `amomax` or `amoor` in the retry loop.

```asm
        la      t0, lock
        li      t1, 1
again:
        amomax.w.aq     t1, t1, (t0)    # silent store when lock == 1
        bnez            t1, again
```
The effect is similar to test-and-test-and-set (TTAS) spinlock behavior, but without the initial optimistic load.