### PR TITLE
add missing AIA CSRs (duplicate pull request with signature)

### DIFF
--- a/src/priv/csrs.adoc
+++ b/src/priv/csrs.adoc
@@ -379,8 +379,16 @@ Note that not all registers are required on all implementations.
 |`0x304` |MRW |csr:mie[]        |Machine interrupt-enable register
 |`0x305` |MRW |csr:mtvec[]      |Machine trap-handler base address
 |`0x306` |MRW |csr:mcounteren[] |Machine counter enable
+|`0x308` |MRW |csr:mvien[]      |Machine virtual interrupt enables
+|`0x309` |MRW |csr:mvip[]       |Machine virtual interrupt-pending bits
 |`0x310` |MRW |csr:mstatush[]   |Upper qty:32[bits] of csr:mstatus[], RV32 only
 |`0x312` |MRW |csr:medelegh[]   |Upper qty:32[bits] of csr:medeleg[], RV32 only
+|`0x313` |MRW |csr:midelegh[]   |Upper qty:32[bits] of csr:mideleg[], RV32 only
+|`0x314` |MRW |csr:mieh[]       |Upper qty:32[bits] of csr:mie[], RV32 only
+|`0x318` |MRW |csr:mvienh[]     |Upper qty:32[bits] of csr:mvien[], RV32 only
+|`0x319` |MRW |csr:mviph[]      |Upper qty:32[bits] of csr:mvip[], RV32 only
+|`0x35C` |MRW |csr:mtopei[]     |Machine top external interrupt (only with an IMSIC)
+|`0xFB0` |MRO |csr:mtopi[]      |Machine top interrupt
 
 4+^|Machine Trap Handling
 
@@ -391,6 +399,7 @@ Note that not all registers are required on all implementations.
 |`0x344` |MRW |csr:mip[]      |Machine interrupt pending
 |`0x34A` |MRW |csr:mtinst[]   |Machine trap instruction (transformed)
 |`0x34B` |MRW |csr:mtval2[]   |Machine second trap value
+|`0x354` |MRW |csr:miph[]     |Upper qty:32[bits] of csr:mip[], RV32 only
 
 4+^|Machine Indirect
 


### PR DESCRIPTION
add missing AIA CSRs (mvien, mvip, midelegh, mieh, mvienh, mviph, mtopei, miph)
to priv/csrs.adoc from Advanced Interrupt Architecture docs at https://github.com/riscv/riscv-aia/blob/main/src/CSRs.adoc