### PR TITLE
Change wording in memory model to be less ambiguous

### DIFF
--- a/src/unpriv/mm-explanatory.adoc
+++ b/src/unpriv/mm-explanatory.adoc
@@ -1710,12 +1710,11 @@ Other general notes:
 [[silent-stores]]
 * Silent stores (i.e., stores that write the same value that already
 exists at a memory location) behave like any other store from a memory
-model point of view. Likewise, AMOs which do not actually change the
-value in memory (e.g., an AMOMAX for which the value in _rs2_ is smaller
-than the value currently in memory) are still semantically considered
-store operations. Microarchitectures that attempt to implement silent
-stores must take care to ensure that the memory model is still obeyed,
-particularly in cases such as RSW <<mm-overlap>>
+model point of view. Likewise, even when an AMO does not change the value
+in memory (e.g., an insn:amomax[] when the current memory value ≥ _rs2_),
+it is still semantically considered a store operation. Microarchitectures
+that attempt to implement silent stores must take care to ensure that the
+memory model is still obeyed, particularly in cases such as RSW <<mm-overlap>>
 which tend to be incompatible with silent stores.
 * Writes may be merged (i.e., two consecutive writes to the same address
 may be merged) or subsumed (i.e., the earlier of two back-to-back writes


### PR DESCRIPTION
> Likewise, AMOs which do not actually change the value in memory...

Could be misread as some AMOs don't change memory when not needed (e.g., amomax), while others always do (e.g., amoswap).

> Likewise, even when an AMO does not change the value in memory...

This makes it clear it's about executions (data-dependent), not instruction properties.