### PR TITLE
State c.jal is only in XLEN=32 Zca

### DIFF
--- a/src/unpriv/zca.adoc
+++ b/src/unpriv/zca.adoc
@@ -53,8 +53,10 @@ double-precision loads and stores are used in LP64D and ILP32D--hence the
 motivation to provide compressed support for these in the XLEN=32-only extlink:zcf[]
 extension.
 
+[[c-jal-rv32-rationale]]
 Short-range subroutine calls are more likely in small binaries for
-microcontrollers, hence the motivation to include these in ext:zca[].
+microcontrollers, hence the motivation to include insn:c.jal[] only in the
+XLEN=32 variant of ext:zca[].
 
 Although reusing opcodes for different purposes for different base ISAs
 adds some complexity to documentation, the impact on implementation
@@ -403,7 +405,7 @@ insn:jal[x0,offset].#
 [#norm:c-jal_op]#insn:c.jal[] is an XLEN=32-only instruction that performs the same operation as
 insn:c.j[], but additionally writes the address of the instruction following
 the jump (`pc+2`) to the link register, `x1`. It expands to
-insn:jal[x1,offset].#
+insn:jal[x1,offset].# (See <<c-jal-rv32-rationale, XLEN=32-only rationale>>.)
 
 [[c-cr-format-ls]]
 include::images/wavedrom/c-cr-format-ls.edn[]


### PR DESCRIPTION
The sentence was vague and could be read as applying to Zca in general.

I also checked static binaries and shared libraries; `c.addiw` appears about 1.74x more often than `c.jal` would in static binaries on average, and about 2.16x more often in shared libraries. It might be worth adding to the rationale that `c.addiw` is more frequent in larger RV64 codebases.