### PR TITLE
Connect unprivileged to privileged references

### DIFF
--- a/src/unpriv/cfi.adoc
+++ b/src/unpriv/cfi.adoc
@@ -64,8 +64,9 @@ provide backward-edge and forward-edge CFI respectively.
 
 The Unprivileged ISA for ext:zicfilp[] extension is specified in <<ext:zicfilp>>
 and for the Unprivileged ISA for ext:zicfiss[] extension is specified in
-<<ext:zicfiss>>. The Privileged ISA for these extensions is specified in the
-Privileged ISA specification.
+<<ext:zicfiss>>. The Privileged ISA for ext:zicfilp[] extension is specified in
+<<priv-forward>> and for the Privileged ISA for ext:zicfiss[] extension is
+specified in <<priv-backward>>.
 
 [[ext:zicfilp]]
 ==== ext:zicfilp[] for Landing Pad

--- a/src/unpriv/mm-explanatory.adoc
+++ b/src/unpriv/mm-explanatory.adoc
@@ -1101,9 +1101,8 @@ RVWMO does not currently attempt to formally describe how FENCE.I,
 SFENCE.VMA, I/O fences, and PMAs behave. All of these behaviors will be
 described by future formalizations. In the meantime, the behavior of
 insn:fence.i[] is described in extlink:zifencei[], the
-behavior of SFENCE.VMA is described in the RISC-V Instruction Set
-Privileged Architecture Manual, and the behavior of I/O fences and the
-effects of PMAs are described below.
+behavior of SFENCE.VMA is described in <<sfence.vma>>, and the behavior
+of I/O fences and the effects of PMAs are described below.
 
 ===== Coherence and Cacheability
 

--- a/src/unpriv/zk.adoc
+++ b/src/unpriv/zk.adoc
@@ -3778,8 +3778,7 @@ there is insufficient seeding material for the host DRBG.
 ===== Access Control to csr:seed[]
 
 The ext:zkr[] extension adds the csr::[sseed] and csr::[useed] fields to the csr:mseccfg[] CSR to
-control access to the csr:seed[] CSR from U, S, or HS modes (see Privileged ISA
-specification).
+control access to the csr:seed[] CSR from U, S, or HS modes (see <<sec:mseccfg>>).
 
 Systems should implement carefully considered access control policies from
 lower privilege modes to physical entropy sources. The system can trap


### PR DESCRIPTION
Since the two specifications were merged, each can cross-reference the other.