### PR TITLE
Align Zicbom cache-block management faults with the CMO chapter

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -3407,12 +3407,15 @@ include::images/bytefield/pmpcfg.edn[]
 
 [#norm:pmp_exec_fault]#Attempting to fetch an instruction from a PMP region that does not have
 execute permissions raises an instruction access-fault exception.#
-[#norm:pmp_load_fault]#Attempting to execute a load, load-reserved, or cache-block management instruction which accesses
+[#norm:pmp_load_fault]#Attempting to execute a load or load-reserved instruction which accesses
 a physical address within a PMP region without read permissions raises a
 load access-fault exception.# [#norm:pmp_store_fault]#Attempting to execute a store,
 store-conditional, AMO, or cache-block zero instruction which accesses a physical address
 within a PMP region without write permissions raises a store
 access-fault exception.#
+[#norm:pmp_cbm_fault]#The permissions required for a cache-block management instruction to access
+a PMP region are defined in <<cmo>>; when such access is not permitted, the instruction raises a
+store access-fault exception.#
 
 ===== Address Matching
 

--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -1563,12 +1563,15 @@ Read-write-execute page.
 
 [#norm:fetch_page_fault_no_x]#Attempting to fetch an instruction from a page that does not have
 execute permissions raises a fetch page-fault exception.#
-[#norm:load_page_fault_no_r]#Attempting to execute a load, load-reserved, or cache-block management
+[#norm:load_page_fault_no_r]#Attempting to execute a load or load-reserved
 instruction whose effective address lies
 within a page without read permissions raises a load page-fault exception.#
-[#norm:store_page_fault_no_w]#Attempting to execute a store, store-conditional, AMO, or cache-block zero instruction
+[#norm:store_page_fault_no_w]#Attempting to execute a store, store-conditional, AMO, or cache-block zero
 instruction whose effective address lies within a page without write
 permissions raises a store page-fault exception.#
+[#norm:cbm_page_fault]#The permissions required for a cache-block management instruction are
+defined in <<cmo>>; when address translation does not permit any access, the instruction raises a
+store page-fault exception.#
 
 [NOTE]
 ====


### PR DESCRIPTION
The privileged spec currently lists `cbo.inval`/`cbo.clean`/`cbo.flush` with loads in the PMP and page-fault rules, implying read permission and load-class faults.

The ratified CMO chapter instead permits these instructions whenever load or store access is permitted, leaves the fetch-only case unspecified, and reports store-class faults when access is not permitted.

That permission rule is over the effective (translation and PMP) permissions, so it cannot be restated by the per-layer privileged fault rules without wrongly faulting read-only or fetch-only regions. This patch removes cache-block management from the load rules and defers its permission requirements to the CMO chapter, reporting the resulting faults as store-class: a store access-fault for PMP, and a store page-fault when address translation permits no access.

It also removes a duplicated "instruction" in the store page-fault sentence. `cbo.zero` is already store-type and is unchanged.