### PR TITLE
Improve Zkr example

### DIFF
--- a/src/unpriv/zk.adoc
+++ b/src/unpriv/zk.adoc
@@ -3643,9 +3643,10 @@ false positive in the continuous testing procedures. In case of a fatal
 failure, an immediate lockdown may also be an appropriate response in
 dedicated security devices.
 
-**Example.** `0x8000ABCD` is a valid `ES16` status output, with `0xABCD`
-being the csr::[entropy] value. `0xFFFFFFFF` is an invalid output (`DEAD`) with
-no csr::[entropy] value.
+**Example.**
+The csr:seed[] value `0x8000ABCD` is a valid ES16 status output, with 0xABCD being the entropy value.
+The value `0xC0000000` indicates the entropy value is invalid because the entropy source is DEAD.
+The value `0xC0000001` cannot occur because the seed must be 0 if the status is not ES16.
 
 [[crypto_scalar_es_state,reftext="Entropy Source State Transition Diagram"]]
 ====


### PR DESCRIPTION
h/t @allenjbaum, who pointed out that the use of an impossible CSR value `0xffffffff` was ambiguous, as it wasn't clear in context whether "invalid" meant "impossible" or "bad entropy".