### PR TITLE
Fix RLB wording and tag hgatp ordering note

### DIFF
--- a/normative_rule_defs/hypervisor.yaml
+++ b/normative_rule_defs/hypervisor.yaml
@@ -275,6 +275,8 @@ normative_rule_definitions:
     tags: ["norm:hgatp_vmid"]
   - name: hgatp_vmid_lsbs
     tags: ["norm:hgatp_vmid_lsbs"]
+  - name: hgatp_op_hfence_gvma
+    tags: ["norm:hgatp_op_hfence_gvma"]
   - names: [vsstatus_sz, vsstatus_acc, vsstatus_op]
     tags: ["norm:vsstatus_sz_acc_op"]
   - name: vsstatus_uxl_op

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -1103,6 +1103,7 @@ This definition simplifies the implementation of speculative execution
 of HLV, HLVX, and HSV instructions.
 ====
 
+[[norm:hgatp_op_hfence_gvma]]
 Note that writing `hgatp` does not imply any ordering constraints
 between page-table updates and subsequent G-stage address translations.
 If the new virtual machine’s guest physical page tables have been

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2378,9 +2378,9 @@ The Smepmp extension adds the `RLB`, `MMWP`, and the `MML` fields in
 `mseccfg`.
 
 [[norm:mseccfg_rlb_op_warl]]
-When `mseccfg.RLB` (Rule Locking Bypass) a WARL field that provides a mechanism
+`mseccfg.RLB` (Rule Locking Bypass) is a WARL field that provides a mechanism
 to temporarily modify *Locked* PMP rules. When `mseccfg.RLB` is 1, locked PMP
-rules may be removed or modified and locked PMP rules may be edited. When
+rules may be removed or modified. When
 `mseccfg.RLB` is 0 and `pmpcfg.L` is 1 in any rule or entry (including disabled
 entries), then `mseccfg.RLB` remains 0 and any further modifications to
 `mseccfg.RLB` are ignored until a *PMP reset*.


### PR DESCRIPTION
Fixes a broken RLB sentence and removes a redundant phrase.

Also adds the missing norm anchor to the hgatp ordering note, matching the existing satp note.