### PR TITLE
Clarify MML rule effective privilege

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2418,13 +2418,15 @@ until a *PMP reset*.#
   *S/U-mode-only* when unset. The formerly reserved encoding of `pmpcfg.RW=01`,
   and the encoding `pmpcfg.LRWX=1111`, now encode a *Shared-Region*.#          +
                                                                                +
-  [#norm:mseccfg_mml_M_rule_op]#An _M-mode-only_ rule is *enforced* on Machine mode and *denied* in Supervisor
-  or User mode. It also remains *locked* so that any further modifications to
-  its associated configuration or address registers are ignored until a *PMP
-  reset*, unless `mseccfg.RLB` is set.#                                        +
+  [#norm:mseccfg_mml_M_rule_op]#An _M-mode-only_ rule is *enforced* on accesses whose effective privilege
+  mode is Machine and *denied* to accesses whose effective privilege mode is Supervisor
+  or User. It also remains *locked* so that any further modifications to its
+  associated configuration or address registers are ignored until a *PMP reset*,
+  unless `mseccfg.RLB` is set.#                                                +
                                                                                +
-  [#norm:mseccfg_mml_SorU_rule_op]#An _S/U-mode-only_ rule is *enforced* on Supervisor and User modes and
-  *denied* on Machine mode.#                                                   +
+  [#norm:mseccfg_mml_SorU_rule_op]#An _S/U-mode-only_ rule is *enforced* on accesses whose effective privilege
+  mode is Supervisor or User and *denied* to accesses whose effective privilege
+  mode is Machine.#                                                           +
                                                                                +
   [#norm:mseccfg_mml_shared_rule_op]#A _Shared-Region_ rule is *enforced* on all modes, with restrictions depending
   on the `pmpcfg.L` and `pmpcfg.X` bits:#                                      +


### PR DESCRIPTION
Clarifies the MML M-mode-only and S/U-only rule descriptions to use effective privilege mode consistently.

MPRV is already defined as modifying the effective privilege mode for explicit memory accesses, and the PMP chapter already says PMP checks are applied based on effective privilege mode. The old MML wording used mode names directly, which can be read as current hart mode rather than the effective mode used by PMP.

This patch updates both MML rule descriptions symmetrically:
- M-mode-only rules are enforced for Machine-effective accesses and denied to Supervisor/User-effective accesses
- S/U-mode-only rules are enforced for Supervisor/User-effective accesses and denied to Machine-effective accesses

No behavior change - just terminology alignment with the existing text.

Shared-Region wording is left unchanged intentionally.