### PR TITLE
Include Zalasr in the misaligned atomicity granule PMA scope

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -3080,9 +3080,11 @@ a naturally aligned power-of-two number of bytes.
 Specific supported values for this PMA are represented by MAG__NN__, e.g.,
 MAG16 indicates the misaligned atomicity granule is at least 16 bytes.
 
-[#norm:pma_mag_insts]#The misaligned atomicity granule PMA applies only to AMOs, loads and stores
-defined in the base ISAs, and loads and stores of no more than XLEN bits
-defined in the F, D, and Q extensions, and compressed encodings thereof.#
+[#norm:pma_mag_insts]#The misaligned atomicity granule PMA applies only to AMOs; loads and stores
+defined in the base ISAs; loads and stores of no more than XLEN bits
+defined in the ext:f[], ext:d[], and ext:q[] extensions; the load-acquire and
+store-release instructions defined in the ext:zalasr[] extension; and compressed
+encodings of the foregoing loads and stores.#
 For an instruction in that set, [#norm:pma_mag_op_within]#if all accessed bytes lie within the same
 misaligned atomicity granule, the instruction will not raise an exception for
 reasons of address alignment, and the instruction will give rise to only one

--- a/src/unpriv/rvwmo.adoc
+++ b/src/unpriv/rvwmo.adoc
@@ -102,7 +102,9 @@ misaligned atomic instructions at all.
 However, [#norm:rvwmo_misaligned_in_atomic_pma]#if misaligned atomics are supported via the
 misaligned atomicity granule PMA, then AMOs within an atomicity granule are not decomposed, nor are
 loads and stores defined in the base ISAs, nor are loads and stores of no more
-than XLEN bits defined in the ext:f[], ext:d[], and ext:q[] extensions.#
+than XLEN bits defined in the ext:f[], ext:d[], and ext:q[] extensions, nor are
+the load-acquire and store-release instructions defined in the ext:zalasr[] extension,
+nor are compressed encodings of the foregoing loads and stores.#
 [NOTE]
 ====
 The decomposition of misaligned memory operations down to byte

--- a/src/unpriv/zaamo.adoc
+++ b/src/unpriv/zaamo.adoc
@@ -26,9 +26,11 @@ not be emulated.
 optionally relaxes this alignment requirement.
 If present, the misaligned atomicity granule PMA specifies the size
 of a misaligned atomicity granule, a power-of-two number of bytes.
-The misaligned atomicity granule PMA applies only to AMOs, loads and stores
-defined in the base ISAs, and loads and stores of no more than XLEN bits
-defined in the ext:f[], ext:d[], and ext:q[] extensions, and compressed encodings thereof.
+The misaligned atomicity granule PMA applies only to AMOs; loads and stores
+defined in the base ISAs; loads and stores of no more than XLEN bits
+defined in the ext:f[], ext:d[], and ext:q[] extensions; the load-acquire and
+store-release instructions defined in the ext:zalasr[] extension; and compressed
+encodings of the foregoing loads and stores.
 For an instruction in that set, if all accessed bytes lie within the same
 misaligned atomicity granule, the instruction will not raise an exception for
 reasons of address alignment, and the instruction will give rise to only one


### PR DESCRIPTION
The MAG PMA scope is stated as a closed list in machine.adoc, restated in zaamo.adoc, with a parallel RVWMO decomposition list in rvwmo.adoc. Those lists omit Zalasr load-acquire/store-release instructions, even though the Zalasr chapter says this same PMA can relax their alignment requirement.

This patch updates the three lists. It also keeps compressed load/store encodings explicit in the MAG/RVWMO lists, and switches the privileged F/D/Q references to ext: macros for consistency.

This is an intentional change to normatively tagged scope text. I left ref/riscv-spec-norm-tags.json unchanged so the existing NormRules workflow can handle reference/CSC tracking separately, without expanding this patch into a broad registry refresh.

The optional nature of the PMA and the Zalasr alignment semantics are unchanged.