### PR TITLE
Add missing AIA CSRs to priv/csrs.adoc

### DIFF
--- a/src/priv/csrs.adoc
+++ b/src/priv/csrs.adoc
@@ -204,6 +204,7 @@ Note that not all registers are required on all implementations.
 |`0x104` |SRW |csr:sie[]        |Supervisor interrupt-enable register
 |`0x105` |SRW |csr:stvec[]      |Supervisor trap handler base address
 |`0x106` |SRW |csr:scounteren[] |Supervisor counter enable
+|`0x114` |SRW |csr:sieh[]       |Upper qty:32[bits] of csr:sie[], RV32 only
 
 4+^|Supervisor Configuration
 
@@ -220,7 +221,10 @@ Note that not all registers are required on all implementations.
 |`0x142` |SRW |csr:scause[]    |Supervisor trap cause
 |`0x143` |SRW |csr:stval[]     |Supervisor trap value
 |`0x144` |SRW |csr:sip[]       |Supervisor interrupt pending
+|`0x154` |SRW |csr:siph[]      |Upper qty:32[bits] of csr:sip[], RV32 only
+|`0x15C` |SRW |csr:stopei[]    |Supervisor top external interrupt
 |`0xDA0` |SRO |csr:scountovf[] |Supervisor count overflow
+|`0xDB0` |SRO |csr:stopi[]     |Supervisor top interrupt
 
 4+^|Supervisor Indirect
 
@@ -281,7 +285,15 @@ Note that not all registers are required on all implementations.
 |`0x604` |HRW |csr:hie[]        |Hypervisor interrupt-enable register
 |`0x606` |HRW |csr:hcounteren[] |Hypervisor counter enable
 |`0x607` |HRW |csr:hgeie[]      |Hypervisor guest external interrupt-enable register
+|`0x608` |HRW |csr:hvien[]      |Hypervisor virtual interrupt enables
+|`0x609` |HRW |csr:hvictl[]     |Hypervisor virtual interrupt control
 |`0x612` |HRW |csr:hedelegh[]   |Upper qty:32[bits] of csr:hedeleg[], RV32 only
+|`0x613` |HRW |csr:hidelegh[]   |Upper qty:32[bits] of csr:hideleg[], RV32 only
+|`0x618` |HRW |csr:hvienh[]     |Upper qty:32[bits] of csr:hvien[], RV32 only
+|`0x646` |HRW |csr:hviprio1[]   |Hypervisor VS-level interrupt priorities
+|`0x647` |HRW |csr:hviprio2[]   |Hypervisor VS-level interrupt priorities
+|`0x656` |HRW |csr:hviprio1h[]  |Upper qty:32[bits] of csr:hviprio1[], RV32 only
+|`0x657` |HRW |csr:hviprio2h[]  |Upper qty:32[bits] of csr:hviprio2[], RV32 only
 
 4+^|Hypervisor Trap Handling
 
@@ -289,6 +301,7 @@ Note that not all registers are required on all implementations.
 |`0x644` |HRW |csr:hip[]    |Hypervisor interrupt pending
 |`0x645` |HRW |csr:hvip[]   |Hypervisor virtual interrupt pending
 |`0x64A` |HRW |csr:htinst[] |Hypervisor trap instruction (transformed)
+|`0x655` |HRW |csr:hviph[]  |Upper qty:32[bits] of csr:hvip[], RV32 only
 |`0xE12` |HRO |csr:hgeip[]  |Hypervisor guest external interrupt pending
 
 4+^|Hypervisor Configuration
@@ -325,12 +338,16 @@ Note that not all registers are required on all implementations.
 |`0x200` |HRW |csr:vsstatus[]  |Virtual supervisor status register
 |`0x204` |HRW |csr:vsie[]      |Virtual supervisor interrupt-enable register
 |`0x205` |HRW |csr:vstvec[]    |Virtual supervisor trap handler base address
+|`0x214` |HRW |csr:vsieh[]     |Upper qty:32[bits] of csr:vsie[], RV32 only
 |`0x240` |HRW |csr:vsscratch[] |Virtual supervisor scratch register
 |`0x241` |HRW |csr:vsepc[]     |Virtual supervisor exception program counter
 |`0x242` |HRW |csr:vscause[]   |Virtual supervisor trap cause
 |`0x243` |HRW |csr:vstval[]    |Virtual supervisor trap value
 |`0x244` |HRW |csr:vsip[]      |Virtual supervisor interrupt pending
+|`0x254` |HRW |csr:vsiph[]     |Upper qty:32[bits] of csr:vsip[], RV32 only
+|`0x25C` |HRW |csr:vstopei[]   |Virtual supervisor top external interrupt
 |`0x280` |HRW |csr:vsatp[]     |Virtual supervisor address translation and protection
+|`0xEB0` |HRO |csr:vstopi[]    |Virtual supervisor top interrupt
 
 4+^|Virtual Supervisor Indirect
 
@@ -387,8 +404,6 @@ Note that not all registers are required on all implementations.
 |`0x314` |MRW |csr:mieh[]       |Upper qty:32[bits] of csr:mie[], RV32 only
 |`0x318` |MRW |csr:mvienh[]     |Upper qty:32[bits] of csr:mvien[], RV32 only
 |`0x319` |MRW |csr:mviph[]      |Upper qty:32[bits] of csr:mvip[], RV32 only
-|`0x35C` |MRW |csr:mtopei[]     |Machine top external interrupt (only with an IMSIC)
-|`0xFB0` |MRO |csr:mtopi[]      |Machine top interrupt
 
 4+^|Machine Trap Handling
 
@@ -400,6 +415,8 @@ Note that not all registers are required on all implementations.
 |`0x34A` |MRW |csr:mtinst[]   |Machine trap instruction (transformed)
 |`0x34B` |MRW |csr:mtval2[]   |Machine second trap value
 |`0x354` |MRW |csr:miph[]     |Upper qty:32[bits] of csr:mip[], RV32 only
+|`0x35C` |MRW |csr:mtopei[]   |Machine top external interrupt
+|`0xFB0` |MRO |csr:mtopi[]    |Machine top interrupt
 
 4+^|Machine Indirect
 


### PR DESCRIPTION
Add the supervisor, hypervisor, and VS CSRs from https://github.com/riscv/riscv-aia/blob/main/src/CSRs.adoc

I also moved mtopi and mtopei from Machine Trap Setup to Machine Trap Handling. That made more sense to me after reading the descriptions. I can change it back and move stopi and stopei if the old location was correct.