### PR TITLE
Add Zvzip extension and integrate with normative-rule pipeline

### DIFF
--- a/normative_rule_defs/zvzip.yaml
+++ b/normative_rule_defs/zvzip.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=../docs-resources/schemas/defs-schema.json
+
+$schema: "../docs-resources/schemas/defs-schema.json#"
+
+chapter_name: Vector Extension for Reordering Structured Data
+
+normative_rule_definitions:
+  - name: Zvzip_dependent_Zve32x
+    tags: ["norm:Zvzip_dependent_Zve32x"]
+
+  - name: Zvzip_eew
+    tags: ["norm:Zvzip_eew"]
+
+  - name: Zvzip_diel
+    tags: ["norm:Zvzip_diel"]
+    summary: All Zvzip instructions must have data-independent execution latency when Zvkt is implemented.
+
+  - name: Zvzip_operand_emul
+    tags: ["norm:Zvzip_operand_emul"]
+    summary: vtype/vl describe the destination (EMUL=LMUL, vl elements) for all instructions; vzip.vv sources have EMUL=LMUL/2, the unzip source has EMUL=2*LMUL.
+
+  - name: Zvzip_operand_align
+    tags: ["norm:Zvzip_operand_align"]
+
+  - name: vzip-vv_op
+    tags: ["norm:vzip-vv_op"]
+
+  - name: vzip-vv_enc
+    tags: ["norm:vzip-vv_enc"]
+
+  - name: vzip-vv_emul_constr
+    tags: ["norm:vzip-vv_emul_constr"]
+    summary: vzip.vv raises an illegal-instruction exception when 2*SEW > LMUL*min(ELEN,VLEN), which includes LMUL=1/8 for every SEW.
+
+  - name: vzip-vv_vreg_constr
+    tags: ["norm:vzip-vv_vreg_constr"]
+    summary: Source/destination overlap of vzip.vv other than in the highest-numbered part of the destination (with source EMUL >= 1) raises an illegal-instruction
+      exception.
+
+  - name: vunzipe-v_op
+    tags: ["norm:vunzipe-v_op"]
+
+  - name: vunzipe-v_src_read
+    tags: ["norm:vunzipe-v_src_read"]
+    summary: vunzipe.v reads the even-indexed source elements at indices below 2*vl, including indices at or above vl.
+
+  - name: vunzipe-v_enc
+    tags: ["norm:vunzipe-v_enc"]
+
+  - name: vunzipe-v_lmul_constr
+    tags: ["norm:vunzipe-v_lmul_constr"]
+    summary: vunzipe.v raises an illegal-instruction exception when LMUL=8.
+
+  - name: vunzipe-v_vm_constr
+    tags: ["norm:vunzipe-v_vm_constr"]
+    summary: The masked (vm=0) encoding of vunzipe.v raises an illegal-instruction exception.
+
+  - name: vunzipe-v_vreg_constr
+    tags: ["norm:vunzipe-v_vreg_constr"]
+    summary: Destination/source overlap of vunzipe.v other than at the lowest-numbered register of the source raises an illegal-instruction exception.
+
+  - name: vunzipo-v_op
+    tags: ["norm:vunzipo-v_op"]
+
+  - name: vunzipo-v_src_read
+    tags: ["norm:vunzipo-v_src_read"]
+    summary: vunzipo.v reads the odd-indexed source elements at indices below 2*vl, including indices at or above vl.
+
+  - name: vunzipo-v_enc
+    tags: ["norm:vunzipo-v_enc"]
+
+  - name: vunzipo-v_lmul_constr
+    tags: ["norm:vunzipo-v_lmul_constr"]
+    summary: vunzipo.v raises an illegal-instruction exception when LMUL=8.
+
+  - name: vunzipo-v_vm_constr
+    tags: ["norm:vunzipo-v_vm_constr"]
+    summary: The masked (vm=0) encoding of vunzipo.v raises an illegal-instruction exception.
+
+  - name: vunzipo-v_vreg_constr
+    tags: ["norm:vunzipo-v_vreg_constr"]
+    summary: Destination/source overlap of vunzipo.v other than at the lowest-numbered register of the source raises an illegal-instruction exception.
+
+  - name: vpaire-vv_op
+    tags: ["norm:vpaire-vv_op"]
+
+  - name: vpaire-vv_enc
+    tags: ["norm:vpaire-vv_enc"]
+
+  - name: vpaire-vv_vreg_constr
+    tags: ["norm:vpaire-vv_vreg_constr"]
+    summary: Destination overlap with either source of vpaire.vv raises an illegal-instruction exception.
+
+  - name: vpairo-vv_op
+    tags: ["norm:vpairo-vv_op"]
+
+  - name: vpairo-vv_oddvl_op
+    tags: ["norm:vpairo-vv_oddvl_op"]
+    summary: With odd vl, the value 0 is used for the out-of-pair source position; no source element at or above vl is read.
+
+  - name: vpairo-vv_enc
+    tags: ["norm:vpairo-vv_enc"]
+
+  - name: vpairo-vv_vreg_constr
+    tags: ["norm:vpairo-vv_vreg_constr"]
+    summary: Destination overlap with either source of vpairo.vv raises an illegal-instruction exception.

--- a/src/unpriv/preface.adoc
+++ b/src/unpriv/preface.adoc
@@ -184,6 +184,7 @@ h|Extension h|Version h|Status
 |*Zclsd* |*1.0* |*Ratified*
 |*B* |*1.0* |*Ratified*
 |*V* |*1.0* |*Ratified*
+|*Zvzip* |*0.1* |_Draft_
 |*Zbkb* |*1.0* |*Ratified*
 |*Zbkc* |*1.0* |*Ratified*
 |*Zbkx* |*1.0* |*Ratified*

--- a/src/unpriv/preface.adoc
+++ b/src/unpriv/preface.adoc
@@ -184,7 +184,6 @@ h|Extension h|Version h|Status
 |*Zclsd* |*1.0* |*Ratified*
 |*B* |*1.0* |*Ratified*
 |*V* |*1.0* |*Ratified*
-|*Zvzip* |*0.1* |_Draft_
 |*Zbkb* |*1.0* |*Ratified*
 |*Zbkc* |*1.0* |*Ratified*
 |*Zbkx* |*1.0* |*Ratified*

--- a/src/unpriv/zv.adoc
+++ b/src/unpriv/zv.adoc
@@ -38,6 +38,7 @@ include::zvfbfmin.adoc[]
 include::zvfbfwma.adoc[]
 include::zvbb.adoc[]
 include::zvbc.adoc[]
+include::zvzip.adoc[]
 
 === Vector Instruction Listing
 

--- a/src/unpriv/zvzip.adoc
+++ b/src/unpriv/zvzip.adoc
@@ -1,0 +1,381 @@
+=== "Zvzip" Extension for Reordering Structured Data, Version 0.1
+
+This chapter describes the Zvzip standard extension for reordering structured
+data in vector registers. These instructions address usages such as packing and
+unpacking data structures such as color components of a pixel, real and
+imaginary components of complex numbers, transposing small matrices, among
+others.
+
+[%autowidth]
+[%header,cols="2,4"]
+|===
+|Mnemonic      |Instruction
+| vzip.vv      | <<insns-vzip>>
+| vunzipe.v    | <<insns-vunzipe>>
+| vunzipo.v    | <<insns-vunzipo>>
+| vpaire.vv    | <<insns-vpaire>>
+| vpairo.vv    | <<insns-vpairo>>
+|===
+
+The Zvzip Extension depends on the Zve32x Extension.
+
+<<<
+
+[[insns-vzip, Vector Zip]]
+==== Vector Zip Instruction
+
+Synopsis::
+
+Interleave elements from source vector register groups into destination vector
+register groups.
+
+Mnemonic::
+
+vzip.vv vd, vs2, vs1, vm
+
+Encoding::
+
+[wavedrom, , svg]
+....
+{reg:[
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm'},
+  {bits: 6, name: '111110'},
+], config:{lanes: 1, hspace:1024}}
+....
+
+Description::
+
+Vector Zip (VZIP) instruction interleaves elements from two source vector
+register groups (`vs2` and `vs1`) into one destination vector register group
+(`vd`) by alternating elements from the two sources.                           +
+                                                                               +
+For destination element index `i`, if `i` is even then `vd[i] = vs2[i/2]`, and
+if `i` is odd then `vd[i] = vs1[i/2]`.                                         +
+                                                                               +
+Equivalently, the result order is:
+`vd = [vs2[0], vs1[0], vs2[1], vs1[1], ... ]`                                  +
+                                                                               +
+This instruction operates with an effective vector length (EVL) of 2*VL. The
+destination EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.
+Prestart, inactive, and tail element handling follows the standard vector
+rules, applied over the EVL.                                                   +
+                                                                               +
+The destination vector register group may overlap the source vector register
+group if the overlap is in the highest-numbered part of the destination
+register group and the source EMUL is at least 1. If the overlap violates these
+constraints, the instruction encoding is reserved.
+
+Operation::
+
+[source,sail]
+--
+function clause execute (VZIP(vs2, vs1, vd, vm)) = {
+  EVL = 2 * VL;
+  foreach (i from vstart to EVL-1) {
+    let j   = i / 2;
+    let op1 = get_velem(vs1, SEW, j);
+    let op2 = get_velem(vs2, SEW, j);
+    let res = if (i % 2 == 0) then op2 else op1;
+    if (vm == 0b1) | (v0[i] == 0b1) then
+      set_velem(vd, EEW=SEW, i, res);
+    // inactive element handling follows VMA
+  }
+  // tail element handling follows VTA
+  RETIRE_SUCCESS
+}
+--
+
+<<<
+
+[[insns-vunzipe, Vector Unzip Even]]
+==== Vector Unzip Even Instruction
+
+Synopsis::
+
+Extract even-indexed elements from source vector register group into the
+destination vector register group.
+
+Mnemonic::
+
+vunzipe.v vd, vs2, vm
+
+Encoding::
+
+[wavedrom, , svg]
+....
+{reg:[
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: '01011'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm'},
+  {bits: 6, name: '010010'},
+], config:{lanes: 1, hspace:1024}}
+....
+
+Description::
+
+The vector unzip-even instruction (VUNZIPE) extracts VL even-indexed elements
+from the source vector register group into the destination vector register
+group.                                                                         +
+                                                                               +
+This instruction accesses 2*VL elements in the source vector register group and
+the source EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.         +
+                                                                               +
+Prestart, inactive, and tail element handling follow the standard vector
+rules and are defined over the destination element indices (`0` to `VL-1`).    +
+                                                                               +
+The destination vector register group may overlap the source vector register
+group only if the overlap is in the lowest-numbered part of the source register
+group. If the overlap violates these constraints, the instruction encoding is
+reserved.
+
+Operation::
+
+[source,sail]
+--
+function clause execute (VUNZIPE(vs2, vd, vm)) = {
+  foreach (i from vstart to VL-1) {
+    let j = i * 2;
+    if (vm == 0b1) | (v0[i] == 0b1) then
+      set_velem(vd, EEW=SEW, i, get_velem(vs2, SEW, j));
+    // inactive element handling follows VMA
+  }
+  // tail element handling follows VTA
+  RETIRE_SUCCESS
+}
+--
+
+<<<
+
+[[insns-vunzipo, Vector Unzip Odd]]
+==== Vector Unzip Odd Instruction
+
+Synopsis::
+
+Extract odd-indexed elements from source vector register group into the
+destination vector register group.
+
+Mnemonic::
+
+vunzipo.v vd, vs2, vm
+
+Encoding::
+
+[wavedrom, , svg]
+....
+{reg:[
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: '01111'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm'},
+  {bits: 6, name: '010010'},
+], config:{lanes: 1, hspace:1024}}
+....
+
+Description::
+
+The vector unzip-odd instruction (VUNZIPO) extracts VL odd-indexed elements
+from the source vector register group into the destination vector register
+group.                                                                         +
+                                                                               +
+This instruction accesses 2*VL elements in the source vector register group and
+the source EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.         +
+                                                                               +
+Prestart, inactive, and tail element handling follow the standard vector
+rules and are defined over the destination element indices (`0` to `VL-1`).    +
+                                                                               +
+The destination vector register group may overlap the source vector register
+group only if the overlap is in the lowest-numbered part of the source register
+group. If the overlap violates these constraints, the instruction encoding is
+reserved.
+
+Operation::
+
+[source,sail]
+--
+function clause execute (VUNZIPO(vs2, vd, vm)) = {
+  foreach (i from vstart to VL-1) {
+    let j = (i * 2) + 1;
+    if (vm == 0b1) | (v0[i] == 0b1) then
+      set_velem(vd, EEW=SEW, i, get_velem(vs2, SEW, j));
+    // inactive element handling follows VMA
+  }
+  // tail element handling follows VTA
+  RETIRE_SUCCESS
+}
+--
+
+<<<
+
+[[insns-vpaire, Vector Pair Even]]
+==== Vector Pair Even Instruction
+
+Synopsis::
+
+Interleave the even-indexed elements of the source vector register groups into
+the destination vector register group.
+
+Mnemonic::
+
+vpaire.vv vd, vs2, vs1, vm
+
+
+Encoding::
+
+[wavedrom, , svg]
+....
+{reg:[
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPIVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm'},
+  {bits: 6, name: '001111'},
+], config:{lanes: 1, hspace:1024}}
+....
+
+Description::
+
+The vector pair-even instruction (VPAIRE) interleaves the even-indexed
+elements of the source vector register groups into the destination vector
+register group.                                                                +
+                                                                               +
+For destination element index `i`, if `i` is even then `vd[i] = vs2[i]`, and if
+`i` is odd then `vd[i] = vs1[i - 1]`.                                          +
+                                                                               +
+Equivalently, the result order is:
+`vd = [vs2[0], vs1[0], vs2[2], vs1[2], ... ]`                                  +
+                                                                               +
+The destination vector register group cannot overlap the source vector register
+groups and, if masked, cannot overlap the mask register. If the overlap
+violates these constraints, the instruction encoding is reserved.              +
+                                                                               +
+Prestart, inactive, and tail element handling follow the standard vector rules.
+
+Operation::
+
+[source,sail]
+--
+function clause execute (VPAIRE(vs2, vs1, vd, vm)) = {
+  foreach (i from vstart to VL-1) {
+    let j = if (i % 2) == 0 then i else (i - 1);
+    let res = if (i % 2) == 0
+              then get_velem(vs2, SEW, j)
+              else get_velem(vs1, SEW, j);
+    if (vm == 0b1) | (v0[i] == 0b1) then
+      set_velem(vd, EEW=SEW, i, res);
+    // inactive element handling follows VMA
+  }
+  // tail element handling follows VTA
+  RETIRE_SUCCESS
+}
+--
+
+<<<
+
+[[insns-vpairo, Vector Pair Odd]]
+==== Vector Pair Odd Instruction
+
+Synopsis::
+
+Interleave the odd-indexed elements of the source vector register groups into
+the destination vector register group.
+
+Mnemonic::
+
+vpairo.vv vd, vs2, vs1, vm
+
+
+Encoding::
+
+[wavedrom, , svg]
+....
+{reg:[
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm'},
+  {bits: 6, name: '001111'},
+], config:{lanes: 1, hspace:1024}}
+....
+
+Description::
+
+The vector pair-odd instruction (VPAIRO) interleaves the odd-indexed
+elements of the source vector register groups into the destination vector
+register group.                                                                +
+                                                                               +
+For destination element index `i`, if `i` is even then `vd[i] = vs2[i + 1]`, and
+if `i` is odd then `vd[i] = vs1[i]`.                                           +
+                                                                               +
+Equivalently, the result order is:
+`vd = [vs2[1], vs1[1], vs2[3], vs1[3], ... ]`                                  +
+                                                                               +
+The destination vector register group cannot overlap the source vector register
+groups and, if masked, cannot overlap the mask register. If the overlap
+violates these constraints, the instruction encoding is reserved.              +
+                                                                               +
+Prestart, inactive, and tail element handling follow the standard vector rules.
+                                                                               +
+VPAIRO may read one element past `VL` in `vs2` when `VL` is odd. If the element
+index is greater than or equal to VLMAX in the source vector register group,
+the value 0 is returned for that element.
+
+Operation::
+
+[source,sail]
+--
+function clause execute (VPAIRO(vs2, vs1, vd, vm)) = {
+  foreach (i from vstart to VL-1) {
+    let j = if (i % 2) == 0 then (i + 1) else i;
+    let res =
+      if (j >= vlmax) then zeros()
+      else if (i % 2) == 0 then get_velem(vs2, SEW, j)
+      else                      get_velem(vs1, SEW, j);
+    if (vm == 0b1) | (v0[i] == 0b1) then
+      set_velem(vd, EEW=SEW, i, res);
+    // inactive element handling follows VMA
+  }
+  // tail element handling follows VTA
+  RETIRE_SUCCESS
+}
+--
+
+<<<
+
+[NOTE]
+====
+
+The following example illustrates use of the vector pair-even and pair-odd to
+transpose VL/4 independent 4x4 matrices packed across vector registers.
+
+The first stage operates on 32-bit elements. The second stage packs adjacent
+pairs into 64-bit elements to complete the transpose.
+
+----
+vsetivli t0, zero, e32, m1, ta, ma
+vpaire.vv v5, v1, v2 #|a|b|c|d|A|B|C|D|..    |a|e|c|g|A|E|C|G|..
+vpairo.vv v6, v1, v2 #|e|f|g|h|E|F|G|H|.. -> |b|f|d|h|B|F|D|H|..
+vpaire.vv v7, v3, v4 #|i|j|k|l|I|J|K|L|..    |i|m|k|o|I|M|K|O|..
+vpairo.vv v8, v3, v4 #|m|n|o|p|M|N|O|P|..    |j|n|l|p|J|N|L|P|..
+
+vsetivli t0, zero, e64, m1, ta, ma
+vpaire.vv v1, v5, v7 #|a e|c g|A E|C G|..    |a e|i m|A E|I M|..
+vpaire.vv v2, v6, v8 #|b f|d h|B F|D H|.. -> |b f|j n|B F|J N|..
+vpairo.vv v3, v5, v7 #|i m|k o|I M|K O|..    |c g|k o|C G|K O|..
+vpairo.vv v4, v6, v8 #|j n|l p|J N|L P|..    |d h|l p|D H|L P|..
+----
+
+====

--- a/src/unpriv/zvzip.adoc
+++ b/src/unpriv/zvzip.adoc
@@ -1,23 +1,114 @@
-=== "Zvzip" Extension for Reordering Structured Data, Version 0.1
+[[ext:zvzip]]
+=== ext:zvzip[] Vector Extension for Reordering Structured Data, Version 0.3
 
-This chapter describes the Zvzip standard extension for reordering structured
-data in vector registers. These instructions address usages such as packing and
-unpacking data structures such as color components of a pixel, real and
-imaginary components of complex numbers, transposing small matrices, among
-others.
+The ext:zvzip[] extension provides vector instructions for reordering
+structured data in vector registers: interleaving and deinterleaving
+element sequences, and pairwise transposition of elements from two
+vector register groups. These instructions address usages such as
+packing and unpacking data structures (e.g., the color components of a
+pixel, or the real and imaginary components of complex numbers) and
+transposing small matrices.
+
+NOTE: This extension is in *Draft* status and has not been ratified.
+The instruction encodings shown in this chapter are provisional,
+pending codepoint allocation, and are subject to change.
 
 [%autowidth]
 [%header,cols="2,4"]
 |===
-|Mnemonic      |Instruction
-| vzip.vv      | <<insns-vzip>>
-| vunzipe.v    | <<insns-vunzipe>>
-| vunzipo.v    | <<insns-vunzipo>>
-| vpaire.vv    | <<insns-vpaire>>
-| vpairo.vv    | <<insns-vpairo>>
+|Mnemonic                     |Instruction
+| vzip.vv vd, vs2, vs1, vm    | <<insns-vzip>>
+| vunzipe.v vd, vs2           | <<insns-vunzipe>>
+| vunzipo.v vd, vs2           | <<insns-vunzipo>>
+| vpaire.vv vd, vs2, vs1, vm  | <<insns-vpaire>>
+| vpairo.vv vd, vs2, vs1, vm  | <<insns-vpairo>>
 |===
 
-The Zvzip Extension depends on the Zve32x Extension.
+[#norm:Zvzip_dependent_Zve32x]#The ext:zvzip[] extension depends upon
+the ext:zve32x[] extension.#
+
+[#norm:Zvzip_eew]#All operands of all ext:zvzip[] instructions have
+EEW=SEW. insn:vpaire.vv[], insn:vpairo.vv[], insn:vunzipe.v[], and
+insn:vunzipo.v[] support all SEW settings supported by the
+implementation; for insn:vzip.vv[], SEW support is additionally
+subject to the SEW/LMUL constraint stated with that instruction.#
+
+[#norm:Zvzip_diel]#If the ext:zvkt[] extension is implemented, all
+ext:zvzip[] instructions shall be executed with data-independent
+execution latency.#
+
+NOTE: Data-reordering instructions are natural building blocks for
+constant-time cryptographic kernels, where they replace
+insn:vrgather.vv[] sequences. Since insn:vrgather.vv[] and the slide
+instructions are on the ext:zvkt[] instruction list, code migrating to
+ext:zvzip[] instructions must not lose the data-independent-latency
+guarantee.
+
+==== Mixed-EMUL operation
+
+insn:vzip.vv[], insn:vunzipe.v[], and insn:vunzipo.v[] convert between
+an _interleaved_ element sequence and a pair of _deinterleaved_
+element sequences of half the length.
+[#norm:Zvzip_operand_emul]#For all ext:zvzip[] instructions,
+csr:vtype[] and csr:vl[] describe the destination: `vl` gives the
+number of destination elements, and the destination is a vector
+register group with EMUL=LMUL. The source operands of insn:vzip.vv[]
+are vector register groups with EMUL=LMUL/2; the source operand of
+insn:vunzipe.v[] and insn:vunzipo.v[] is a vector register group with
+EMUL=2*LMUL.#
+
+[#norm:Zvzip_operand_align]#The standard vector register alignment
+rules apply to each operand according to its EMUL.#
+
+[NOTE]
+====
+For every ext:zvzip[] instruction, `vl` gives the number of elements
+written to the destination, matching the base specification's
+definition of csr:vl[], and masking, prestart, body, and tail element
+handling follow the standard vector rules, applied to the destination
+element indices. The unzip instructions read source elements at
+indices up to `2*vl-1`, following the pattern of insn:vslidedown[]
+and insn:vrgather[], whose source reads are likewise not bounded by
+`vl`.
+
+Two alternative formulations were considered. Defining the family as
+widening and narrowing operations on element pairs, with one pair as
+a single element of EEW=2*SEW, would require EEW=128 for SEW=64, the
+one case for which no base-vector emulation sequence exists; the
+vector cryptography extension faced the same question and adopted
+element groups rather than element widths beyond ELEN. Splitting each
+instruction into a pair of same-length low/high (or even/odd) halves
+would double the instruction count for full-width reordering.
+====
+
+insn:vpaire.vv[] and insn:vpairo.vv[] do not change the number of
+elements: all their operands have EMUL=LMUL, and the standard vector
+rules apply without modification.
+
+The base specification's universal rules are unaffected; in
+particular, the destination of a masked insn:vzip.vv[],
+insn:vpaire.vv[], or insn:vpairo.vv[] cannot overlap the mask
+register `v0`, and such encodings remain reserved as specified by the
+base vector specification.
+
+The illegal-instruction exceptions specified in this chapter for
+unsupported SEW/LMUL settings, register-group overlap violations, and
+`vm=0` on the unzip instructions are a deliberate strengthening
+relative to the base vector specification, which treats such
+encodings as reserved; the vector cryptography extension provides
+precedent for mandating an illegal-instruction exception, but only
+for its unsupported-EMUL condition, not for register-group overlap.
+
+In the operation blocks in this chapter, `handle_illegal()` raises an
+illegal-instruction exception for an illegal encoding, following the
+convention of the vector cryptography chapter, and
+`vreg_groups_overlap(x, ex, y, ey)` is true when the vector register
+group starting at register `x` with EMUL=`ex` and the vector register
+group starting at register `y` with EMUL=`ey` share at least one
+vector register. `LMUL` denotes the exact (possibly fractional) value
+of the csr:vtype[] LMUL setting, and arithmetic on it is exact
+rational arithmetic; a vector register group whose EMUL is less than
+or equal to 1 occupies a single vector register.
 
 <<<
 
@@ -26,14 +117,17 @@ The Zvzip Extension depends on the Zve32x Extension.
 
 Synopsis::
 
-Interleave elements from source vector register groups into destination vector
-register groups.
+Interleave the elements of two source vector register groups into one
+destination vector register group of twice the EMUL.
 
 Mnemonic::
 
-vzip.vv vd, vs2, vs1, vm
+insn:vzip.vv[vd,vs2,vs1,vm]
 
 Encoding::
+
+[#norm:vzip-vv_enc]#insn:vzip.vv[] is encoded in the OP-V major opcode
+with funct3=OPMVV and funct6=0b111110.#
 
 [wavedrom, , svg]
 ....
@@ -50,43 +144,69 @@ Encoding::
 
 Description::
 
-Vector Zip (VZIP) instruction interleaves elements from two source vector
-register groups (`vs2` and `vs1`) into one destination vector register group
-(`vd`) by alternating elements from the two sources.                           +
-                                                                               +
-For destination element index `i`, if `i` is even then `vd[i] = vs2[i/2]`, and
-if `i` is odd then `vd[i] = vs1[i/2]`.                                         +
-                                                                               +
-Equivalently, the result order is:
-`vd = [vs2[0], vs1[0], vs2[1], vs1[1], ... ]`                                  +
-                                                                               +
-This instruction operates with an effective vector length (EVL) of 2*VL. The
-destination EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.
-Prestart, inactive, and tail element handling follows the standard vector
-rules, applied over the EVL.                                                   +
-                                                                               +
-The destination vector register group may overlap the source vector register
-group if the overlap is in the highest-numbered part of the destination
-register group and the source EMUL is at least 1. If the overlap violates these
-constraints, the instruction encoding is reserved.
+The vector zip instruction interleaves the elements of two source
+vector register groups (`vs2` and `vs1`, each with EMUL=LMUL/2) into
+the destination vector register group (`vd`, with EMUL=LMUL) by
+alternating elements from the two sources.
+
+[#norm:vzip-vv_op]#For destination element index `i`, if `i` is even
+then `vd[i] = vs2[i/2]`, and if `i` is odd then `vd[i] = vs1[i/2]`.#
+Equivalently, the result order is
+`vd = [vs2[0], vs1[0], vs2[1], vs1[1], ...]`.
+
+The destination is the interleaved operand: it has `vl` body elements,
+and the source element indices read are less than `ceil(vl/2)` in
+`vs2` and less than `floor(vl/2)` in `vs1`. Masking, prestart,
+inactive, and tail element handling follow the standard vector rules,
+applied to the destination element indices.
+
+NOTE: When `vl` is odd, `vs2` supplies one element more than `vs1`.
+Software must ensure that `vs2` holds at least `ceil(vl/2)` valid
+elements (e.g., by producing it with an AVL of `ceil(vl/2)`);
+otherwise `vd[vl-1]` reflects a tail element of the instruction that
+produced `vs2`.
+
+[#norm:vzip-vv_emul_constr]#insn:vzip.vv[] raises an
+illegal-instruction exception when `2*SEW > LMUL * min(ELEN, VLEN)`,
+i.e., when a source operand with EMUL=LMUL/2 cannot support EEW=SEW.
+This condition includes LMUL=1/8 for every SEW.#
+
+[#norm:vzip-vv_vreg_constr]#A source vector register group of
+insn:vzip.vv[] may overlap the destination vector register group only
+if the source EMUL is at least 1 and the highest-numbered vector
+register in the source vector register group is also the
+highest-numbered vector register in the destination vector register
+group. Otherwise, an overlapping encoding raises an
+illegal-instruction exception.#
+
+NOTE: This is the same overlap rule that applies to the destination of
+widening vector arithmetic instructions, restated for a widened
+destination of the same EEW.
 
 Operation::
 
 [source,sail]
 --
 function clause execute (VZIP(vs2, vs1, vd, vm)) = {
-  EVL = 2 * VL;
-  foreach (i from vstart to EVL-1) {
-    let j   = i / 2;
-    let op1 = get_velem(vs1, SEW, j);
-    let op2 = get_velem(vs2, SEW, j);
-    let res = if (i % 2 == 0) then op2 else op1;
-    if (vm == 0b1) | (v0[i] == 0b1) then
-      set_velem(vd, EEW=SEW, i, res);
-    // inactive element handling follows VMA
+  let src_EMUL = LMUL / 2;
+  let vs2_overlap_ok = not(vreg_groups_overlap(vs2, src_EMUL, vd, LMUL))
+                       | ((src_EMUL >= 1) & (vs2 + src_EMUL == vd + LMUL));
+  let vs1_overlap_ok = not(vreg_groups_overlap(vs1, src_EMUL, vd, LMUL))
+                       | ((src_EMUL >= 1) & (vs1 + src_EMUL == vd + LMUL));
+  if (2 * SEW > LMUL * min(ELEN, VLEN))
+     | not(vs2_overlap_ok) | not(vs1_overlap_ok)
+  then { handle_illegal(); RETIRE_FAIL }  // illegal encoding
+  else {
+    foreach (i from vstart to vl - 1) {
+      let src = if (i % 2 == 0) then vs2 else vs1;
+      let res = get_velem(src, SEW, i / 2);  // source EMUL is LMUL/2
+      if (vm == 0b1) | (v0.mask[i] == 0b1) then
+        set_velem(vd, SEW, i, res);
+      // inactive elements follow the vma policy
+    };
+    // tail elements (indices >= vl) follow the vta policy
+    RETIRE_SUCCESS
   }
-  // tail element handling follows VTA
-  RETIRE_SUCCESS
 }
 --
 
@@ -97,14 +217,18 @@ function clause execute (VZIP(vs2, vs1, vd, vm)) = {
 
 Synopsis::
 
-Extract even-indexed elements from source vector register group into the
-destination vector register group.
+Extract the even-indexed elements of a source vector register group
+of twice the EMUL into the destination vector register group.
 
 Mnemonic::
 
-vunzipe.v vd, vs2, vm
+insn:vunzipe.v[vd,vs2]
 
 Encoding::
+
+[#norm:vunzipe-v_enc]#insn:vunzipe.v[] is encoded in the OP-V major
+opcode with funct3=OPMVV, funct6=0b010010, the value 0b01011 in the
+vs1 field, and vm=1.#
 
 [wavedrom, , svg]
 ....
@@ -114,41 +238,95 @@ Encoding::
   {bits: 3, name: 'OPMVV'},
   {bits: 5, name: '01011'},
   {bits: 5, name: 'vs2'},
-  {bits: 1, name: 'vm'},
+  {bits: 1, name: '1'},
   {bits: 6, name: '010010'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
 Description::
 
-The vector unzip-even instruction (VUNZIPE) extracts VL even-indexed elements
-from the source vector register group into the destination vector register
-group.                                                                         +
-                                                                               +
-This instruction accesses 2*VL elements in the source vector register group and
-the source EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.         +
-                                                                               +
-Prestart, inactive, and tail element handling follow the standard vector
-rules and are defined over the destination element indices (`0` to `VL-1`).    +
-                                                                               +
-The destination vector register group may overlap the source vector register
-group only if the overlap is in the lowest-numbered part of the source register
-group. If the overlap violates these constraints, the instruction encoding is
-reserved.
+The vector unzip-even instruction extracts the even-indexed elements
+of the source vector register group (`vs2`, with EMUL=2*LMUL) into the
+destination vector register group (`vd`, with EMUL=LMUL).
+
+[#norm:vunzipe-v_op]#For destination element index `i` (with
+`0 <= i < vl`), `vd[i] = vs2[2*i]`.#
+[#norm:vunzipe-v_src_read]#insn:vunzipe.v[] reads the even-indexed
+elements of `vs2` at indices below `2*vl`, including indices at or
+above `vl`.#
+
+Prestart, body, and tail element handling follow the standard vector
+rules, applied to the destination element indices.
+
+NOTE: Source elements at indices at or above `vl` must hold valid
+data for the result to be meaningful: a loop that loads or computes
+only `vl` interleaved elements and then deinterleaves at `vl`
+silently consumes stale register contents. The instruction producing
+the interleaved operand must cover `2*vl` elements.
+
+[#norm:vunzipe-v_lmul_constr]#insn:vunzipe.v[] raises an
+illegal-instruction exception when LMUL=8, as the source EMUL of
+2*LMUL would exceed 8.#
+
+[#norm:vunzipe-v_vm_constr]#insn:vunzipe.v[] is encoded as an
+unmasked instruction (`vm=1`). The masked encoding (`vm=0`) raises an
+illegal-instruction exception.#
+
+NOTE: A mask register value is indexed by element position, so a
+predicate computed on the interleaved data does not line up with the
+destination element indices of an unzip. Excluding the masked form
+avoids this hazard. Packing selected elements is provided by
+insn:vcompress.vm[]; a position-preserving predicated update can be
+performed with an unmasked unzip followed by insn:vmerge.vvm[].
+
+NOTE: Because both unzip instructions are unmasked-only, the `vm` bit
+carries no information in their encodings. As an alternative
+allocation, the two instructions could share a single VXUNARY0
+codepoint differentiated by `vm` (`vm=1` for insn:vunzipe.v[], `vm=0`
+for insn:vunzipo.v[]), halving the footprint of this extension in the
+VXUNARY0 encoding space. insn:vunzipo.v[] would then be the first
+unmasked instruction encoded with `vm=0` (insn:vmerge.vvm[] and
+insn:vmv.v.v[] share one funct6 differentiated by `vm`, but their
+`vm=0` form reads `v0`). The base specification's rules keyed on the
+`vm` bit, such as the prohibition of a masked instruction's
+destination overlapping `v0`, would need an explicit exemption, and
+decoders that infer a `v0` dependency from `vm=0` would need
+updating.
+
+[#norm:vunzipe-v_vreg_constr]#The destination vector register group
+of insn:vunzipe.v[] may overlap the source vector register group only
+if the lowest-numbered vector register in the destination vector
+register group is also the lowest-numbered vector register in the
+source vector register group. Otherwise, an overlapping encoding
+raises an illegal-instruction exception.#
+
+NOTE: This is the same overlap rule that applies to the destination of
+narrowing vector arithmetic instructions, restated for a narrowed
+destination of the same EEW. In particular, `vunzipe.v vd, vd` is
+legal, permitting an in-place deinterleave of the even elements. The
+write overwrites the low half of the source register group,
+destroying the interleaved elements held there: when extracting both
+halves of a register group in place, the odd elements must be
+extracted first into a non-overlapping destination (e.g.,
+`vunzipo.v v6, v4` followed by `vunzipe.v v4, v4`); reversing the
+order leaves the second unzip reading partially overwritten data.
 
 Operation::
 
 [source,sail]
 --
-function clause execute (VUNZIPE(vs2, vd, vm)) = {
-  foreach (i from vstart to VL-1) {
-    let j = i * 2;
-    if (vm == 0b1) | (v0[i] == 0b1) then
-      set_velem(vd, EEW=SEW, i, get_velem(vs2, SEW, j));
-    // inactive element handling follows VMA
+function clause execute (VUNZIPE(vs2, vd)) = {
+  let overlap_ok = not(vreg_groups_overlap(vd, LMUL, vs2, 2 * LMUL))
+                   | (vd == vs2);  // lowest-numbered registers coincide
+  if (LMUL == 8) | not(overlap_ok)
+  then { handle_illegal(); RETIRE_FAIL }  // illegal encoding
+  else {
+    foreach (i from vstart to vl - 1) {
+      set_velem(vd, SEW, i, get_velem(vs2, SEW, 2 * i));
+    };
+    // tail elements (indices >= vl) follow the vta policy
+    RETIRE_SUCCESS
   }
-  // tail element handling follows VTA
-  RETIRE_SUCCESS
 }
 --
 
@@ -159,14 +337,18 @@ function clause execute (VUNZIPE(vs2, vd, vm)) = {
 
 Synopsis::
 
-Extract odd-indexed elements from source vector register group into the
-destination vector register group.
+Extract the odd-indexed elements of a source vector register group
+of twice the EMUL into the destination vector register group.
 
 Mnemonic::
 
-vunzipo.v vd, vs2, vm
+insn:vunzipo.v[vd,vs2]
 
 Encoding::
+
+[#norm:vunzipo-v_enc]#insn:vunzipo.v[] is encoded in the OP-V major
+opcode with funct3=OPMVV, funct6=0b010010, the value 0b01111 in the
+vs1 field, and vm=1.#
 
 [wavedrom, , svg]
 ....
@@ -176,41 +358,57 @@ Encoding::
   {bits: 3, name: 'OPMVV'},
   {bits: 5, name: '01111'},
   {bits: 5, name: 'vs2'},
-  {bits: 1, name: 'vm'},
+  {bits: 1, name: '1'},
   {bits: 6, name: '010010'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
 Description::
 
-The vector unzip-odd instruction (VUNZIPO) extracts VL odd-indexed elements
-from the source vector register group into the destination vector register
-group.                                                                         +
-                                                                               +
-This instruction accesses 2*VL elements in the source vector register group and
-the source EMUL is 2xLMUL. The instruction is reserved when LMUL is 8.         +
-                                                                               +
-Prestart, inactive, and tail element handling follow the standard vector
-rules and are defined over the destination element indices (`0` to `VL-1`).    +
-                                                                               +
-The destination vector register group may overlap the source vector register
-group only if the overlap is in the lowest-numbered part of the source register
-group. If the overlap violates these constraints, the instruction encoding is
-reserved.
+The vector unzip-odd instruction extracts the odd-indexed elements of
+the source vector register group (`vs2`, with EMUL=2*LMUL) into the
+destination vector register group (`vd`, with EMUL=LMUL).
+
+[#norm:vunzipo-v_op]#For destination element index `i` (with
+`0 <= i < vl`), `vd[i] = vs2[2*i + 1]`.#
+[#norm:vunzipo-v_src_read]#insn:vunzipo.v[] reads the odd-indexed
+elements of `vs2` at indices below `2*vl`, including indices at or
+above `vl`.#
+
+Prestart, body, and tail element handling follow the standard vector
+rules, applied to the destination element indices.
+
+[#norm:vunzipo-v_lmul_constr]#insn:vunzipo.v[] raises an
+illegal-instruction exception when LMUL=8, as the source EMUL of
+2*LMUL would exceed 8.#
+
+[#norm:vunzipo-v_vm_constr]#insn:vunzipo.v[] is encoded as an
+unmasked instruction (`vm=1`). The masked encoding (`vm=0`) raises an
+illegal-instruction exception.#
+
+[#norm:vunzipo-v_vreg_constr]#The destination vector register group
+of insn:vunzipo.v[] may overlap the source vector register group only
+if the lowest-numbered vector register in the destination vector
+register group is also the lowest-numbered vector register in the
+source vector register group. Otherwise, an overlapping encoding
+raises an illegal-instruction exception.#
 
 Operation::
 
 [source,sail]
 --
-function clause execute (VUNZIPO(vs2, vd, vm)) = {
-  foreach (i from vstart to VL-1) {
-    let j = (i * 2) + 1;
-    if (vm == 0b1) | (v0[i] == 0b1) then
-      set_velem(vd, EEW=SEW, i, get_velem(vs2, SEW, j));
-    // inactive element handling follows VMA
+function clause execute (VUNZIPO(vs2, vd)) = {
+  let overlap_ok = not(vreg_groups_overlap(vd, LMUL, vs2, 2 * LMUL))
+                   | (vd == vs2);  // lowest-numbered registers coincide
+  if (LMUL == 8) | not(overlap_ok)
+  then { handle_illegal(); RETIRE_FAIL }  // illegal encoding
+  else {
+    foreach (i from vstart to vl - 1) {
+      set_velem(vd, SEW, i, get_velem(vs2, SEW, 2 * i + 1));
+    };
+    // tail elements (indices >= vl) follow the vta policy
+    RETIRE_SUCCESS
   }
-  // tail element handling follows VTA
-  RETIRE_SUCCESS
 }
 --
 
@@ -221,15 +419,17 @@ function clause execute (VUNZIPO(vs2, vd, vm)) = {
 
 Synopsis::
 
-Interleave the even-indexed elements of the source vector register groups into
-the destination vector register group.
+Interleave the even-indexed elements of two source vector register
+groups into the destination vector register group.
 
 Mnemonic::
 
-vpaire.vv vd, vs2, vs1, vm
-
+insn:vpaire.vv[vd,vs2,vs1,vm]
 
 Encoding::
+
+[#norm:vpaire-vv_enc]#insn:vpaire.vv[] is encoded in the OP-V major
+opcode with funct3=OPIVV and funct6=0b001111.#
 
 [wavedrom, , svg]
 ....
@@ -246,38 +446,48 @@ Encoding::
 
 Description::
 
-The vector pair-even instruction (VPAIRE) interleaves the even-indexed
-elements of the source vector register groups into the destination vector
-register group.                                                                +
-                                                                               +
-For destination element index `i`, if `i` is even then `vd[i] = vs2[i]`, and if
-`i` is odd then `vd[i] = vs1[i - 1]`.                                          +
-                                                                               +
-Equivalently, the result order is:
-`vd = [vs2[0], vs1[0], vs2[2], vs1[2], ... ]`                                  +
-                                                                               +
-The destination vector register group cannot overlap the source vector register
-groups and, if masked, cannot overlap the mask register. If the overlap
-violates these constraints, the instruction encoding is reserved.              +
-                                                                               +
-Prestart, inactive, and tail element handling follow the standard vector rules.
+The vector pair-even instruction interleaves the even-indexed elements
+of the two source vector register groups into the destination vector
+register group. All operands have EMUL=LMUL.
+
+[#norm:vpaire-vv_op]#For destination element index `i`, if `i` is even
+then `vd[i] = vs2[i]`, and if `i` is odd then `vd[i] = vs1[i-1]`.#
+Equivalently, the result order is
+`vd = [vs2[0], vs1[0], vs2[2], vs1[2], ...]`.
+
+All source element indices read are less than `vl`. Masking, prestart,
+inactive, and tail element handling follow the standard vector rules.
+
+[#norm:vpaire-vv_vreg_constr]#The destination vector register group
+of insn:vpaire.vv[] cannot overlap either source vector register
+group. An overlapping encoding raises an illegal-instruction
+exception.#
+
+NOTE: As with insn:vrgather.vv[], the destination is not permitted to
+overlap the sources because destination elements are not a function of
+the same-indexed source elements alone, which would otherwise
+constrain element-ordered implementations.
 
 Operation::
 
 [source,sail]
 --
 function clause execute (VPAIRE(vs2, vs1, vd, vm)) = {
-  foreach (i from vstart to VL-1) {
-    let j = if (i % 2) == 0 then i else (i - 1);
-    let res = if (i % 2) == 0
-              then get_velem(vs2, SEW, j)
-              else get_velem(vs1, SEW, j);
-    if (vm == 0b1) | (v0[i] == 0b1) then
-      set_velem(vd, EEW=SEW, i, res);
-    // inactive element handling follows VMA
+  if vreg_groups_overlap(vd, LMUL, vs2, LMUL)
+     | vreg_groups_overlap(vd, LMUL, vs1, LMUL)
+  then { handle_illegal(); RETIRE_FAIL }  // illegal encoding
+  else {
+    foreach (i from vstart to vl - 1) {
+      let j   = if (i % 2 == 0) then i else (i - 1);
+      let res = if (i % 2 == 0) then get_velem(vs2, SEW, j)
+                else                 get_velem(vs1, SEW, j);
+      if (vm == 0b1) | (v0.mask[i] == 0b1) then
+        set_velem(vd, SEW, i, res);
+      // inactive elements follow the vma policy
+    };
+    // tail elements (indices >= vl) follow the vta policy
+    RETIRE_SUCCESS
   }
-  // tail element handling follows VTA
-  RETIRE_SUCCESS
 }
 --
 
@@ -288,15 +498,17 @@ function clause execute (VPAIRE(vs2, vs1, vd, vm)) = {
 
 Synopsis::
 
-Interleave the odd-indexed elements of the source vector register groups into
-the destination vector register group.
+Interleave the odd-indexed elements of two source vector register
+groups into the destination vector register group.
 
 Mnemonic::
 
-vpairo.vv vd, vs2, vs1, vm
-
+insn:vpairo.vv[vd,vs2,vs1,vm]
 
 Encoding::
+
+[#norm:vpairo-vv_enc]#insn:vpairo.vv[] is encoded in the OP-V major
+opcode with funct3=OPMVV and funct6=0b001111.#
 
 [wavedrom, , svg]
 ....
@@ -313,43 +525,55 @@ Encoding::
 
 Description::
 
-The vector pair-odd instruction (VPAIRO) interleaves the odd-indexed
-elements of the source vector register groups into the destination vector
-register group.                                                                +
-                                                                               +
-For destination element index `i`, if `i` is even then `vd[i] = vs2[i + 1]`, and
-if `i` is odd then `vd[i] = vs1[i]`.                                           +
-                                                                               +
-Equivalently, the result order is:
-`vd = [vs2[1], vs1[1], vs2[3], vs1[3], ... ]`                                  +
-                                                                               +
-The destination vector register group cannot overlap the source vector register
-groups and, if masked, cannot overlap the mask register. If the overlap
-violates these constraints, the instruction encoding is reserved.              +
-                                                                               +
-Prestart, inactive, and tail element handling follow the standard vector rules.
-                                                                               +
-VPAIRO may read one element past `VL` in `vs2` when `VL` is odd. If the element
-index is greater than or equal to VLMAX in the source vector register group,
-the value 0 is returned for that element.
+The vector pair-odd instruction interleaves the odd-indexed elements
+of the two source vector register groups into the destination vector
+register group. All operands have EMUL=LMUL.
+
+[#norm:vpairo-vv_op]#For destination element index `i`, if `i` is even
+then `vd[i] = vs2[i+1]`, and if `i` is odd then `vd[i] = vs1[i]`.#
+Equivalently, the result order is
+`vd = [vs2[1], vs1[1], vs2[3], vs1[3], ...]`.
+
+[#norm:vpairo-vv_oddvl_op]#When `vl` is odd, the source element index
+`i+1` used for the last destination element equals `vl`; in this case
+the value 0 is used in place of a source element. insn:vpairo.vv[]
+never reads a source element with index at or above `vl`.#
+
+NOTE: Returning 0 for the out-of-pair position (rather than reading
+the source register content beyond `vl`, or leaving the result
+implementation-defined) makes the result of insn:vpairo.vv[] a pure
+function of the source elements below `vl`, so results are identical
+across implementations and independent of stale register contents.
+
+Masking, prestart, inactive, and tail element handling follow the
+standard vector rules.
+
+[#norm:vpairo-vv_vreg_constr]#The destination vector register group
+of insn:vpairo.vv[] cannot overlap either source vector register
+group. An overlapping encoding raises an illegal-instruction
+exception.#
 
 Operation::
 
 [source,sail]
 --
 function clause execute (VPAIRO(vs2, vs1, vd, vm)) = {
-  foreach (i from vstart to VL-1) {
-    let j = if (i % 2) == 0 then (i + 1) else i;
-    let res =
-      if (j >= vlmax) then zeros()
-      else if (i % 2) == 0 then get_velem(vs2, SEW, j)
-      else                      get_velem(vs1, SEW, j);
-    if (vm == 0b1) | (v0[i] == 0b1) then
-      set_velem(vd, EEW=SEW, i, res);
-    // inactive element handling follows VMA
+  if vreg_groups_overlap(vd, LMUL, vs2, LMUL)
+     | vreg_groups_overlap(vd, LMUL, vs1, LMUL)
+  then { handle_illegal(); RETIRE_FAIL }  // illegal encoding
+  else {
+    foreach (i from vstart to vl - 1) {
+      let j   = if (i % 2 == 0) then (i + 1) else i;
+      let res = if (j >= vl) then zeros(SEW)
+                else if (i % 2 == 0) then get_velem(vs2, SEW, j)
+                else                      get_velem(vs1, SEW, j);
+      if (vm == 0b1) | (v0.mask[i] == 0b1) then
+        set_velem(vd, SEW, i, res);
+      // inactive elements follow the vma policy
+    };
+    // tail elements (indices >= vl) follow the vta policy
+    RETIRE_SUCCESS
   }
-  // tail element handling follows VTA
-  RETIRE_SUCCESS
 }
 --
 
@@ -357,25 +581,94 @@ function clause execute (VPAIRO(vs2, vs1, vd, vm)) = {
 
 [NOTE]
 ====
+The following example illustrates the use of vector pair-even and
+pair-odd to transpose `vl/4` independent 4x4 matrices of 32-bit
+elements packed across vector registers.
 
-The following example illustrates use of the vector pair-even and pair-odd to
-transpose VL/4 independent 4x4 matrices packed across vector registers.
-
-The first stage operates on 32-bit elements. The second stage packs adjacent
-pairs into 64-bit elements to complete the transpose.
+The example assumes that `vl` is a multiple of 4, that registers
+`v1`-`v4` are fully packed with matrix data, and that the
+implementation supports ELEN>=64 (e.g., ext:zve64x[]) for the second
+stage, which operates on 64-bit elements. The first stage operates on
+32-bit elements; the second stage packs adjacent pairs into 64-bit
+elements to complete the transpose.
 
 ----
-vsetivli t0, zero, e32, m1, ta, ma
+vsetvli t0, x0, e32, m1, ta, ma
 vpaire.vv v5, v1, v2 #|a|b|c|d|A|B|C|D|..    |a|e|c|g|A|E|C|G|..
 vpairo.vv v6, v1, v2 #|e|f|g|h|E|F|G|H|.. -> |b|f|d|h|B|F|D|H|..
 vpaire.vv v7, v3, v4 #|i|j|k|l|I|J|K|L|..    |i|m|k|o|I|M|K|O|..
 vpairo.vv v8, v3, v4 #|m|n|o|p|M|N|O|P|..    |j|n|l|p|J|N|L|P|..
 
-vsetivli t0, zero, e64, m1, ta, ma
+vsetvli t0, x0, e64, m1, ta, ma
 vpaire.vv v1, v5, v7 #|a e|c g|A E|C G|..    |a e|i m|A E|I M|..
 vpaire.vv v2, v6, v8 #|b f|d h|B F|D H|.. -> |b f|j n|B F|J N|..
 vpairo.vv v3, v5, v7 #|i m|k o|I M|K O|..    |c g|k o|C G|K O|..
 vpairo.vv v4, v6, v8 #|j n|l p|J N|L P|..    |d h|l p|D H|L P|..
 ----
 
+After the sequence, `v1`-`v4` hold the columns `a e i m`, `b f j n`,
+`c g k o`, and `d h l p` of each matrix, completing the transpose.
+====
+
+==== Intrinsics (informative)
+
+[NOTE]
+====
+This subsection is informative. The normative specification of C
+intrinsics is maintained in the RISC-V Vector Intrinsics document
+(`rvv-intrinsic-doc`); the signatures below are the proposed shape for
+that specification.
+
+The intrinsics follow the type-suffix convention used for mixed-EMUL
+instructions such as the widening arithmetic intrinsics: the type
+suffix names the result type, and the `vl` argument gives the element
+count of the destination for all five intrinsics, matching the
+instructions' definition. The compiler is responsible for
+establishing the required `vtype` setting.
+
+For insn:vzip.vv[], the result type has twice the LMUL of the source
+types, so sources of LMUL up to 4 are supported (an LMUL=8 result) and
+fractional source types start at the smallest supported fraction.
+For insn:vunzipe.v[]/insn:vunzipo.v[], the source type has twice the
+LMUL of the result type. insn:vpaire.vv[] and insn:vpairo.vv[] are
+type-preserving.
+
+Illustrated for `int32_t` elements at a source LMUL of 1 (the pattern
+repeats for every supported SEW, LMUL, and for unsigned and
+floating-point element types):
+
+[source,c]
+----
+// vzip: two m1 sources -> one m2 result; vl counts result elements.
+vint32m2_t __riscv_vzip_vv_i32m2(vint32m1_t vs2, vint32m1_t vs1,
+                                 size_t vl);
+
+// vunzipe/vunzipo: one m2 source -> one m1 result; vl counts result
+// elements. Source elements at indices below 2*vl are read.
+vint32m1_t __riscv_vunzipe_v_i32m1(vint32m2_t vs2, size_t vl);
+vint32m1_t __riscv_vunzipo_v_i32m1(vint32m2_t vs2, size_t vl);
+
+// vpaire/vpairo: type-preserving; vl counts elements as usual.
+vint32m1_t __riscv_vpaire_vv_i32m1(vint32m1_t vs2, vint32m1_t vs1,
+                                   size_t vl);
+vint32m1_t __riscv_vpairo_vv_i32m1(vint32m1_t vs2, vint32m1_t vs1,
+                                   size_t vl);
+----
+
+Masked (`_m`) and tail/mask policy (`_tu`, `_tum`, `_tumu`, `_mu`)
+variants follow the standard intrinsics conventions for
+insn:vzip.vv[], insn:vpaire.vv[], and insn:vpairo.vv[]; the mask for
+`__riscv_vzip_vv_..._m` has one bit per _result_ element.
+insn:vunzipe.v[] and insn:vunzipo.v[] have no masked variants, as the
+masked encodings raise an illegal-instruction exception;
+tail-undisturbed (`_tu`) variants
+remain available.
+
+A convenience intrinsic returning both deinterleaved halves as a
+tuple type may additionally be layered on the unzip pair:
+
+[source,c]
+----
+vint32m1x2_t __riscv_vunzip_v_i32m1x2(vint32m2_t vs2, size_t vl);
+----
 ====


### PR DESCRIPTION
This PR adds the draft Zvzip extension chapter to the unprivileged manual: five instructions for interleaving, deinterleaving, and pairwise transposition of vector elements (vzip.vv, vunzipe.v, vunzipo.v, vpaire.vv, vpairo.vv), targeting workloads such as complex-number packing, pixel-component (de)interleaving, and small-matrix transposition. It supersedes the earlier draft, which defined the count-changing instructions over an effective vector length of `2*vl`.

