### PR TITLE
Add changebar PDF build target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,28 @@ This skips the clean-workdir step between builds, so unchanged files are not rep
 
 Outputs land in the `build/` directory.
 
+### Changebar PDF (review aid)
+
+`make build-changebar-pdf` builds the normal manual with a red bar in the left
+margin next to everything the current branch changed. It is fully automatic —
+the bars are derived from `git diff`, so no source annotation is needed and it
+works for any branch with any mix of additions, edits, and deletions.
+
+```bash
+make build-changebar-pdf                       # vs origin/main (merge base)
+make build-changebar-pdf CHANGEBAR_BASE=v2.0   # vs any ref/tag/commit
+```
+
+The comparison uses the merge base with `CHANGEBAR_BASE` (default `origin/main`),
+i.e. everything the branch changed since it forked, and includes uncommitted
+working-tree edits so you can preview before committing. Output:
+`build/riscv-spec-changebar.pdf`.
+
+How it works: `scripts/gen-changebar-diff.sh` emits the changed `.adoc` line
+ranges as JSON (git runs on the host, not in the build container), and
+`src/lib/changebar.rb` uses Asciidoctor's `--sourcemap` to tag the affected
+blocks and draw the bars.
+
 ## Contributing changes
 
 - Create a branch for your change.

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-sail
 
 .PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub build-tags docker-pull-latest submodule-check
-.PHONY: build-norm-rules build-norm-rules-json build-norm-rules-html check-tags update-ref check-xref-fallbacks
+.PHONY: build-norm-rules build-norm-rules-json build-norm-rules-html check-tags update-ref check-xref-fallbacks build-changebar-pdf
 
 all: build
 
@@ -153,7 +153,19 @@ ifeq ("$(wildcard docs-resources/global-config.adoc)","")
   $(shell git submodule update --init --recursive)
 endif
 
+# Changebar PDF: the normal manual with a red bar in the left margin next to
+# everything this branch changed relative to CHANGEBAR_BASE (default
+# origin/main). The diff is computed on the host by
+# scripts/gen-changebar-diff.sh (git isn't available in the build container) and
+# consumed by src/lib/changebar.rb via --sourcemap.
+# Override the base ref with e.g.: make build-changebar-pdf CHANGEBAR_BASE=v2.0
+CHANGEBAR_BASE ?= origin/main
+CHANGEBAR_PDF := $(BUILD_DIR)/$(DOCS)-changebar.pdf
+CHANGEBAR_DIFF_JSON := changebar-changes.json
+CHANGEBAR_OPTS := --sourcemap -r ./src/lib/changebar.rb -a changebar-diff=$(CHANGEBAR_DIFF_JSON)
+
 build-pdf: $(DOCS_PDF)
+build-changebar-pdf: $(CHANGEBAR_PDF)
 build-html: $(DOCS_HTML) check-xref-fallbacks
 build-epub: $(DOCS_EPUB)
 build-tags: $(DOCS_NORM_TAGS)
@@ -196,6 +208,13 @@ $(BUILD_DIR)/%.pdf: $(SRC_DIR)/%.adoc $(ALL_SRCS)
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
+	@printf '\n  Built \033]8;;file://%s\033\\%s\033]8;;\033\\\n\n' "$(abspath $@)" "$@"
+
+$(CHANGEBAR_PDF): $(SRC_DIR)/$(DOCS).adoc $(ALL_SRCS)
+	$(WORKDIR_SETUP)
+	bash ./scripts/gen-changebar-diff.sh "$(CHANGEBAR_BASE)" > "$@.workdir/$(CHANGEBAR_DIFF_JSON)"
+	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(CHANGEBAR_OPTS) $(REQUIRES) $< $(DOCKER_QUOTE)
+	mv $@.workdir/$(BUILD_DIR)/$(DOCS).pdf $@ && rm -rf $@.workdir
 	@printf '\n  Built \033]8;;file://%s\033\\%s\033]8;;\033\\\n\n' "$(abspath $@)" "$@"
 
 $(BUILD_DIR)/%.html: $(SRC_DIR)/%.adoc $(ALL_SRCS)

--- a/scripts/gen-changebar-diff.sh
+++ b/scripts/gen-changebar-diff.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# gen-changebar-diff.sh — emit the changed AsciiDoc line ranges for changebars.
+#
+# Prints a JSON object mapping each changed .adoc source file to the list of
+# line ranges (in the *working-tree* version of the file) that differ from a
+# base ref. changebar.rb consumes this to place margin bars.
+#
+# Usage:
+#   scripts/gen-changebar-diff.sh [BASE_REF] > changes.json
+#
+# BASE_REF defaults to origin/main. The comparison uses the merge base
+# (git diff BASE...HEAD), i.e. "everything this branch changed since it forked",
+# which matches what a reviewer expects to see marked. Uncommitted working-tree
+# edits are included too, so you can preview changes before committing.
+#
+# Requires: git, awk. Run from the repo root (the Makefile does).
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Resolve the merge base so we compare against the fork point, not the tip of
+# the base branch. Fall back to comparing directly against BASE_REF if no common
+# ancestor exists (e.g. unrelated histories).
+if MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+  DIFF_BASE="$MERGE_BASE"
+else
+  DIFF_BASE="$BASE_REF"
+fi
+
+# --unified=0 gives one hunk per changed region with exact new-file line spans.
+# We include staged + unstaged working-tree changes (no ".." end ref) so a build
+# reflects the tree being rendered.
+#
+# awk parses hunk headers `@@ -old +new,count @@`:
+#   - a pure addition/modification (count>0) marks lines new..new+count-1
+#   - a pure deletion (count==0) marks the single line `new` so the removal is
+#     still visibly flagged at the point content was cut.
+git diff --no-color --unified=0 --diff-filter=ACMR "$DIFF_BASE" -- '*.adoc' \
+  | awk '
+    /^\+\+\+ / {
+      path = $2
+      sub(/^b\//, "", path)
+      next
+    }
+    /^@@ / {
+      # field looks like +new or +new,count
+      hunk = $3
+      sub(/^\+/, "", hunk)
+      n = split(hunk, a, ",")
+      start = a[1] + 0
+      count = (n > 1) ? a[2] + 0 : 1
+      if (count == 0) { lo = start; hi = start }        # deletion point
+      else            { lo = start; hi = start + count - 1 }
+      ranges[path] = ranges[path] sep[path] "[" lo "," hi "]"
+      sep[path] = ","
+    }
+    END {
+      printf "{"
+      first = 1
+      for (p in ranges) {
+        if (!first) printf ","
+        printf "\n  \"%s\": [%s]", p, ranges[p]
+        first = 0
+      }
+      printf "\n}\n"
+    }
+  '

--- a/src/lib/changebar.rb
+++ b/src/lib/changebar.rb
@@ -1,0 +1,222 @@
+# changebar.rb — automatic git-driven changebars for the RISC-V PDF build.
+#
+# Marks the left margin of every block whose source lines differ between a base
+# ref and the working tree, so a reader can see exactly what a branch changed
+# without any manual annotation.
+#
+# It has two halves:
+#
+#   1. A tree processor that reads a JSON map of changed line ranges (produced by
+#      scripts/gen-changebar-diff.sh) and, using Asciidoctor's sourcemap, adds
+#      the "changed" role to each affected block.
+#   2. A PDF converter that draws a vertical bar in the left margin next to any
+#      block carrying that role.
+#
+# Enable it in a build with:
+#   asciidoctor-pdf --sourcemap -r ./src/lib/changebar.rb \
+#     -a changebar-diff=<path-to-changes.json> ...
+#
+# With no changebar-diff attribute (or an empty map) it is a complete no-op, so
+# it is safe to leave wired into a build target.
+#
+# NOTE: the converter half depends on a few asciidoctor-pdf internals
+# (ink_general_heading / ink_chapter_title / ink_part_title and the section's
+# pdf-page-start attribute). The build pins asciidoctor-pdf via the docs base
+# container image, so these are stable for this repo; revisit on a major bump.
+
+require 'json'
+require 'asciidoctor-pdf'
+
+module Changebar
+  ROLE = 'changed'.freeze
+
+  # Barable = block contexts the converter knows how to draw a bar around. When
+  # a changed line lands in a finer node (a list item, a table cell) we climb to
+  # the nearest ancestor in this set.
+  BARABLE = %i[
+    section paragraph listing literal ulist olist dlist admonition quote
+    example sidebar open verse image table thematic_break floating_title pass
+  ].freeze
+
+  # Normalise a source path to a repo-relative "src/..." key so paths from git
+  # (repo-relative) and from Asciidoctor's sourcemap (absolute, and different
+  # inside the build container) compare equal.
+  def self.normalize(path)
+    return nil unless path
+    if (i = path.rindex('/src/'))
+      path[(i + 1)..]
+    elsif path.start_with?('src/')
+      path
+    else
+      File.basename(path)
+    end
+  end
+
+  # Load { "src/foo.adoc" => [[start,end], ...] } from the JSON file named by the
+  # changebar-diff attribute. Returns {} when unset or unreadable.
+  def self.load_ranges(doc)
+    spec = doc.attr('changebar-diff')
+    return {} if spec.nil? || spec.empty?
+    # Resolve against the document base dir, then the working dir, then as given
+    # — base_dir differs between a local build and the container build.
+    candidates = [spec, File.expand_path(spec, Dir.pwd)]
+    candidates << (doc.normalize_system_path(spec, doc.base_dir) rescue nil)
+    path = candidates.compact.find { |c| File.file?(c) }
+    return {} unless path
+    raw = JSON.parse(File.read(path))
+    raw.each_with_object({}) do |(file, ranges), acc|
+      acc[normalize(file)] = ranges.map { |a, b| [a.to_i, b.to_i] }
+    end
+  rescue JSON::ParserError
+    {}
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Tree processor: tag changed blocks.
+# ---------------------------------------------------------------------------
+Asciidoctor::Extensions.register do
+  tree_processor do
+    process do |doc|
+      ranges = Changebar.load_ranges(doc)
+      next if ranges.empty?
+
+      # Collect barable blocks with a known source location, grouped by file.
+      by_file = Hash.new { |h, k| h[k] = [] }
+      doc.find_by.each do |node|
+        next unless Changebar::BARABLE.include?(node.context)
+        sl = node.source_location rescue nil
+        next unless sl && sl.file && sl.lineno
+        key = Changebar.normalize(sl.file)
+        by_file[key] << [sl.lineno, node]
+      end
+
+      by_file.each do |file, entries|
+        file_ranges = ranges[file]
+        next unless file_ranges
+
+        entries.sort_by! { |lineno, _| lineno }
+        starts = entries.map(&:first)
+
+        entries.each_with_index do |(lineno, node), idx|
+          # A block "owns" the lines from its start up to the next barable
+          # block's start; mark it if any changed line falls in that span.
+          span_end = idx + 1 < starts.length ? starts[idx + 1] - 1 : Float::INFINITY
+          changed = file_ranges.any? do |lo, hi|
+            lo <= span_end && hi >= lineno
+          end
+          node.add_role(Changebar::ROLE) if changed
+        end
+      end
+      nil
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Converter: draw the bars.
+# ---------------------------------------------------------------------------
+class ChangebarConverter < (Asciidoctor::Converter.for 'pdf')
+  register_for 'pdf'
+
+  BAR_COLOR = 'D64541'.freeze
+  BAR_WIDTH = 2.5
+  BAR_INSET = 12 # points left of the content box
+  BAR_PAD   = 5  # extend each bar so adjacent changed blocks merge visually
+
+  # Sections draw a bar around the heading only; their changed descendants are
+  # marked and barred individually. This keeps a one-line edit inside a big
+  # section from barring the whole section, while a wholly-new section still
+  # reads as a continuous bar (heading + every child block).
+  def convert_section(node, opts = {})
+    return super unless changed?(node)
+    prev = @cb_active_section
+    @cb_active_section = node
+    super
+    region = (@cb_regions ||= {}).delete(node.object_id)
+    draw_region(region) if region
+    @cb_active_section = prev
+  end
+
+  # Capture the heading's rendered extent (after any chapter page break) so the
+  # section bar hugs the title exactly. Keyed per node so nested changed
+  # sections don't clobber each other's region.
+  %i[ink_general_heading ink_chapter_title ink_part_title].each do |m|
+    define_method(m) do |*args, &blk|
+      node = args.first
+      unless node.equal?(@cb_active_section)
+        return super(*args, &blk)
+      end
+      start_page = page_number
+      start_top = cursor
+      result = super(*args, &blk)
+      (@cb_regions ||= {})[node.object_id] =
+        { start_page: start_page, start_top: start_top,
+          end_page: page_number, end_bottom: cursor }
+      result
+    end
+  end
+
+  %i[paragraph listing literal ulist olist dlist admonition quote
+     example sidebar open verse image table thematic_break].each do |ctx|
+    define_method(:"convert_#{ctx}") do |node, *rest|
+      unless changed?(node) && !ancestor_changed?(node)
+        return super(node, *rest)
+      end
+      start_page = page_number
+      start_top = cursor
+      result = super(node, *rest)
+      # draw_region restores the text cursor to the post-block position itself.
+      draw_region(start_page: start_page, start_top: start_top,
+                  end_page: page_number, end_bottom: cursor)
+      result
+    end
+  end
+
+  private
+
+  def changed?(node)
+    node.respond_to?(:role?) && node.role? && node.roles.include?(Changebar::ROLE)
+  end
+
+  # Avoid a doubled bar when a changed block sits inside an already-barred
+  # ancestor (e.g. a changed list inside a changed open block).
+  def ancestor_changed?(node)
+    p = node.parent
+    while p
+      if p.respond_to?(:roles) && p.respond_to?(:role?) && p.role? &&
+         p.roles.include?(Changebar::ROLE) && p.context != :section
+        return true
+      end
+      p = p.respond_to?(:parent) ? p.parent : nil
+    end
+    false
+  end
+
+  # Stroke the bar across every page the region spans, then restore the text
+  # cursor (go_to_page resets it to the page top, which would corrupt the flow).
+  def draw_region(region)
+    start_page = region[:start_page]
+    end_page   = region[:end_page]
+    start_top  = region[:start_top]
+    end_bottom = region[:end_bottom]
+    resume_page = page_number
+    resume_cursor = cursor
+    bar_x = bounds.left - BAR_INSET
+
+    (start_page..end_page).each do |pnum|
+      go_to_page pnum
+      top    = pnum == start_page ? [start_top + BAR_PAD, bounds.height].min : bounds.height
+      bottom = pnum == end_page   ? [end_bottom - BAR_PAD, 0].max : 0
+      next if top <= bottom
+      stroke do
+        line_width BAR_WIDTH
+        stroke_color BAR_COLOR
+        stroke_vertical_line bottom, top, at: bar_x
+      end
+    end
+
+    go_to_page resume_page
+    move_cursor_to resume_cursor
+  end
+end


### PR DESCRIPTION
This new makefile build target allows an ISA extension author to build a PDF with their changes highlighted by changebars in the left hand column of the PDF.