### PR TITLE
rvwmo: add source/destination register listings for Zacas, Zabha, Zalasr

### DIFF
--- a/src/unpriv/rvwmo.adoc
+++ b/src/unpriv/rvwmo.adoc
@@ -640,6 +640,70 @@ register(s) to destination register(s) as specified
 
 |===
 
+.Zabha Standard Extension
+[%autowidth.stretch,float="center",align="center",cols="<,<,<,<,<",options="header"]
+|===
+||Source Registers |Destination Registers |Accumulating CSRs|
+
+|insn:amoswap.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amoadd.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amoxor.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amoand.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amoor.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amomin.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amomax.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amominu.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amomaxu.b/h[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:amocas.b/h[]† |_rs1_ ^A^, _rs2_ ^D^, _rd_ ^D^ |_rd_ | |
+|===
+
+.Zacas Standard Extension
+[%autowidth.stretch,float="center",align="center",cols="<,<,<,<,<",options="header"]
+|===
+||Source Registers |Destination Registers |Accumulating CSRs|
+
+|insn:amocas.w[]† |_rs1_ ^A^, _rs2_ ^D^, _rd_ ^D^ |_rd_ | |
+
+|insn:amocas.d[]†^*^ |_rs1_ ^A^, _rs2_ ^D^, _rd_ ^D^ |_rd_ | |
+
+|insn:amocas.q[]†^*^ |_rs1_ ^A^, _rs2_ ^D^, _rd_ ^D^ |_rd_ | |
+
+5+| ^*^ insn:amocas.d[] uses register-pair operands on RV32, and insn:amocas.q[] (RV64-only) uses register-pair operands on RV64.  For these forms, if _rs2_ is not `x0`, _rs2_+1 is also a data source register, and if _rd_ is not `x0`, _rd_+1 is also a data source and destination register.
+|===
+
+.Zalasr Standard Extension
+[%autowidth.stretch,float="center",align="center",cols="<,<,<,<,<",options="header"]
+|===
+||Source Registers |Destination Registers |Accumulating CSRs|
+
+|insn:lb.{aq,aqrl}[]† |_rs1_ ^A^ |_rd_ | |
+
+|insn:lh.{aq,aqrl}[]† |_rs1_ ^A^ |_rd_ | |
+
+|insn:lw.{aq,aqrl}[]† |_rs1_ ^A^ |_rd_ | |
+
+|insn:ld.{aq,aqrl}[]†^*^ |_rs1_ ^A^ |_rd_ | |
+
+|insn:sb.{rl,aqrl}[] |_rs1_ ^A^, _rs2_ ^D^ | | |
+
+|insn:sh.{rl,aqrl}[] |_rs1_ ^A^, _rs2_ ^D^ | | |
+
+|insn:sw.{rl,aqrl}[] |_rs1_ ^A^, _rs2_ ^D^ | | |
+
+|insn:sd.{rl,aqrl}[]^*^ |_rs1_ ^A^, _rs2_ ^D^ | | |
+
+5+| ^*^ insn:ld.{aq,aqrl}[] and insn:sd.{rl,aqrl}[] are RV64-only
+|===
+
 .RV32F Standard Extension
 [%autowidth.stretch,float="center",align="center",cols="<,<,<,<,<",options="header"]
 |===


### PR DESCRIPTION
The RVWMO atomic register listings cover RV32A/RV64A but omit the ratified Zacas, Zabha, and Zalasr instructions. This adds them: Zabha at the same profile as the word/doubleword AMOs, Zalasr with the same register-dependency profile as ordinary loads and stores, and amocas with the old rd as a data source (the comparand) and also the destination — footnoted for the rd+1/rs2+1 pair roles on amocas.d/.q. Daggers match the existing AMOs and loads.

Fixes #3241.
