### PR TITLE
[RVBNA] correcting pseudo-code description (round-to-odd masking in particular)

### DIFF
--- a/src/unpriv/rvbna.adoc
+++ b/src/unpriv/rvbna.adoc
@@ -231,9 +231,10 @@ BulkNormalizedDotProduct(A[n], B[n]) {
         } else {
             // denormalization and final round-to-odd
             // (of bits discarded during denormalization)
-            let denormalizedSig = accAbs >> (q - 1 + resExp)
-            let discardedMask = ((1 << (q - 1)) - 1) >> (q - 1 + resExp)
-            let discardedBits = accAbs & discardedMask
+            let denormShift = -resExp
+            let denormalizedSig = (accAbs << lzc) >> (g + o + 1 + 1 + denormShift)
+            let discardedMask = (1 << (g + o + 1 + 1 + denormShift)) - 1
+            let discardedBits = (accAbs << lzc) & discardedMask
             let forceLSB =  (discardedBits != 0 ? 1 : 0)
             return (accSign << (q + f - 1)) | denormalizedSig | forceLSB
         }

--- a/src/unpriv/rvbna.adoc
+++ b/src/unpriv/rvbna.adoc
@@ -208,7 +208,8 @@ BulkNormalizedDotProduct(A[n], B[n]) {
     let resExp = accumulator == 0 ? 0 : ((maxExp + o + 1 - lzc) - prodOpBias + res_bias)
     let unroundedSig = (accAbs << lzc) >> (g + o + 1)
     let rawJamMask = (1 << (g + o + 1)) - 1
-    let jamMask = (rawJamMask >> (lzc > (g + o + 1) ? 0 : (g + o + 1 - lzc)))
+    let jamMaskShift = (lzc > (g + o + 1) ? 0 : (g + o + 1 - lzc))
+    let jamMask = rawJamMask >> jamMaskShift
 
     let jamSig = ((accAbs << lzc) & jamMask) != 0
     let roundedSig = unroundedSig | (jamSig ? 1 : 0)

--- a/src/unpriv/rvbna.adoc
+++ b/src/unpriv/rvbna.adoc
@@ -208,10 +208,10 @@ BulkNormalizedDotProduct(A[n], B[n]) {
     let resExp = accumulator == 0 ? 0 : ((maxExp + o + 1 - lzc) - prodOpBias + res_bias)
     let unroundedSig = (accAbs << lzc) >> (g + o + 1)
     let rawJamMask = (1 << (g + o + 1)) - 1
-    let jamMaskShift = (lzc > (g + o + 1) ? 0 : (g + o + 1 - lzc))
+    let jamMaskShift = (lzc > (g + o + 1)) ? (g + o + 1) : lzc
     let jamMask = rawJamMask >> jamMaskShift
 
-    let jamSig = ((accAbs << lzc) & jamMask) != 0
+    let jamSig = (accAbs & jamMask) != 0
     let roundedSig = unroundedSig | (jamSig ? 1 : 0)
 
     if (accAbs == 0) {


### PR DESCRIPTION
Numerous errors have been found in the RVBNA pseudo-code specification (thanks to @AAgarwal04 and @jrahmeh).

This PR addresses the known issues:
- Fixing the computation of bit masks used in both the normal and subnormal result round-to-odd process


### Mask for jamming normal results

The mask used for normal results was incorrect

<img width="1781" height="911" alt="image" src="https://github.com/user-attachments/assets/adae6ea1-eeae-4b42-b8df-721a8a339220" />

The `jamMask` should have a size of (o+1+g - lzc) bits if applied before the normalization shift, or have a size of (o+1+g) bits if applied after the left normalization shift by lzc bits.

So the following is not correct:

```    
    let resExp = accumulator == 0 ? 0 : ((maxExp + o + 1 - lzc) - prodOpBias + res_bias)
    let unroundedSig = (accAbs << lzc) >> (g + o + 1)
    let rawJamMask = (1 << (g + o + 1)) - 1
    let jamMask = (rawJamMask >> (lzc > (g + o + 1) ? 0 : (g + o + 1 - lzc)))

    let jamSig = ((accAbs << lzc) & jamMask) != 0
    let roundedSig = unroundedSig | (jamSig ? 1 : 0)
```
In particular:
```
    let jamMask = (rawJamMask >> (lzc > (g + o + 1) ? 0 : (g + o + 1 - lzc)))

    let jamSig = ((accAbs << lzc) & jamMask) != 0
```
should actually either be
```
    let jamMask = (lzc > (g + o + 1)) ? 0 : (rawJamMask >> lzc)

    let jamSig = (accAbs & jamMask) != 0
```


Or 
```
    let jamSig = ((accAbs << lzc) & rawJamMask) != 0
```

### Denormalization and Mask for jamming subnormal results

<img width="1798" height="553" alt="image" src="https://github.com/user-attachments/assets/efd79f49-82ac-4337-9b0c-6f66ef7bfb94" />

Both the denormalization of the result and the mask jamming for subnormal result were incorrect.
For the least normal result, the expected biased exponent is `resExp=1`.
`resExp=0` and any negative `resExp` values correspond to a subnormal result.
if `resExp < -(q-1)`, then the result's MSB is smaller than the least representable subnormal.

Once normalized by the leading zero count `lzc`, the denormalized result can be obtained by keeping (q-1) mantissa bits with the MSB corresponding to `resExp=0`.

### Mask for jamming products

The product jamming scheme looks correct:
<img width="3122" height="984" alt="image" src="https://github.com/user-attachments/assets/0d4463e2-01a6-446b-934a-871d08ad989d" />


### Methodology

To uncover the issues and test the corrections, I have developed a benchmark to compare the pseudo-code (AI generated translation) and the spike implementation: https://github.com/nibrunieAtSi5/riscv-experimental/pull/2.

At the moment, the spike implementation seems clear of issues (
(https://github.com/riscv-software-src/riscv-isa-sim/blob/master/riscv/bulknormdot.h)