### PR TITLE
Clarify that M-mode interrupts are optional

### DIFF
--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1411,6 +1411,21 @@ normative_rule_definitions:
   - name: exc_priority
     tag: "norm:exc_priority"
 
+  - names:
+      - MEI_INTR_IMPL
+      - MTI_INTR_IMPL
+      - MSI_INTR_IMPL
+    tags: ["norm:std_mach_intr_impl"]
+    impl-def-behavior: true
+    kind: extension
+    instance: Sm
+  - names: [MIP_WARL, MIE_WARL]
+    tags: ["norm:mip_mie_warl"]
+    impl-def-behavior: true
+    kind: extension
+    instance: Sm
+    impl-def-category: WARL
+
   # Interrupts - Asynchronous event unrelated to instruction's execution
   - name: intr_mip_mie_op
     tag: "norm:intr_mip_mie_op"

--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -1419,12 +1419,6 @@ normative_rule_definitions:
     impl-def-behavior: true
     kind: extension
     instance: Sm
-  - names: [MIP_WARL, MIE_WARL]
-    tags: ["norm:mip_mie_warl"]
-    impl-def-behavior: true
-    kind: extension
-    instance: Sm
-    impl-def-category: WARL
 
   # Interrupts - Asynchronous event unrelated to instruction's execution
   - name: intr_mip_mie_op

--- a/normative_rule_defs/supervisor.yaml
+++ b/normative_rule_defs/supervisor.yaml
@@ -129,7 +129,6 @@ normative_rule_definitions:
       - SEI_INTR_IMPL
       - STI_INTR_IMPL
       - SSI_INTR_IMPL
-      - LCOFI_INTR_IMPL
     tags: ["norm:std_super_intr_impl"]
     impl-def-behavior: true
     kind: extension

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1313,7 +1313,7 @@ include::images/bytefield/mideleg.edn[]
 
 [#norm:mideleg_enc_txt]#csr:mideleg[] holds trap delegation bits for individual interrupts, with the
 layout of bits matching those in the csr:mip[] register# (i.e., STIP
-interrupt delegation control is located in bit 5).
+interrupt delegation control is located in bit 5).  If a bit of csr:mie[] is read-only zero, the corresponding bit of csr:mideleg[] is also read-only zero.
 
 [#norm:medeleg_when_rd0]#For exceptions that cannot occur in less privileged modes, the
 corresponding csr:medeleg[] bits should be read-only zero. In particular,
@@ -1420,6 +1420,13 @@ reflected in csr:mip[msip] eventually, but not necessarily immediately.#
 if a platform standard supports the delivery of machine-level
 interprocessor interrupts through external interrupts (MEI) instead,
 then csr:mip[msip] and csr:mie[msie] may both be read-only zeros.#
+
+[#norm:std_mach_intr_impl]#Each standard machine interrupt type (MEI, MTI, MSI) may not be implemented,
+in which case the corresponding interrupt-pending and interrupt-enable
+bits are read-only zeros.#
+[#norm:mip_mie_warl]#All bits in `mip` and `mie` are *WARL* fields. The
+implemented interrupts may be found by writing one to every bit location
+in `mie`, then reading back to see which bit positions hold a one.#
 
 [#norm:mip_sxip_mie_sxie_rdonly0]#If supervisor mode is not implemented, bits csr::[seip], csr::[stip], and csr::[ssip] of
 csr:mip[] and csr::[seie], csr::[stie], and csr::[ssie] of csr:mie[] are read-only zeros.#

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1424,9 +1424,9 @@ then csr:mip[msip] and csr:mie[msie] may both be read-only zeros.#
 [#norm:std_mach_intr_impl]#Each standard machine interrupt type (MEI, MTI, MSI) may not be implemented,
 in which case the corresponding interrupt-pending and interrupt-enable
 bits are read-only zeros.#
-[#norm:mip_mie_warl]#All bits in `mip` and `mie` are *WARL* fields. The
+All bits in `mip` and `mie` are *WARL* fields. The
 implemented interrupts may be found by writing one to every bit location
-in `mie`, then reading back to see which bit positions hold a one.#
+in `mie`, then reading back to see which bit positions hold a one.
 
 [#norm:mip_sxip_mie_sxie_rdonly0]#If supervisor mode is not implemented, bits csr::[seip], csr::[stip], and csr::[ssip] of
 csr:mip[] and csr::[seie], csr::[stie], and csr::[ssie] of csr:mie[] are read-only zeros.#

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1313,7 +1313,7 @@ include::images/bytefield/mideleg.edn[]
 
 [#norm:mideleg_enc_txt]#csr:mideleg[] holds trap delegation bits for individual interrupts, with the
 layout of bits matching those in the csr:mip[] register# (i.e., STIP
-interrupt delegation control is located in bit 5).  If a bit of csr:mie[] is read-only zero, the corresponding bit of csr:mideleg[] is also read-only zero.
+interrupt delegation control is located in bit 5).
 
 [#norm:medeleg_when_rd0]#For exceptions that cannot occur in less privileged modes, the
 corresponding csr:medeleg[] bits should be read-only zero. In particular,

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1421,12 +1421,10 @@ if a platform standard supports the delivery of machine-level
 interprocessor interrupts through external interrupts (MEI) instead,
 then csr:mip[msip] and csr:mie[msie] may both be read-only zeros.#
 
-[#norm:std_mach_intr_impl]#Each standard machine interrupt type (MEI, MTI, MSI) may not be implemented,
+[#norm:std_mach_intr_impl]#Each standard machine interrupt type (MEI, MTI, MSI) might not be implemented,
 in which case the corresponding interrupt-pending and interrupt-enable
 bits are read-only zeros.#
-All bits in `mip` and `mie` are *WARL* fields. The
-implemented interrupts may be found by writing one to every bit location
-in `mie`, then reading back to see which bit positions hold a one.
+All bits in `mip` and `mie` are *WARL* fields.
 
 [#norm:mip_sxip_mie_sxie_rdonly0]#If supervisor mode is not implemented, bits csr::[seip], csr::[stip], and csr::[ssip] of
 csr:mip[] and csr::[seie], csr::[stie], and csr::[ssie] of csr:mie[] are read-only zeros.#

--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -462,12 +462,12 @@ implementation-specific means, which will ultimately cause the SSIP bit
 to be set in the recipient hart’s `sip` register.
 ====
 
-[#norm:std_super_intr_impl]#Each standard interrupt type (SEI, STI, SSI, or LCOFI) may not be implemented,
+[#norm:std_super_intr_impl]#Each standard interrupt type (SEI, STI, SSI, or LCOFI) might not be implemented,
 in which case the corresponding interrupt-pending and interrupt-enable
 bits are read-only zeros.#
-[#norm:sip_sie_warl]#All bits in `sip` and `sie` are *WARL* fields. The
+[#norm:sip_sie_warl]#All bits in `sip` and `sie` are *WARL* fields.# The
 implemented interrupts may be found by writing one to every bit location
-in `sie`, then reading back to see which bit positions hold a one.#
+in `sie`, then reading back to see which bit positions hold a one.
 
 [NOTE]
 ====


### PR DESCRIPTION
Added a paragraph to Machine Interrupt section clarifying that mip and mie are WARL and any field can be ROZ.  Language parallels corresponding paragraph in Supervisor Interrupt section.

Updated normative rules to match.  Deleted LCOFI_INTR_IMPL rule because it is implied by Sscofpmf.

If this PR is not accurate, there should be the opposite language that every bit MEI/MTI must be writable.  However, this would be inconsistent with the supervisor interrupts, and also strange that a very simple core would necessarily implement interrupts.

Also a question about whether the following statement is accurate.  Can delete if not accurate.
"If a bit of csr:mie[] is read-only zero, the corresponding bit of csr:mideleg[] is also read-only zero."