### PR TITLE
[BLOCKED on docs-resources#246] Makefile: drop the normative-tags trailing-newline workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,15 +177,10 @@ check-xref-fallbacks: $(DOCS_HTML)
 
 # Regenerate the checked-in normative tags JSON in $(REF_DIR) from the sources.
 #
-# The tags backend (docs-resources/converters/tags.rb) emits JSON with no
-# trailing newline, but pre-commit's end-of-file-fixer requires one, so append
-# it when it is missing. Inside a command substitution `tail -c 1` yields the
-# empty string exactly when the file already ends in a newline.
+# The tags backend (docs-resources/converters/tags.rb) emits a trailing newline
+# as of riscv/docs-resources#246, so no newline fix-up is needed here.
 update-ref: $(DOCS_NORM_TAGS)
 	cp -f $(DOCS_NORM_TAGS) $(REF_DIR)
-	@for f in $(REF_NORM_TAGS); do \
-	  if [ -n "$$(tail -c 1 "$$f")" ]; then printf '\n' >> "$$f"; fi; \
-	done
 
 # Fail if the checked-in normative tags are out of date with respect to the
 # sources.


### PR DESCRIPTION
> [!WARNING]
> **DRAFT — BLOCKED. Do not merge yet.**
> Merging this before the tags backend emits the newline would make `make check-ref` fail (a regenerated `ref/` would lose its trailing newline and pre-commit's `end-of-file-fixer` would reject it).
>
> **Merge only after both:**
> 1. riscv/docs-resources#246 is merged, **and**
> 2. this repo's `docs-resources` submodule is bumped to a commit that includes it.
>
> Ideally fold the submodule bump into this PR (or land it first), then rebase.

The tags backend now emits a trailing newline directly (riscv/docs-resources#246), so `update-ref` no longer needs to append one.

The former fix-up used `tail -c 1` in a command substitution; its original BSD `sed -i .bak` form failed on GNU sed, so the only documented way to regenerate the reference file worked on macOS only — one of the factors behind `ref/` drifting out of date (riscv/docs-resources#245, item 3).

### Validation
Previewed by pointing this repo's `docs-resources` submodule at a branch containing docs-resources#246: `make update-ref` produces a `ref/riscv-spec-norm-tags.json` **byte-for-byte identical** to the committed one, and `make check-ref` passes — i.e. with #246 in place the removed `tail -c 1` step is provably a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
