### PR TITLE
Clarify PMM fence handling

### DIFF
--- a/normative_rule_defs/supervisor.yaml
+++ b/normative_rule_defs/supervisor.yaml
@@ -232,6 +232,8 @@ normative_rule_definitions:
 
   - name: senvcfg_pmm_Ssnpm
     tags: ["norm:senvcfg_pmm_Ssnpm"]
+  - name: senvcfg_pmm_immediate
+    tags: ["norm:senvcfg_pmm_immediate"]
 
   - names: [senvcfg_lpe_Zicfilp_acc, senvcfg_lpe_Zicfilp_op]
     tags: ["norm:senvcfg_lpe_Zicfilp"]

--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -2145,6 +2145,7 @@
     "norm:cbo-inval_s-mode_op1": "",
     "norm:cbo-inval_s-mode_op2": "",
     "norm:senvcfg_pmm_Ssnpm": "If the Ssnpm extension is implemented, the PMM field enables or disables pointer masking (see ) for the next-lower privilege mode (U/VU), according to the values in . If Ssnpm is not implemented, PMM is read-only zero. The PMM field is read-only zero for RV32.",
+    "norm:senvcfg_pmm_immediate": "Changing senvcfg.PMM takes effect immediately, without the need to execute an SFENCE.VMA instruction.",
     "norm:senvcfg_lpe_Zicfilp": "The Zicfilp extension adds the LPE field in senvcfg. When the LPE field is set to 1, the Zicfilp extension is enabled in VU/U-mode. When the LPE field is 0, the Zicfilp extension is not enabled in VU/U-mode and the following rules apply to VU/U-mode:",
     "norm:senvcfg_sse_Zicfilp": "The Zicfiss extension adds the SSE field in senvcfg. When the SSE field is set to 1, the Zicfiss extension is activated in VU/U-mode. When the SSE field is 0, the Zicfiss extension remains inactive in VU/U-mode, and the following rules apply:",
     "norm:satp": "The satp CSR is an SXLEN-bit read/write register, formatted as shown in  for SXLEN=32 and  for SXLEN=64, which controls supervisor-mode address translation and protection. This register holds the physical page number (PPN) of the root page table, i.e., its supervisor physical address divided by 4 KiB; an address space identifier (ASID), which facilitates address-translation fences on a per-address-space basis; and the MODE field, which selects the current address-translation scheme. Further details on the access to this register are described in .",
@@ -10950,6 +10951,7 @@
                       "norm:cbo-inval_s-mode_op1",
                       "norm:cbo-inval_s-mode_op2",
                       "norm:senvcfg_pmm_Ssnpm",
+                      "norm:senvcfg_pmm_immediate",
                       "norm:senvcfg_lpe_Zicfilp",
                       "norm:senvcfg_sse_Zicfilp"
                     ]

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -2135,6 +2135,9 @@ supervisor physical addresses. When running with virtualization in VS/VU mode
 with csr:vsatp[mode]=Bare, this means that those qty:2[bits] may be subject to
 pointer masking, depending on csr:hgatp[mode] and csr:senvcfg[pmm] or csr:henvcfg[pmm] (for
 VU/VS mode). If csr:vsatp[mode]{ne}Bare, this issue does *not* apply.
+Those qty:2[bits] may likewise be subject to pointer masking according to
+csr:hstatus[hupmm] for explicit memory accesses made by `HLV.\*` or `HSV.*`
+instructions in U-mode as though in VU-mode.
 
 [NOTE]
 ====
@@ -2149,8 +2152,9 @@ entries.
 
 To support implementations where (XLEN-PMLEN) can be less than the GPA width
 supported by `hgatp.MODE`, hypervisors should execute an `HFENCE.GVMA` with
-_rs1_=`x0` if the `henvcfg.PMM` is changed from or to a value where (XLEN-PMLEN)
-is less than GPA width supported by the `hgatp` translation mode of that guest.
+_rs1_=`x0` if either `henvcfg.PMM` or `hstatus.HUPMM` is changed from or to a
+value where (XLEN-PMLEN) is less than GPA width supported by the `hgatp`
+translation mode of that guest.
 Specifically, these cases are:
 
 * `PMLEN=7` and `hgatp.MODE=sv57x4`

--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -931,6 +931,10 @@ according to the values in <<senvcfg_pmm-values>>. If Ssnpm is not
 implemented, `PMM` is read-only zero. The `PMM` field is read-only zero for
 RV32.
 
+[[norm:senvcfg_pmm_immediate]]
+Changing `senvcfg.PMM` takes effect immediately, without the need to execute an
+`SFENCE.VMA` instruction.
+
 [[senvcfg_pmm-values]]
 
 [%header, cols="25%,75%", options="header"]


### PR DESCRIPTION
Clarifies pointer masking behavior, following #2613:

- Extends the GPA masking and `HFENCE.GVMA` guidance (for `vsatp.MODE=Bare`) to `hstatus.HUPMM`.
- Specifies in the supervisor chapter that `senvcfg.PMM` changes take effect immediately without `SFENCE.VMA`, avoiding TLB flushes on context switches.
