### PR TITLE
supervisor: correct "step 0" to "step 1" in translation-cache text

### DIFF
--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -1789,7 +1789,7 @@ with other harts. The address-translation cache may hold an arbitrary
 number of entries, including an arbitrary number of entries for the same
 address and ASID. Entries in the address-translation cache may then
 satisfy subsequent step 2 reads if the ASID associated with the entry
-matches the ASID loaded in step 0 or if the entry is associated with a
+matches the ASID loaded in step 1 or if the entry is associated with a
 _global_ mapping. To ensure that implicit reads observe writes to the
 same memory locations, an SFENCE.VMA instruction must be executed after
 the writes to flush the relevant cached translations.


### PR DESCRIPTION
`src/priv/supervisor.adoc:1792` refers to "the ASID loaded in **step 0**", but the translation algorithm is 1-indexed and has no step 0 — the `satp`/ASID load is **step 1**. Editorial only.