### PR TITLE
rvwmo, zalrsc, zalasr: fix editorial typos in atomics/MCM text

### DIFF
--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -376,7 +376,7 @@
     "norm:sdrl_atomic_store_op": "This instruction stores 2^width^ bytes of memory from rs1 atomically.",
     "norm:sdrl_rl_required": "This store must have ordering annotation rl",
     "norm:sdrl_aq_optional": "may have ordering annotation aq encoded in the instruction.",
-    "norm:sdrl_rcsc_semantics": "The instruction always has an release-RCsc annotation, and if the bit aq is set the instruction has a acquire-RCsc annotation.",
+    "norm:sdrl_rcsc_semantics": "The instruction always has a release-RCsc annotation, and if the bit aq is set the instruction has an acquire-RCsc annotation.",
     "norm:sdrl_no_rl_reserved": "The versions without the rl bit set are RESERVED.",
     "norm:sdrl_rv64_only": "insn:sd.{rl,aqrl}[] is RV64-only.",
     "norm:Zabha_rd_sign_extension": "Byte and halfword AMOs always sign-extend the value placed in rd, and ignore\nthe 0 bits of the original value in rs2.",

--- a/src/unpriv/mm-explanatory.adoc
+++ b/src/unpriv/mm-explanatory.adoc
@@ -504,9 +504,7 @@ indirection.
 
 [[frirfi]]
 .A litmus test MP+fence.w.w+fri-rfi-addr (outcome permitted)
-
 [float="center",align="center",cols=".^1a,.^1a",frame="none",grid="none",options="noheader"]
-.Litmus test MP+fence.w.w+fre-rfi-addr (outcome permitted)
 |===
 |
 [%autowidth,cols="^,<,^,<",options="header",float="center",align="center"]

--- a/src/unpriv/zalasr.adoc
+++ b/src/unpriv/zalasr.adoc
@@ -120,7 +120,7 @@ Description::
 
 [#norm:sdrl_atomic_store_op]#This instruction stores 2^width^ bytes of memory from rs1 atomically.#
 [#norm:sdrl_rl_required]#This store must have ordering annotation _rl_# and [#norm:sdrl_aq_optional]#may have ordering annotation _aq_ encoded in the instruction.#
-[#norm:sdrl_rcsc_semantics]#The instruction always has an release-RCsc annotation, and if the bit _aq_ is set the instruction has a acquire-RCsc annotation.#
+[#norm:sdrl_rcsc_semantics]#The instruction always has a release-RCsc annotation, and if the bit _aq_ is set the instruction has an acquire-RCsc annotation.#
 +
 [#norm:sdrl_no_rl_reserved]#The versions without the _rl_ bit set are RESERVED.#
 [#norm:sdrl_rv64_only]#insn:sd.{rl,aqrl}[] is RV64-only.#

--- a/src/unpriv/zalrsc.adoc
+++ b/src/unpriv/zalrsc.adoc
@@ -156,7 +156,7 @@ the insn:lr[] instruction that established the reservation.#
 ====
 The insn:lr[]/insn:sc[] sequence can be given acquire semantics by setting the
 _aq_ bit on the insn:lr[] instruction. The insn:lr[]/insn:sc[] sequence can be
-given release semantics by by setting the _rl_ bit on the insn:sc[] instruction.
+given release semantics by setting the _rl_ bit on the insn:sc[] instruction.
 Assuming suitable mappings for other atomic operations, setting the _aq_ bit on
 the insn:lr[] instruction, and setting the _rl_ bit on the insn:sc[] instruction
 makes the insn:lr[]/insn:sc[] sequence sequentially consistent in the {cpp}


### PR DESCRIPTION
Three editorial typos in the memory-model / atomics chapters; no semantic change.

- **`mm-explanatory.adoc`:** the fri-rfi litmus figure had two block titles; drop the duplicate.
- **`zalrsc.adoc`:** drop duplicated "by".
- **`zalasr.adoc`:** article agreement ("a release-RCsc", "an acquire-RCsc").