### PR TITLE
Bump actions/checkout@v4 to v7

### DIFF
--- a/.github/workflows/check-normative-tags.yml
+++ b/.github/workflows/check-normative-tags.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           # Needed so the report can read ref/*.json as of the base revision.


### PR DESCRIPTION
bumps actions/checkout v4 to v7 as it was missed when dependabot was not running. Signed-off-by: Bill Traynor wmat@riscv.org