### PR TITLE
ci: gate autofix on update-norm-rules label and exempt bots from DCO

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,8 +3,17 @@
 
 name: autofix.ci
 
+# Regenerating the normative tag reference commits back to the PR, so it only
+# runs on demand: a maintainer applies the 'update-norm-rules' label when the PR
+# is otherwise ready, and this pushes the fresh ref/ before merge. `labeled`
+# fires on that apply; `synchronize`/`reopened` keep ref/ fresh on later pushes
+# while the label remains (the job `if` below enforces the label on every event).
 on:
   pull_request:
+    types:
+      - labeled
+      - synchronize
+      - reopened
 
 # Only run on the latest commit if a PR is updated
 concurrency:
@@ -17,6 +26,9 @@ permissions:
 jobs:
   autofix:
     name: Regenerate checked-in normative tag reference
+    # On demand only: gated behind the 'update-norm-rules' label so the bot push
+    # happens when a maintainer asks for it, not on every PR update.
+    if: contains(github.event.pull_request.labels.*.name, 'update-norm-rules')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-normative-tags.yml
+++ b/.github/workflows/check-normative-tags.yml
@@ -182,12 +182,15 @@ jobs:
       # ref/ is stale still gets to see what actually changed.
       #
       # check-ref regenerates the files, so its own advice ("commit the result")
-      # is aimed at someone running it locally. Here the fix has to happen on the
-      # contributor's machine, so say that instead.
+      # is aimed at someone running it locally. Here the fix has to happen either
+      # on the contributor's machine or via the on-demand autofix workflow, so
+      # point at both: a maintainer can apply the 'update-norm-rules' label to
+      # have autofix regenerate and commit the files, or the contributor can
+      # regenerate locally.
       - name: Verify ref/ is up to date
         run: |
           if ! make check-ref; then
-            echo "::error::Normative tag reference files are out of date. Run 'make update-ref' locally and commit the result."
+            echo "::error::Normative tag reference files are out of date. A maintainer can apply the 'update-norm-rules' label to have autofix regenerate and commit them, or run 'make update-ref' locally and commit the result."
             exit 1
           fi
 

--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -33,8 +33,18 @@ jobs:
               pull_number: pr.number,
             });
 
+            // Bots (e.g. autofix-ci[bot] pushing regenerated normative rules,
+            // dependabot) cannot sign off their commits, so exclude them from
+            // the DCO requirement. GitHub resolves the author to a user object
+            // whose type is 'Bot' and whose login ends in '[bot]'.
+            const isBot = (user) =>
+              !!user && (user.type === 'Bot' || /\[bot\]$/.test(user.login || ''));
+
             const dcoFailedCommits = commits.filter(
-              (commit) => !/Signed-off-by:/.test(commit.commit.message)
+              (commit) =>
+                !isBot(commit.author) &&
+                !isBot(commit.committer) &&
+                !/Signed-off-by:/.test(commit.commit.message)
             );
 
             if (dcoFailedCommits.length > 0) {


### PR DESCRIPTION
## Summary

Makes the normative-rule autofix run **on demand** and stops its bot commit from failing the DCO check.

- **autofix**: gate the regeneration workflow behind a new `update-norm-rules` label (triggers on `labeled`, plus `synchronize`/`reopened` while the label is present). Instead of running on every PR update, a maintainer applies the label when a PR that changes normative rules is ready, and autofix regenerates `ref/` and pushes it before merge.
- **DCO**: exempt bot-authored/-committed commits from the sign-off requirement. The autofix push lands as `autofix-ci[bot]`, and bots cannot sign off their commits, so without this the bot commit fails DCO (observed on #3269). Human commits are still required to be signed off.
- **Signposting**: the `check-normative-tags` freshness error now tells the maintainer to apply the `update-norm-rules` label (or regenerate locally), so the trigger is discoverable on the failing check itself.

## Setup

The `update-norm-rules` label has been created in the repo so maintainers can apply it.

## Notes

- `autofix-ci` only commits when there is an actual diff, so gated re-runs on later pushes add no empty/noise commits.
- The autofix workflow is the *mechanism*; the merge gate remains `check-normative-tags`' freshness check, which goes green once the regenerated `ref/` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)