### PR TITLE
Add zvabd extension and integrate with normative-rule pipeline

### DIFF
--- a/normative_rule_defs/zvabd.yaml
+++ b/normative_rule_defs/zvabd.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=../docs-resources/schemas/defs-schema.json
+
+$schema: "../docs-resources/schemas/defs-schema.json#"
+
+chapter_name: Vector Extension for Integer Absolute Difference Instructions
+
+normative_rule_definitions:
+
+  - name: Zvabd_dependent_Zve32x
+    tags: ["norm:Zvabd_dependent_Zve32x"]
+
+  - name: Zvabd_eew
+    tags: ["norm:Zvabd_eew", "norm:Zvabd_eew_Zve64x"]
+
+  - name: vabs_op
+    tags: ["norm:vabs_op"]
+
+  - name: vabd_sew_rsv
+    tags: ["norm:vabd_sew_rsv"]
+
+  - name: vabd_op
+    tags: ["norm:vabd_op"]
+
+  - name: vabd_sew_defined
+    tags: ["norm:vabd_sew_defined"]
+
+  - name: vabdu_sew_rsv
+    tags: ["norm:vabdu_sew_rsv"]
+
+  - name: vabdu_op
+    tags: ["norm:vabdu_op"]
+
+  - name: vabdu_sew_defined
+    tags: ["norm:vabdu_sew_defined"]
+
+  - name: vwabda_sew_rsv
+    tags: ["norm:vwabda_sew_rsv"]
+
+  - name: vwabda_op
+    tags: ["norm:vwabda_op"]
+
+  - name: vwabda_sew_defined
+    tags: ["norm:vwabda_sew_defined"]
+
+  - name: vwabdau_sew_rsv
+    tags: ["norm:vwabdau_sew_rsv"]
+
+  - name: vwabdau_op
+    tags: ["norm:vwabdau_op"]
+
+  - name: vwabdau_sew_defined
+    tags: ["norm:vwabdau_sew_defined"]

--- a/normative_rule_defs/zvabd.yaml
+++ b/normative_rule_defs/zvabd.yaml
@@ -10,12 +10,6 @@ normative_rule_definitions:
   - name: Zvabd_dependent_Zve32x
     tags: ["norm:Zvabd_dependent_Zve32x"]
 
-  - name: Zvabd_eew
-    tags: ["norm:Zvabd_eew", "norm:Zvabd_eew_Zve64x"]
-
-  - name: vabs_op
-    tags: ["norm:vabs_op"]
-
   - name: vabd_sew_rsv
     tags: ["norm:vabd_sew_rsv"]
 

--- a/normative_rule_defs/zvabd.yaml
+++ b/normative_rule_defs/zvabd.yaml
@@ -10,17 +10,11 @@ normative_rule_definitions:
   - name: Zvabd_dependent_Zve32x
     tags: ["norm:Zvabd_dependent_Zve32x"]
 
-  - name: vabd_sew_rsv
-    tags: ["norm:vabd_sew_rsv"]
-
   - name: vabd_op
     tags: ["norm:vabd_op"]
 
   - name: vabd_sew_defined
     tags: ["norm:vabd_sew_defined"]
-
-  - name: vabdu_sew_rsv
-    tags: ["norm:vabdu_sew_rsv"]
 
   - name: vabdu_op
     tags: ["norm:vabdu_op"]

--- a/src/unpriv/zv.adoc
+++ b/src/unpriv/zv.adoc
@@ -38,6 +38,7 @@ include::zvfbfmin.adoc[]
 include::zvfbfwma.adoc[]
 include::zvbb.adoc[]
 include::zvbc.adoc[]
+include::zvabd.adoc[]
 
 === Vector Instruction Listing
 

--- a/src/unpriv/zvabd.adoc
+++ b/src/unpriv/zvabd.adoc
@@ -14,15 +14,14 @@ Below is a list of all of the instructions that are included in the extension.
 |Mnemonic
 |Instruction
 
-| vabs.v             | <<insns-vabs>>
-| vabd.vv            | <<insns-vabd>>
-| vabdu.vv           | <<insns-vabdu>>
-| vwabda.vv        | <<insns-vwabda>>
-| vwabdau.vv       | <<insns-vwabdau>>
+| vabd.vv / vabd.vx         | <<insns-vabd>>
+| vabdu.vv / vabdu.vx       | <<insns-vabdu>>
+| vwabda.vv / vwabda.vx     | <<insns-vwabda>>
+| vwabdau.vv / vwabdau.vx   | <<insns-vwabdau>>
 
 |===
 
-NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16. Additionally, `vabs` is considered to support all the element sizes as it is quite common used and simple to implement.
+NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, Zvabd are designed for only SEW=8 and SEW=16.
 
 [#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend upon ext:zve32x[].#
 
@@ -31,153 +30,17 @@ The semantics of each instruction is expressed in a SAIL-like syntax, following 
 
 ==== Instructions
 
-[[insns-vabs, Vector Signed Integer Absolute]]
-===== insn:vabs.v[]
-
-Synopsis::
-Vector Single-Width Signed Integer Absolute
-
-Mnemonic::
-vabs.v _vd_, _vs2_, _vm_
-
-Encoding::
-[wavedrom, , svg]
-....
-{reg: [
-  {bits: 7, name: 'OP-V'},
-  {bits: 5, name: 'vd'},
-  {bits: 3, name: 'OPMVV'},
-  {bits: 5, name: 0x10},
-  {bits: 5, name: 'vs2'},
-  {bits: 1, name: 'vm', attr: 'vm'},
-  {bits: 6, name: 'VXUNARY0', attr: 'funct6'},
-]}
-....
-
-Description::
-[#norm:vabs_op]#An absolute value operation is performed on each element of vs2#
-
-[#norm:Zvabd_eew]#vabs provide support for SEW of 8, 16, and 32.# [#norm:Zvabd_eew_Zve64x]#If ext:zve64x[] is supported then vabs also add support for SEW 64.#
-
-Operation::
-[source,sail]
---
-let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == 0b1 then
-        result[i] = to_bits(SEW, abs_int(signed(vs2_val[i])));
-}
-write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-set_vstart(zeros());
-RETIRE_SUCCESS
---
-
 [[insns-vabd, Vector Signed Integer Absolute Difference]]
-===== insn:vabd.vv[]
+===== insn:vabd.vv[] and insn:vabd.vx[]
 
 Synopsis::
 Vector Single-Width Signed Integer Absolute Difference
 
 Mnemonic::
-vabd.vv _vd_, _vs2_, _vs1_, _vm_
+vabd.vv _vd_, _vs2_, _vs1_, _vm_ +
+vabd.vx _vd_, _vs2_, _rs1_, _vm_
 
-Encoding::
-[wavedrom, , svg]
-....
-{reg: [
-  {bits: 7, name: 'OP-V'},
-  {bits: 5, name: 'vd'},
-  {bits: 3, name: 'OPMVV'},
-  {bits: 5, name: 'vs1'},
-  {bits: 5, name: 'vs2'},
-  {bits: 1, name: 'vm', attr: 'vm'},
-  {bits: 6, name: 0x11, attr: 'funct6'},
-]}
-....
-
-Reserved Encodings::
-* [#norm:vabd_sew_rsv]#`SEW` is neither 8 nor 16.#
-
-Description::
-[#norm:vabd_op]#This instruction computes the absolute difference between the elements of two signed integer SEW-bit source operands vs1 and vs2.#
-
-[#norm:vabd_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
-
-Operation::
-[source,sail]
---
-let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == 0b1 then {
-        result[i] = to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(vs1_val[i])));
-    }
-}
-write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-set_vstart(zeros());
-RETIRE_SUCCESS
---
-
-[[insns-vabdu, Vector Unsigned Integer Absolute Difference]]
-===== insn:vabdu.vv[]
-
-Synopsis::
-Vector Single-Width Unsigned Integer Absolute Difference
-
-Mnemonic::
-vabdu.vv _vd_, _vs2_, _vs1_, _vm_
-
-Encoding::
-[wavedrom, , svg]
-....
-{reg: [
-  {bits: 7, name: 'OP-V'},
-  {bits: 5, name: 'vd'},
-  {bits: 3, name: 'OPMVV'},
-  {bits: 5, name: 'vs1'},
-  {bits: 5, name: 'vs2'},
-  {bits: 1, name: 'vm', attr: 'vm'},
-  {bits: 6, name: 0x13, attr: 'funct6'},
-]}
-....
-
-Reserved Encodings::
-* [#norm:vabdu_sew_rsv]#`SEW` is neither 8 nor 16.#
-
-Description::
-[#norm:vabdu_op]#This instruction computes the absolute difference between the elements of two unsigned integer SEW-bit source operands vs1 and vs2.#
-
-[#norm:vabdu_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
-
-Operation::
-[source,sail]
---
-let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == 0b1 then {
-        result[i] = {
-            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
-                           then unsigned(vs2_val[i] - vs1_val[i])
-                           else unsigned(vs1_val[i] - vs2_val[i]);
-            to_bits(SEW, abs_diff);
-        } 
-        
-    };
-};
-write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-set_vstart(zeros());
-RETIRE_SUCCESS
---
-
-[[insns-vwabda, Vector Signed Integer Absolute Difference And Accumulate]]
-===== insn:vwabda.vv[]
-
-Synopsis::
-    Vector Widening Signed Integer Absolute Difference and Accumulate, Overwrite Addend
-
-Mnemonic::
-vwabda.vv _vd_, _vs2_, _vs1_, _vm_
-
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg: [
@@ -191,43 +54,75 @@ Encoding::
 ]}
 ....
 
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVX'},
+  {bits: 5, name: 'rs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x15, attr: 'funct6'},
+]}
+....
+
 Reserved Encodings::
-* [#norm:vwabda_sew_rsv]#`SEW` is neither 8 nor 16.#
+* [#norm:vabd_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Arguments::
+
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register
+|Direction
+|Definition
+
+| _vs1_/_rs1_ | input  | Op1
+| _vs2_       | input  | Op2
+| _vd_        | output | Absolute difference
+|===
 
 Description::
-[#norm:vwabda_op]#This instruction computes the absolute difference between the elements of two signed integer SEW-bit source operands vs1 and vs2, and accumulates the results into the elements of a 2*SEW-bit integer operand vd.#
+[#norm:vabd_op]#This instruction computes the absolute difference between the signed integer SEW-bit `Op1` and `Op2` elements, writing the result into the SEW-bit elements in _vd_.#
 
-[#norm:vwabda_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+[#norm:vabd_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
 
 Operation::
 [source,sail]
 --
-let SEW_widen = SEW * 2;
-let LMUL_pow_widen = LMUL_pow + 1;
-let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then {
-        result[i] = {
-            let diff = signed(vs2_val[i]) - signed(vs1_val[i]);
-            to_bits_unsafe(SEW_widen, signed(vd_val[i]) + abs_int(diff));
-        }
+        let op1 = match suffix {
+            "vv" => vs1_val[i],
+            "vx" => sext_or_truncate_to_sew(X(rs1))
+        };
+        result[i] = to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(op1)));
     }
 }
-write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+write_vreg(num_elem, SEW, LMUL_pow, vd, result);
 set_vstart(zeros());
 RETIRE_SUCCESS
 --
 
-[[insns-vwabdau, Vector Unsigned Integer Absolute Difference And Accumulate]]
-===== insn:vwabdau.vv[]
+NOTE: A vector of integer values can have its absolute value computed using an
+absolute-difference instruction with a scalar operand of `x0`. An
+assembly pseudoinstruction insn:vabs.v[vd,vs2] = insn:vabd.vx[vd,vs2,x0] is provided.
+
+[[insns-vabdu, Vector Unsigned Integer Absolute Difference]]
+===== insn:vabdu.vv[] and insn:vabdu.vx[]
 
 Synopsis::
-Vector Widening Unsigned Integer Absolute Difference and Accumulate, Overwrite Addend.
+Vector Single-Width Unsigned Integer Absolute Difference
 
 Mnemonic::
-vwabdau.vv _vd_, _vs2_, _vs1_, _vm_
+vabdu.vv _vd_, _vs2_, _vs1_, _vm_ +
+vabdu.vx _vd_, _vs2_, _rs1_, _vm_
 
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg: [
@@ -241,11 +136,205 @@ Encoding::
 ]}
 ....
 
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVX'},
+  {bits: 5, name: 'rs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x16, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vabdu_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Arguments::
+
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register
+|Direction
+|Definition
+
+| _vs1_/_rs1_ | input  | Op1
+| _vs2_       | input  | Op2
+| _vd_        | output | Absolute difference
+|===
+
+Description::
+[#norm:vabdu_op]#This instruction computes the absolute difference between the unsigned integer SEW-bit `Op1` and `Op2` elements, writing the result into the SEW-bit elements in _vd_.#
+
+[#norm:vabdu_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+        result[i] = {
+            let op1 = match suffix {
+                "vv" => vs1_val[i],
+                "vx" => sext_or_truncate_to_sew(X(rs1))
+            };
+            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(op1)
+                           then unsigned(vs2_val[i] - op1)
+                           else unsigned(op1 - vs2_val[i]);
+            to_bits(SEW, abs_diff);
+        }
+    };
+};
+write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vwabda, Vector Signed Integer Absolute Difference And Accumulate]]
+===== insn:vwabda.vv[] and insn:vwabda.vx[]
+
+Synopsis::
+    Vector Widening Signed Integer Absolute Difference and Accumulate, Overwrite Addend
+
+Mnemonic::
+vwabda.vv _vd_, _vs2_, _vs1_, _vm_ +
+vwabda.vx _vd_, _vs2_, _rs1_, _vm_
+
+Encoding (Vector-Vector)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPIVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x3D, attr: 'funct6'},
+]}
+....
+
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPIVX'},
+  {bits: 5, name: 'rs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x3D, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vwabda_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Arguments::
+
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register
+|Direction
+|Definition
+
+| _vs1_/_rs1_ | input        | Op1
+| _vs2_       | input        | Op2
+| _vd_        | input/output | Accumulator and result (2*SEW-bit)
+|===
+
+Description::
+[#norm:vwabda_op]#This instruction computes the absolute difference between the signed integer SEW-bit `Op1` and `Op2` elements, and accumulates the results into the 2*SEW-bit accumulator elements in _vd_.#
+
+[#norm:vwabda_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let SEW_widen = SEW * 2;
+let LMUL_pow_widen = LMUL_pow + 1;
+let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+        result[i] = {
+            let op1 = match suffix {
+                "vv" => vs1_val[i],
+                "vx" => sext_or_truncate_to_sew(X(rs1))
+            };
+            let diff = signed(vs2_val[i]) - signed(op1);
+            to_bits_truncate(SEW_widen, signed(vd_val[i]) + abs_int(diff));
+        }
+    }
+}
+write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vwabdau, Vector Unsigned Integer Absolute Difference And Accumulate]]
+===== insn:vwabdau.vv[] and insn:vwabdau.vx[]
+
+Synopsis::
+Vector Widening Unsigned Integer Absolute Difference and Accumulate, Overwrite Addend.
+
+Mnemonic::
+vwabdau.vv _vd_, _vs2_, _vs1_, _vm_ +
+vwabdau.vx _vd_, _vs2_, _rs1_, _vm_
+
+Encoding (Vector-Vector)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPIVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x3E, attr: 'funct6'},
+]}
+....
+
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPIVX'},
+  {bits: 5, name: 'rs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x3E, attr: 'funct6'},
+]}
+....
+
 Reserved Encodings::
 * [#norm:vwabdau_sew_rsv]#`SEW` is neither 8 nor 16.#
 
+Arguments::
+
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register
+|Direction
+|Definition
+
+| _vs1_/_rs1_ | input        | Op1
+| _vs2_       | input        | Op2
+| _vd_        | input/output | Accumulator and result (2*SEW-bit)
+|===
+
 Description::
-[#norm:vwabdau_op]#This instruction computes the absolute difference between the elements of two unsigned integer SEW-bit source operands vs1 and vs2, and accumulates the results into the elements of a 2*SEW-bit integer operand vd.#
+[#norm:vwabdau_op]#This instruction computes the absolute difference between the unsigned integer SEW-bit `Op1` and `Op2` elements, and accumulates the results into the 2*SEW-bit accumulator elements in _vd_.#
 
 [#norm:vwabdau_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
 
@@ -258,10 +347,14 @@ let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_
 foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then {
         result[i] = {
-            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
-                           then unsigned(vs2_val[i] - vs1_val[i])
-                           else unsigned(vs1_val[i] - vs2_val[i]);
-            to_bits_unsafe(SEW_widen, unsigned(vd_val[i]) + abs_diff);
+            let op1 = match suffix {
+                "vv" => vs1_val[i],
+                "vx" => sext_or_truncate_to_sew(X(rs1))
+            };
+            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(op1)
+                           then unsigned(vs2_val[i] - op1)
+                           else unsigned(op1 - vs2_val[i]);
+            to_bits_truncate(SEW_widen, unsigned(vd_val[i]) + abs_diff);
         }
     }
 }

--- a/src/unpriv/zvabd.adoc
+++ b/src/unpriv/zvabd.adoc
@@ -1,0 +1,260 @@
+[[ext:zvabd]]
+=== ext:zvabd[] Vector Extension for Integer Vector Absolute Difference Instructions
+
+==== Introduction
+This document describes the Zvabd extension for instructions that compute the element-wise absolute difference of vectors. That is, given two vectors v and u, compute the vector y such that stem:[y_i = abs(v_i - u_i)] and stem:[y_i += abs(v_i - u_i)].
+
+These operations are widely utilized in image registration, object recognition, motion estimation and loop filters for video workloads.
+
+==== Extension Overview
+The Zvabd extension follows the vector arithmetic instruction specification in "V" Standard Extension.
+
+Below is a list of all of the instructions that are included in the extension.
+[%autowidth]
+[%header,cols="2,4"]
+|===
+|Mnemonic
+|Instruction
+
+| vabs.v             | <<insns-vabs>>
+| vabd.vv            | <<insns-vabd>>
+| vabdu.vv           | <<insns-vabdu>>
+| vwabda.vv        | <<insns-vwabda>>
+| vwabdau.vv       | <<insns-vwabdau>>
+
+|===
+
+NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16. Additionally, `vabs` is considered to support all the element sizes as it is quite common used and simple to implement.
+
+[#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend on ext:zve32x[].#
+
+[#norm:Zvabd_eew]#If ext:zve32x[] is supported then vabs provide support for SEW of 8, 16, and 32.# [#norm:Zvabd_eew_Zve64x]#If ext:zve64x[] is supported then vabs also add support for SEW 64.#
+
+==== Pseudocode for instruction semantics
+The semantics of each instruction is expressed in a SAIL-like syntax, following the link:https://github.com/riscv/sail-riscv/tree/master/model/extensions/V[RISC-V Vector Sail Model].
+
+==== Instructions
+
+[[insns-vabs, Vector Signed Integer Absolute]]
+===== insn:vabs.v[]
+
+Synopsis::
+Vector Single-Width Signed Integer Absolute
+
+Mnemonic::
+vabs.v _vd_, _vs2_, _vm_
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 0x10},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 'VXUNARY0', attr: 'funct6'},
+]}
+....
+
+Description::
+[#norm:vabs_op]#An absolute value operation is performed on each element of vs2#
+
+Operation::
+[source,sail]
+--
+let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        result[i] = abs(signed(vs2_val[i]));
+    }
+}
+write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vabd, Vector Signed Integer Absolute Difference]]
+===== insn:vabd.vv[]
+
+Synopsis::
+Vector Single-Width Signed Integer Absolute Difference
+
+Mnemonic::
+vabd.vv _vd_, _vs2_, _vs1_, _vm_
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x11, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vabd_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Description::
+[#norm:vabd_op]#This instruction computes the absolute difference between the elements of two signed integer SEW-bit source operands vs1 and vs2.#
+
+[#norm:vabd_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        result[i] = max(vs2_val[i], vs1_val[i]) - min(vs2_val[i], vs1_val[i]);
+    }
+}
+write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vabdu, Vector Unsigned Integer Absolute Difference]]
+===== insn:vabdu.vv[]
+
+Synopsis::
+Vector Single-Width Unsigned Integer Absolute Difference
+
+Mnemonic::
+vabdu.vv _vd_, _vs2_, _vs1_, _vm_
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x13, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vabdu_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Description::
+[#norm:vabdu_op]#This instruction computes the absolute difference between the elements of two unsigned integer SEW-bit source operands vs1 and vs2.#
+
+[#norm:vabdu_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        result[i] = maxu(vs2_val[i], vs1_val[i]) - minu(vs2_val[i], vs1_val[i]);
+    }
+}
+write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vwabda, Vector Signed Integer Absolute Difference And Accumulate]]
+===== insn:vwabda.vv[]
+
+Synopsis::
+    Vector Widening Signed Integer Absolute Difference and Accumulate, Overwrite Addend
+
+Mnemonic::
+vwabda.vv _vd_, _vs2_, _vs1_, _vm_
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x15, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vwabda_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Description::
+[#norm:vwabda_op]#This instruction computes the absolute difference between the elements of two signed integer SEW-bit source operands vs1 and vs2, and accumulates the results into the elements of a 2*SEW-bit integer operand vd.#
+
+[#norm:vwabda_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let SEW_widen = SEW * 2;
+let LMUL_pow_widen = LMUL_pow + 1;
+let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        result[i] = to_bits_unsafe(SEW_widen, max(vs2_val[i], vs1_val[i]) - min(vs2_val[i], vs1_val[i]) ) + vd_val[i];
+    }
+}
+write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--
+
+[[insns-vwabdau, Vector Unsigned Integer Absolute Difference And Accumulate]]
+===== insn:vwabdau.vv[]
+
+Synopsis::
+Vector Widening Unsigned Integer Absolute Difference and Accumulate, Overwrite Addend.
+
+Mnemonic::
+vwabdau.vv _vd_, _vs2_, _vs1_, _vm_
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+  {bits: 7, name: 'OP-V'},
+  {bits: 5, name: 'vd'},
+  {bits: 3, name: 'OPMVV'},
+  {bits: 5, name: 'vs1'},
+  {bits: 5, name: 'vs2'},
+  {bits: 1, name: 'vm', attr: 'vm'},
+  {bits: 6, name: 0x16, attr: 'funct6'},
+]}
+....
+
+Reserved Encodings::
+* [#norm:vwabdau_sew_rsv]#`SEW` is neither 8 nor 16.#
+
+Description::
+[#norm:vwabdau_op]#This instruction computes the absolute difference between the elements of two unsigned integer SEW-bit source operands vs1 and vs2, and accumulates the results into the elements of a 2*SEW-bit integer operand vd.#
+
+[#norm:vwabdau_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+
+Operation::
+[source,sail]
+--
+let SEW_widen = SEW * 2;
+let LMUL_pow_widen = LMUL_pow + 1;
+let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        result[i] = to_bits_unsafe(SEW_widen, maxu(vs2_val[i], vs1_val[i]) - minu(vs2_val[i], vs1_val[i]) ) + vd_val[i];
+    }
+}
+write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+set_vstart(zeros());
+RETIRE_SUCCESS
+--

--- a/src/unpriv/zvabd.adoc
+++ b/src/unpriv/zvabd.adoc
@@ -21,9 +21,9 @@ Below is a list of all of the instructions that are included in the extension.
 
 |===
 
-NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, vwabda/vwabdau are designed for only SEW=8 and SEW=16.
+NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integers, vwabda/vwabdau are designed for only SEW=8 and SEW=16.
 
-[#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend upon ext:zve32x[].#
+[#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depends upon ext:zve32x[].#
 
 ==== Pseudocode for instruction semantics
 The semantics of each instruction is expressed in a SAIL-like syntax, following the link:https://github.com/riscv/sail-riscv/tree/master/model/extensions/V[RISC-V Vector Sail Model].

--- a/src/unpriv/zvabd.adoc
+++ b/src/unpriv/zvabd.adoc
@@ -1,5 +1,5 @@
 [[ext:zvabd]]
-=== ext:zvabd[] Vector Extension for Integer Vector Absolute Difference Instructions
+=== ext:zvabd[] Vector Extension for Integer Absolute Difference
 
 ==== Introduction
 This document describes the Zvabd extension for instructions that compute the element-wise absolute difference of vectors. That is, given two vectors v and u, compute the vector y such that stem:[y_i = abs(v_i - u_i)] and stem:[y_i += abs(v_i - u_i)].
@@ -7,8 +7,6 @@ This document describes the Zvabd extension for instructions that compute the el
 These operations are widely utilized in image registration, object recognition, motion estimation and loop filters for video workloads.
 
 ==== Extension Overview
-The Zvabd extension follows the vector arithmetic instruction specification in "V" Standard Extension.
-
 Below is a list of all of the instructions that are included in the extension.
 [%autowidth]
 [%header,cols="2,4"]
@@ -26,9 +24,7 @@ Below is a list of all of the instructions that are included in the extension.
 
 NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16. Additionally, `vabs` is considered to support all the element sizes as it is quite common used and simple to implement.
 
-[#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend on ext:zve32x[].#
-
-[#norm:Zvabd_eew]#If ext:zve32x[] is supported then vabs provide support for SEW of 8, 16, and 32.# [#norm:Zvabd_eew_Zve64x]#If ext:zve64x[] is supported then vabs also add support for SEW 64.#
+[#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend upon ext:zve32x[].#
 
 ==== Pseudocode for instruction semantics
 The semantics of each instruction is expressed in a SAIL-like syntax, following the link:https://github.com/riscv/sail-riscv/tree/master/model/extensions/V[RISC-V Vector Sail Model].
@@ -61,14 +57,15 @@ Encoding::
 Description::
 [#norm:vabs_op]#An absolute value operation is performed on each element of vs2#
 
+[#norm:Zvabd_eew]#vabs provide support for SEW of 8, 16, and 32.# [#norm:Zvabd_eew_Zve64x]#If ext:zve64x[] is supported then vabs also add support for SEW 64.#
+
 Operation::
 [source,sail]
 --
 let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then {
-        result[i] = abs(signed(vs2_val[i]));
-    }
+    if mask[i] == 0b1 then
+        result[i] = to_bits(SEW, abs_int(signed(vs2_val[i])));
 }
 write_vreg(num_elem, SEW, LMUL_pow, vd, result);
 set_vstart(zeros());
@@ -111,8 +108,8 @@ Operation::
 --
 let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then {
-        result[i] = max(vs2_val[i], vs1_val[i]) - min(vs2_val[i], vs1_val[i]);
+    if mask[i] == 0b1 then {
+        result[i] = to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(vs1_val[i])));
     }
 }
 write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -156,10 +153,16 @@ Operation::
 --
 let (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then {
-        result[i] = maxu(vs2_val[i], vs1_val[i]) - minu(vs2_val[i], vs1_val[i]);
-    }
-}
+    if mask[i] == 0b1 then {
+        result[i] = {
+            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
+                           then unsigned(vs2_val[i] - vs1_val[i])
+                           else unsigned(vs1_val[i] - vs2_val[i]);
+            to_bits(SEW, abs_diff);
+        } 
+        
+    };
+};
 write_vreg(num_elem, SEW, LMUL_pow, vd, result);
 set_vstart(zeros());
 RETIRE_SUCCESS
@@ -203,8 +206,11 @@ let SEW_widen = SEW * 2;
 let LMUL_pow_widen = LMUL_pow + 1;
 let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then {
-        result[i] = to_bits_unsafe(SEW_widen, max(vs2_val[i], vs1_val[i]) - min(vs2_val[i], vs1_val[i]) ) + vd_val[i];
+    if mask[i] == 0b1 then {
+        result[i] = {
+            let diff = signed(vs2_val[i]) - signed(vs1_val[i]);
+            to_bits_unsafe(SEW_widen, signed(vd_val[i]) + abs_int(diff));
+        }
     }
 }
 write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
@@ -250,8 +256,13 @@ let SEW_widen = SEW * 2;
 let LMUL_pow_widen = LMUL_pow + 1;
 let (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
 foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then {
-        result[i] = to_bits_unsafe(SEW_widen, maxu(vs2_val[i], vs1_val[i]) - minu(vs2_val[i], vs1_val[i]) ) + vd_val[i];
+    if mask[i] == 0b1 then {
+        result[i] = {
+            let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
+                           then unsigned(vs2_val[i] - vs1_val[i])
+                           else unsigned(vs1_val[i] - vs2_val[i]);
+            to_bits_unsafe(SEW_widen, unsigned(vd_val[i]) + abs_diff);
+        }
     }
 }
 write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);

--- a/src/unpriv/zvabd.adoc
+++ b/src/unpriv/zvabd.adoc
@@ -21,7 +21,7 @@ Below is a list of all of the instructions that are included in the extension.
 
 |===
 
-NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, Zvabd are designed for only SEW=8 and SEW=16.
+NOTE: Since the targeted use cases are mostly based on 8-bit and 16-bit integer, vwabda/vwabdau are designed for only SEW=8 and SEW=16.
 
 [#norm:Zvabd_dependent_Zve32x]#The Zvabd extension depend upon ext:zve32x[].#
 
@@ -68,9 +68,6 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 
-Reserved Encodings::
-* [#norm:vabd_sew_rsv]#`SEW` is neither 8 nor 16.#
-
 Arguments::
 
 [%autowidth]
@@ -88,7 +85,7 @@ Arguments::
 Description::
 [#norm:vabd_op]#This instruction computes the absolute difference between the signed integer SEW-bit `Op1` and `Op2` elements, writing the result into the SEW-bit elements in _vd_.#
 
-[#norm:vabd_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+[#norm:vabd_sew_defined]#vabd provides support for SEW of 8, 16, and 32. If ext:zve64x[] is supported, then vabd also adds support for SEW 64.#
 
 Operation::
 [source,sail]
@@ -150,9 +147,6 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 
-Reserved Encodings::
-* [#norm:vabdu_sew_rsv]#`SEW` is neither 8 nor 16.#
-
 Arguments::
 
 [%autowidth]
@@ -170,7 +164,7 @@ Arguments::
 Description::
 [#norm:vabdu_op]#This instruction computes the absolute difference between the unsigned integer SEW-bit `Op1` and `Op2` elements, writing the result into the SEW-bit elements in _vd_.#
 
-[#norm:vabdu_sew_defined]#This instruction is defined for SEW=8 and SEW=16, otherwise the instruction encoding is reserved.#
+[#norm:vabdu_sew_defined]#vabdu provides support for SEW of 8, 16, and 32. If ext:zve64x[] is supported, then vabdu also adds support for SEW 64.#
 
 Operation::
 [source,sail]


### PR DESCRIPTION
This PR adds the Zvabd extension chapter to the unprivileged manual, as a subsection of the "Vector Extensions" chapter.

Jira: 
https://riscv.atlassian.net/browse/RVS-3896