### PR TITLE
rvwmo: add Zicfiss source/destination register listings

### DIFF
--- a/src/unpriv/rvwmo.adoc
+++ b/src/unpriv/rvwmo.adoc
@@ -363,6 +363,7 @@ infinite sequence of other memory operations.
 |csr:fflags[] |Bits 4, 3, 2, 1, 0 |csr:fcsr[]
 |csr:frm[] |entire CSR |csr:fcsr[]
 |csr:fcsr[] |Bits 7-5, 4, 3, 2, 1, 0 |csr:fflags[], csr:frm[]
+|csr:ssp[] |entire CSR |
 |===
 
 Note: read-only CSRs are not listed, as they do not participate in the
@@ -702,6 +703,30 @@ register(s) to destination register(s) as specified
 |insn:sd.{rl,aqrl}[]^*^ |_rs1_ ^A^, _rs2_ ^D^ | | |
 
 5+| ^*^ insn:ld.{aq,aqrl}[] and insn:sd.{rl,aqrl}[] are RV64-only
+|===
+
+.Zicfiss Standard Extension
+[%autowidth.stretch,float="center",align="center",cols="<,<,<,<,<",options="header"]
+|===
+||Source Registers |Destination Registers |Accumulating CSRs|
+
+|insn:sspush[]‡ |_rs2_ ^D^, csr:ssp[] ^A^ |csr:ssp[] | |
+
+|insn:c.sspush[]‡ |`x1` ^D^, csr:ssp[] ^A^ |csr:ssp[] | |
+
+|insn:sspopchk[]‡ |_rs1_, csr:ssp[] ^A^ |csr:ssp[] | |
+
+|insn:c.sspopchk[]‡ |`x5`, csr:ssp[] ^A^ |csr:ssp[] | |
+
+5+| ‡ carries a dependency from csr:ssp[] to csr:ssp[]
+
+|insn:ssrdp[] |csr:ssp[] |_rd_ | |
+
+|insn:ssamoswap.w[]† |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+|insn:ssamoswap.d[]†^*^ |_rs1_ ^A^, _rs2_ ^D^ |_rd_ | |
+
+5+| ^*^ insn:ssamoswap.d[] is RV64-only.
 |===
 
 .RV32F Standard Extension


### PR DESCRIPTION
RVWMO's source/destination tables are meant to be complete but Zicfiss isn't in them. This adds the rows (sspush, sspopchk, ssrdp, ssamoswap, compressed forms) plus an ssp entry in the CSR granularity table, like the Zabha/Zacas/Zalasr change in riscv/riscv-isa-manual#3243.

Push/pop are marked to carry ssp->ssp only — the new ssp is just old ssp +/- XLEN/8, not the pushed value, so the Accumulating CSRs column (which would pull in the GPR) doesn't fit.

On sspopchk the update is gated on rs1 matching, so rs1->ssp is arguable; listed ssp->ssp only since the new ssp derives from the old one. See also riscv/riscv-isa-manual#2782.
