### PR TITLE
Add SARV project details to marchid.md

### DIFF
--- a/marchid.md
+++ b/marchid.md
@@ -72,4 +72,4 @@ Sargantana    | BSC-LOCA                        | [Narcís Rodas](mailto:narcis.
 KianV Stealth | Hirosh Dabui                    | [Hirosh Dabui](mailto:hirosh@dabui.de)                      | 52               | https://github.com/splinedrive/kianRiscV
 RVController  | April Kolwey (cheapie)          | [April Kolwey](mailto:cheapiephp@gmail.com)                 | 53               | https://cheapiesystems.com/git/rvcontroller/
 aRVern        | Arvern Silicon                  | [Arvern Silicon](mailto:arvernsilicon@gmail.com)            | 54               | https://github.com/Arvern-Silicon
-SARV          | Amirreza Torabi                 | [Amirreza Torabi](mailto:sayyidtorabi@gmail.com)            |                  | https://github.com/Sarst04/SARV
+SARV          | Amirreza Torabi                 | [Amirreza Torabi](mailto:sayyidtorabi@gmail.com)            | 55               | https://github.com/Sarst04/SARV

--- a/marchid.md
+++ b/marchid.md
@@ -72,3 +72,4 @@ Sargantana    | BSC-LOCA                        | [Narcís Rodas](mailto:narcis.
 KianV Stealth | Hirosh Dabui                    | [Hirosh Dabui](mailto:hirosh@dabui.de)                      | 52               | https://github.com/splinedrive/kianRiscV
 RVController  | April Kolwey (cheapie)          | [April Kolwey](mailto:cheapiephp@gmail.com)                 | 53               | https://cheapiesystems.com/git/rvcontroller/
 aRVern        | Arvern Silicon                  | [Arvern Silicon](mailto:arvernsilicon@gmail.com)            | 54               | https://github.com/Arvern-Silicon
+SARV          | Amirreza Torabi                 | [Amirreza Torabi](mailto:sayyidtorabi@gmail.com)            |                  | https://github.com/Sarst04/SARV


### PR DESCRIPTION
Requesting an open-source architecture ID allocation for SARV Core.

SARV32 is an open-source 32-bit RISC-V processor core implemented in Verilog.

Repository:
https://github.com/Sarst04/SARV

ISA:
RV32IB with Zmmul, Zicond, Zicsr, Zca, Zicntr, Zihpm and Zihintpause extensions.

License:
CERN-OHL-S-2.0