### PR TITLE
Make the workflow callable from other repos

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - synchronize
       - converted_to_draft
+  workflow_call:
 
 jobs:
   dco_check:


### PR DESCRIPTION
Add workflow_call attribute.

Signed-off-by: Bill Traynor wmat@riscv.org