### PR TITLE
Fix Encoding of satp MODE field table formatting.

### DIFF
--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -1076,39 +1076,23 @@ and Sv57.
 |===
 3+|SXLEN=32
 |Value |Name |Description
-|0 +
-1
-|Bare +
-Sv32
-|No translation or protection. +
-Page-based 32-bit virtual addressing (see <<sv32>>).
+
+|0 |Bare |No translation or protection.
+|1 |Sv32 |Page-based 32-bit virtual addressing (see <<sv32>>).
+
 3+|*SXLEN=64*
 |Value |Name |Description
-|0 +
-1-7 +
-8 +
-9 +
-10 +
-11 +
-12-13 +
-14-15
-|Bare +
-- +
-Sv39 +
-Sv48 +
-Sv57 +
-Sv64 +
-- +
--
-|No translation or protection. +
-_Reserved for standard use_ +
-Page-based 39-bit virtual addressing (see <<sv39>>). +
-Page-based 48-bit virtual addressing (see <<sv48>>). +
-Page-based 57-bit virtual addressing (see <<sv57>>). +
-_Reserved for page-based 64-bit virtual addressing._ +
-_Reserved for standard use_ +
-_Designated for custom use_
+
+|0    |Bare |No translation or protection.
+|1-7  |-    |_Reserved for standard use_
+|8    |Sv39 |Page-based 39-bit virtual addressing (see <<sv39>>).
+|9    |Sv48 |Page-based 48-bit virtual addressing (see <<sv48>>).
+|10   |Sv57 |Page-based 57-bit virtual addressing (see <<sv57>>).
+|11   |Sv64 |_Reserved for page-based 64-bit virtual addressing._
+|12-13|-    |_Reserved for standard use_
+|14-15|-    |_Designated for custom use_
 |===
+
 
 [NOTE]
 ====


### PR DESCRIPTION
Fixes the layout of the Encoding of `satp` MODE field table in the supervisor chapter.

Signed-off-by: Bill Traynor wmat@riscv.org