### PR TITLE
RVA23.1 and RVB23.1 submission for Public Review

### DIFF
--- a/src/profiles/profiles.adoc
+++ b/src/profiles/profiles.adoc
@@ -9,7 +9,9 @@ include::rvi20.adoc[]
 include::rva20.adoc[]
 include::rva22.adoc[]
 include::rva23.adoc[]
+include::rva23p1.adoc[]
 include::rvb23.adoc[]
+include::rvb23p1.adoc[]
 
 // Appendices
 :appendix-number: @

--- a/src/profiles/rva23p1.adoc
+++ b/src/profiles/rva23p1.adoc
@@ -1,0 +1,61 @@
+== RVA23.1 Profiles
+
+The RVA23.1 profiles are intended to expand upon
+the RVA23 major release of the RVA Family of RISC-V Application
+Processor Profile.
+
+This is a minor release of the RVA23 Profile Family. As such, Minor
+Profiles do not contain any new mandatory extensions and are expected to be
+built on top of the extensions listed in the RVA23 profiles. For
+the sake of simplicity when referring to this profile in code or
+use in a command line argument, all instances of the period will
+be replaced with the lower case letter 'p', as in `rva23p1s64`.
+
+Only supervisor-mode (`rva23p1s64`) profiles are specified in this
+family.
+
+=== The `rva23p1s64` Profile
+
+The `rva23p1s64` profile specifies the ISA features available to a
+supervisor-mode execution environment in 64-bit applications
+processors.  `rva23p1s64` is based on and requires an `rva23s64`
+implementation.
+
+==== Optional Extensions
+
+The `rva23p1s64` profile specifies the ISA features available to a
+supervisor-mode execution environment in 64-bit applications
+processors.  `rva23p1s64` is designed to be added on to and requires
+and implementation of `rva23s64` for Mandatory Base and Mandatory
+Extensions. `rva23p1s64` only provides new Development Options and
+Expansion Options on top of the `rva23s64`.
+
+===== Localized Options
+
+There are no privileged localized options in `rva23p1s64`.
+
+===== Development Options
+
+The following are new privileged development options in `rva23p1s64`:
+
+- ext:svrsw60t59b[] PTE reserved-for-software bits.
+
+- **Ssdbltrp** Double Trap.
+
+- **Ssccfg** Supervisor Counter Delegation.
+
+===== Expansion Options
+
+The following are new privileged expansion options in `rva23p1s64`:
+
+- ext:ssctr[] Control Transfer Records, CTR.
+
+NOTE: *Ssctr* also implies inclusion of *Sscsrind* (indirect CSR access)
+
+- <<ssqosid,**Ssqosid**>> QoS identifiers.
+
+===== Transitory Options
+
+There are no privileged transitory options in `rva23p1s64`.
+
+//

--- a/src/profiles/rva23p1.adoc
+++ b/src/profiles/rva23p1.adoc
@@ -1,6 +1,6 @@
-== RVA23.1 Profiles
+== RVA23.1 Profile
 
-The RVA23.1 profiles are intended to expand upon
+The RVA23.1 profile is intended to expand upon
 the RVA23 major release of the RVA Family of RISC-V Application
 Processor Profile.
 
@@ -11,7 +11,7 @@ the sake of simplicity when referring to this profile in code or
 use in a command line argument, all instances of the period will
 be replaced with the lower case letter 'p', as in `rva23p1s64`.
 
-Only supervisor-mode (`rva23p1s64`) profiles are specified in this
+Only a supervisor-mode (`rva23p1s64`) profile is specified in this
 family.
 
 === The `rva23p1s64` Profile
@@ -23,12 +23,10 @@ implementation.
 
 ==== Optional Extensions
 
-The `rva23p1s64` profile specifies the ISA features available to a
-supervisor-mode execution environment in 64-bit applications
-processors.  `rva23p1s64` is designed to be added on to and requires
-and implementation of `rva23s64` for Mandatory Base and Mandatory
-Extensions. `rva23p1s64` only provides new Development Options and
-Expansion Options on top of the `rva23s64`.
+`rva23p1s64` is designed as an add-on and requires an implementation
+of `rva23s64` for its Mandatory Base and Mandatory Extensions.
+`rva23p1s64` only provides new Development Options and Expansion
+Options on top of the `rva23s64`.
 
 ===== Localized Options
 

--- a/src/profiles/rva23p1.adoc
+++ b/src/profiles/rva23p1.adoc
@@ -1,15 +1,12 @@
-== RVA23.1 Profile
+== RVA23.1 Profile Family
 
-The RVA23.1 profile is intended to expand upon
-the RVA23 major release of the RVA Family of RISC-V Application
-Processor Profile.
+The RVA23.1 profile family is intended to expand upon
+the RVA23 family of RISC-V Application Processor Profiles.
 
-This is a minor release of the RVA23 Profile Family. As such, Minor
-Profiles do not contain any new mandatory extensions and are expected to be
-built on top of the extensions listed in the RVA23 profiles. For
-the sake of simplicity when referring to this profile in code or
-use in a command line argument, all instances of the period will
-be replaced with the lower case letter 'p', as in `rva23p1s64`.
+This is a minor release of the RVA23 profile family. As such, it
+contains only optional extensions. The minor release number is part
+of the profile name, with the period replaced by the lowercase
+letter 'p', as in `rva23p1s64`.
 
 Only a supervisor-mode (`rva23p1s64`) profile is specified in this
 family.

--- a/src/profiles/rvb23p1.adoc
+++ b/src/profiles/rvb23p1.adoc
@@ -1,8 +1,8 @@
-== RVB23.1 Profiles
+== RVB23.1 Profile
 
-This chapter specifies the RVB23 Profile Family. RVB23.1 is the
-first minor release intended to expand upon the RVB23 major release
-of the RVB23 Family of RISC-V Application Processor Profile.
+The RVB23.1 profile is intended to expand upon
+the RVB23 major release of the RVB Family of RISC-V Application
+Processor Profile.
 
 This is a minor release of the RVB23 Profile Family. As such, Minor Profiles
 do not contain any new mandatory extensions and are expected to be
@@ -11,7 +11,7 @@ the sake of simplicity when referring to this profile in code or
 use in a command line argument, all instances of the period will
 be replaced with the lower case letter 'p', as in `rvb23p1s64`.
 
-Only supervisor-mode (`rvb23p1s64`) profiles are
+Only a supervisor-mode (`rvb23p1s64`) profile is
 specified in this family.
 
 === The `rvb23p1s64` Profile

--- a/src/profiles/rvb23p1.adoc
+++ b/src/profiles/rvb23p1.adoc
@@ -1,15 +1,12 @@
-== RVB23.1 Profile
+== RVB23.1 Profile Family
 
-The RVB23.1 profile is intended to expand upon
-the RVB23 major release of the RVB Family of RISC-V Application
-Processor Profile.
+The RVB23.1 profile family is intended to expand upon
+the RVB23 family of RISC-V Application Processor Profiles.
 
-This is a minor release of the RVB23 Profile Family. As such, Minor Profiles
-do not contain any new mandatory extensions and are expected to be
-built on top of the extensions listed in the RVB23 profiles. For
-the sake of simplicity when referring to this profile in code or
-use in a command line argument, all instances of the period will
-be replaced with the lower case letter 'p', as in `rvb23p1s64`.
+This is a minor release of the RVB23 profile family. As such, it
+contains only optional extensions. The minor release number is part
+of the profile name, with the period replaced by the lowercase
+letter 'p', as in `rvb23p1s64`.
 
 Only a supervisor-mode (`rvb23p1s64`) profile is
 specified in this family.

--- a/src/profiles/rvb23p1.adoc
+++ b/src/profiles/rvb23p1.adoc
@@ -1,0 +1,57 @@
+== RVB23.1 Profiles
+
+This chapter specifies the RVB23 Profile Family. RVB23.1 is the
+first minor release intended to expand upon the RVB23 major release
+of the RVB23 Family of RISC-V Application Processor Profile.
+
+This is a minor release of the RVB23 Profile Family. As such, Minor Profiles
+do not contain any new mandatory extensions and are expected to be
+built on top of the extensions listed in the RVB23 profiles. For
+the sake of simplicity when referring to this profile in code or
+use in a command line argument, all instances of the period will
+be replaced with the lower case letter 'p', as in `rvb23p1s64`.
+
+Only supervisor-mode (`rvb23p1s64`) profiles are
+specified in this family.
+
+=== The `rvb23p1s64` Profile
+
+The `rvb23p1s64` profile specifies the ISA features available to a
+supervisor-mode execution environment in 64-bit applications
+processors.  `rvb23p1s64` is based on and requires an `rvb23s64`
+implementation.
+
+==== Optional Extensions
+
+`rvb23p1s64` has the same unprivileged options as `rvb23u64`.
+
+The privileged options in `rvb23p1s64` are listed in the following
+sections and are additional options to the `rvb23s64` Profile.
+
+===== Localized Options
+
+There are no privileged localized options in `rvb23p1s64`.
+
+===== Development Options
+
+The following are new privileged development options in `rvb23p1s64`:
+
+- ext:svrsw60t59b[] PTE reserved-for-software bits.
+
+NOTE: *Svrsw60t59b* is used to avoid optionality in Linux kernel page tables
+
+- **Ssdbltrp** Double Trap, which is included to make trap handling more robust
+
+===== Expansion Options
+
+The following are new privileged expansion options in `rvb23p1s64`:
+
+- **Ssccfg** Supervisor Counter Delegation.
+
+- ext:ssctr[] Control Transfer Records, CTR.
+
+NOTE: *Ssctr* also implies inclusion of *Sscsrind* (indirect CSR access)
+
+- <<ssqosid,**Ssqosid**>> QoS identifiers.
+
+//


### PR DESCRIPTION
This PR supersedes #3170.

It is intended for Public Review.

Included is the v0.7.1 Frozen version of the RVA23.1 and RVB23.1 Profiles. The normative text is unchanged from the previous stand-alone documents archived at https://github.com/riscv/riscv-profiles/tree/rva23p1-rvb23p1

The intention is to move that into the new combined ISA manual, bringing only the minimum required changes.

### Why this replaces #3170

The content of this PR is byte-identical to the head of #3170 (`7f75e156`) for all three files. It is resubmitted here because the original branch could not satisfy the repository's contribution checks:

- `dco_check` requires a `Signed-off-by:` trailer on every non-bot commit. None of the 7 commits on #3170 carried one.
- `signing_check` requires every commit to be cryptographically verified. 4 of the 7 were unsigned.

The original contributor is no longer able to contribute to RISC-V International, so the sign-off and signature could not be added to those commits. RISC-V International staff are therefore carrying the submission forward, with the DCO sign-off made by the submitter of this PR. The 7 commits (including 2 merge commits) are collapsed into a single signed, signed-off commit.


### Public review comments

Addresses #3314.

Issue #3314 raised five editorial points on these documents. All five are addressed here. The changes are editorial only: no normative requirement and no extension list is altered. As a consequence the chapters are no longer byte-identical to the archived stand-alone documents at `riscv/riscv-profiles`. The differences are limited to:

- singular "Profile" in both chapter headings and the surrounding prose
- the grammar correction in the RVA23.1 optional extensions paragraph, using the wording proposed in #3314
- removal of a sentence duplicated within the RVA23.1 chapter
- rewriting the RVB23.1 opening, which incorrectly claimed to specify the entire RVB23 profile family
