### PR TITLE
Normative rule change recommended by CSC WG

### DIFF
--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -2044,10 +2044,9 @@ whether this usage will ever become common, we chose not to preclude it.
 
 ==== Guest-Page Faults
 
-[[norm:H_guest_page_fault]]
-Guest-page-fault traps may be delegated from M-mode to HS-mode under the
+[#norm:H_guest_page_fault]#Guest-page-fault traps are delegated from M-mode to HS-mode under the
 control of CSR csr:medeleg[], but cannot be delegated to other privilege
-modes. On a guest-page fault, CSR csr:mtval[] or csr:stval[] is written with the
+modes.# On a guest-page fault, CSR csr:mtval[] or csr:stval[] is written with the
 faulting guest virtual address as usual, and csr:mtval2[] or csr:htval[] is
 written either with zero or with the faulting guest physical address,
 shifted right by qty:2[bits]. CSR csr:mtinst[] or csr:htinst[] may also be written


### PR DESCRIPTION
Hypervisor: guest-page-fault traps 'are delegated'; scope tag to first sentence only