### PR TITLE
Keyword change recommended by CSC WG

### DIFF
--- a/ref/riscv-spec-norm-tags.json
+++ b/ref/riscv-spec-norm-tags.json
@@ -2544,7 +2544,7 @@
     "norm:mcyclecfg_op": "configure privilege mode filtering for the cycle and instret counters, respectively.",
     "norm:all_xinh_zero": "When all xINH bits are zero, event counting is enabled in all modes.",
     "norm:unimplemented_mode_bits": "For each bit in 61:58, if the associated privilege mode is not implemented, the bit is read-only zero.",
-    "norm:rv32_high_access": "For RV32, bits 63:32 of mcyclecfg can be accessed via the mcyclecfgh CSR, and bits 63:32 of minstretcfg can be accessed via the minstretcfgh CSR.",
+    "norm:rv32_high_access": "For RV32, bits 63:32 of mcyclecfg are accessed via the mcyclecfgh CSR, and bits 63:32 of minstretcfg are accessed via the minstretcfgh CSR.",
     "norm:csr_supervisor_access": "The content of these registers may be accessible from Supervisor level if the Smcdeleg/Ssccfg extensions are implemented.",
     "norm:counter_inhibited_behavior": "The fundamental behavior of cycle and instret is modified in that counting does not occur while executing in an inhibited privilege mode.",
     "norm:transition_counting_defined": "Further, the following defines how transitions between a non-inhibited privilege mode and an inhibited privilege mode are counted.",

--- a/src/priv/smcntrpmf.adoc
+++ b/src/priv/smcntrpmf.adoc
@@ -37,7 +37,7 @@ Smcntrpmf remedies these issues by introducing privilege mode filtering for the 
 
 [#norm:unimplemented_mode_bits]#For each bit in 61:58, if the associated privilege mode is not implemented, the bit is read-only zero.#
 
-[#norm:rv32_high_access]#For RV32, bits 63:32 of mcyclecfg can be accessed via the mcyclecfgh CSR, and bits 63:32 of minstretcfg can be accessed via the minstretcfgh CSR.#
+[#norm:rv32_high_access]#For RV32, bits 63:32 of mcyclecfg are accessed via the mcyclecfgh CSR, and bits 63:32 of minstretcfg are accessed via the minstretcfgh CSR.#
 
 [#norm:csr_supervisor_access]#The content of these registers may be accessible from Supervisor level if the Smcdeleg/Ssccfg extensions are implemented.#
 


### PR DESCRIPTION
keyword_matches row 1305. WG: change 'can be accessed' to 'are accessed' in both places.