### PR TITLE
Keyword change recommended by CSC WG

### DIFF
--- a/src/priv/smctr.adoc
+++ b/src/priv/smctr.adoc
@@ -504,7 +504,7 @@ _Consider an exception that traps from VU-mode to HS-mode, with `vsctrctl`.U=1 a
 
 ====== External Traps
 
-[#norm:exttrap_def]#External traps are traps from a privilege mode enabled for CTR recording to a privilege mode that is not enabled for CTR recording.  By default external traps are not recorded, but privileged software running in the target mode of the trap can opt-in to allowing CTR to record external traps into that mode. The `__x__ctrctl`.__x__TE bits allow M-mode, S-mode, and VS-mode to opt-in separately.#
+[#norm:exttrap_def]#External traps are traps from a privilege mode enabled for CTR recording to a privilege mode that is not enabled for CTR recording.  The `__x__ctrctl`.__x__TE bits allow M-mode, S-mode, and VS-mode to be enabled separately.#  When the `__x__ctrctl`.__x__TE bits are clear, external traps are not recorded, but privileged software running in the target mode of the trap can enable CTR to record external traps into that mode.
 
 [#norm:exttrap_requirements]#External trap recording depends not only on the target mode, but on any intervening modes, which are modes that are more privileged than the source mode but less privileged than the target mode.  Not only must the external trap enable bit for the target mode be set, but the external trap enable bit(s) for any intervening modes must also be set.#  See the table below for details.
 


### PR DESCRIPTION
keyword_matches row 1311. WG: move the 3rd sentence to 2nd and let the tag cover sentences 1-2; replace 'opt-in' with 'enable(d)'; replace 'By default' with 'When the xctrctl.xTE bits are clear'.