### PR TITLE
Keyword change recommended by CSC WG

### DIFF
--- a/normative_rule_defs/smcdeleg.yaml
+++ b/normative_rule_defs/smcdeleg.yaml
@@ -15,6 +15,9 @@ normative_rule_definitions:
   - name: smcdeleg_cde_en
     tags: ["norm:smcdeleg_cde_en"]
 
+  - name: smcdeleg_delegated_access
+    tags: ["norm:smcdeleg_delegated_access"]
+
   - name: ssccfg_illegal_sireg_cde0
     tags: ["norm:ssccfg_illegal_sireg_cde0"]
 

--- a/src/priv/smcdeleg.adoc
+++ b/src/priv/smcdeleg.adoc
@@ -36,11 +36,11 @@ The Smcdeleg and Ssccfg extensions both depend on the Sscsrind extension.
 The `mcounteren` register allows M-mode to provide the next-lower
 privilege mode with read access to select counters.[#norm:smcdeleg_cde_en]#When the Smcdeleg/Ssccfg extensions are enabled (`menvcfg`.CDE=1), it further allows M-mode to delegate select counters to S-mode.#
 
-The `siselect` (and `vsiselect`) index range 0x40-0x5F is reserved for
+[#norm:smcdeleg_delegated_access]#The `siselect` (and `vsiselect`) index range 0x40-0x5F is reserved for
 delegated counter access. When a counter _i_ is delegated
 (`mcounteren`[_i_]=1 and `menvcfg`.CDE=1), the register state associated
-with counter _i_ can be read or written via `sireg*`, while `siselect` holds
-0x40+__i__. The counter state accessible via alias CSRs is shown in
+with counter _i_ is read or written via `sireg*`, when `siselect` is
+0x40+__i__.# The counter state accessible via alias CSRs is shown in
 the table below.
 
 .Indirect HPM State Mappings


### PR DESCRIPTION
keyword_matches row 1302. WG: change 'can be' to 'is'; 'while siselect holds' ->
'when siselect'; the state-mapping table is not tagged, so tag this rule.