### PR TITLE
Keyword change recommended by CSC WG

### DIFF
--- a/normative_rule_defs/smctr.yaml
+++ b/normative_rule_defs/smctr.yaml
@@ -186,6 +186,10 @@ normative_rule_definitions:
     summary: FROZEN bit inhibits transfer recording.
     tags: ["norm:sctrstatus_frozen_op"]
 
+  - name: sctrstatus_frozen_inhibit
+    summary: When sctrstatus.FROZEN=1, transfer recording is inhibited.
+    tags: ["norm:sctrstatus_frozen_inhibit"]
+
   - name: sctrstatus_acc
     summary: Undefined bits WPRI, read-only 0 unless custom extension.
     tags: ["norm:Ssctr_sctrstatus_acc"]

--- a/src/priv/smctr.adoc
+++ b/src/priv/smctr.adoc
@@ -725,7 +725,7 @@ an implementation may opt to record CCV=0 for all calls, or those whose parent c
 
 ===== Freeze
 
-When `sctrstatus`.FROZEN=1, transfer recording is inhibited.  This bit can be set by hardware, as described below, or by software.
+[#norm:sctrstatus_frozen_inhibit]#When `sctrstatus`.FROZEN=1, transfer recording is inhibited.#
 
 [#norm:sctrstatus_frozen_set]#When `sctrctl`.LCOFIFRZ=1 and a local-counter-overflow interrupt
 (LCOFI) traps (as a result of an HPM counter overflow) to M-mode or to S-mode, `sctrstatus`.FROZEN is set by hardware. This inhibits CTR recording until software clears FROZEN. The LCOFI trap itself is not recorded.#


### PR DESCRIPTION
keyword_matches row 1315. WG: the first sentence is normative and should be tagged; remove the duplicated 'This bit can be set by hardware ...' reference.