### PR TITLE
Describe frm and fflags as standalone CSRs

### DIFF
--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -46,8 +46,9 @@ the original value into integer register _rd_, and then writing a new
 value obtained from integer register _rs1_ into csr:fcsr[].
 
 [[norm:fflags_frm_op_sz_acc]]
-The fields within the csr:fcsr[] can also be accessed individually through
-different CSR addresses, and separate assembler pseudoinstructions are defined
+The Rounding Mode and Accrued Exception Flags fields of csr:fcsr[] are also
+accessible individually as the csr:frm[] and csr:fflags[] CSRs at different CSR
+addresses, and separate assembler pseudoinstructions are defined
 for these accesses. The insn:frrm[] instruction reads the Rounding Mode field
 csr:frm[] (csr:fcsr[] bits 7{endash}5) and copies it into the least-significant three bits of
 integer register _rd_, with zero in all other bits. insn:fsrm[] swaps the value in

--- a/src/unpriv/f-st-ext.adoc
+++ b/src/unpriv/f-st-ext.adoc
@@ -45,17 +45,15 @@ into integer register _rd_. insn:fscsr[] swaps the value in csr:fcsr[] by copyin
 the original value into integer register _rd_, and then writing a new
 value obtained from integer register _rs1_ into csr:fcsr[].
 
-[[norm:fflags_frm_op_sz_acc]]
-The Rounding Mode and Accrued Exception Flags fields of csr:fcsr[] are also
+[#norm:fflags_frm_op_sz_acc]#The Rounding Mode and Accrued Exception Flags fields of csr:fcsr[] are also
 accessible individually as the csr:frm[] and csr:fflags[] CSRs at different CSR
-addresses, and separate assembler pseudoinstructions are defined
-for these accesses. The insn:frrm[] instruction reads the Rounding Mode field
-csr:frm[] (csr:fcsr[] bits 7{endash}5) and copies it into the least-significant three bits of
-integer register _rd_, with zero in all other bits. insn:fsrm[] swaps the value in
-csr:frm[] by copying the original value into integer register _rd_, and then
-writing a new value obtained from the three least-significant bits of integer
-register _rs1_ into csr:frm[]. insn:frflags[] and insn:fsflags[] are defined analogously for the
-Accrued Exception Flags field csr:fflags[] (csr:fcsr[] bits 4{endash}0).
+addresses. The csr:frm[] CSR contains the Rounding Mode field
+(csr:fcsr[] bits 7{endash}5) right-justified and zero-extended.
+The csr:fflags[] CSR contains the Accrued Exception Flags field
+(csr:fcsr[] bits 4{endash}0) right-justified and zero-extended.#
+The insn:frrm[] pseudoinstruction performs a insn:csrr[] from
+csr:frm[]. ins:fsrm[] similarly performs a ins:csrrw[] to csr:frm[].
+insn:frflags[] and insn:fsflags[] are defined analogously for csr:fflags[].
 
 [[norm:fcsr_rsv]]
 Bits 31{endash}8 of the csr:fcsr[] are reserved for other standard extensions. If


### PR DESCRIPTION
keyword_matches row 1268. WG: rewrite to admit the existence of the frm CSR. The fcsr fields frm and fflags are also individually addressable CSRs; reword the fcsr-field-access sentence to say so.