### PR TITLE
Clarify that MXR doesn't affect M-mode pointer masking

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -602,7 +602,8 @@ less privileged than M also sets csr::[mprv]=0.#
 The csr::[mxr] (Make eXecutable Readable) bit modifies the privilege with which loads access virtual memory.
 [#norm:mstatus_mxr_op]#When csr::[mxr]=0, only loads from pages marked readable (R=1 in <<sv32pte>>) will succeed.
 When csr::[mxr]=1, loads from pages marked either readable or executable (R=1 or
-X=1) will succeed.  csr::[mxr] has no effect when page-based virtual memory is not in effect.#
+X=1) will succeed.
+csr::[mxr] only affects loads whose effective privilege mode is less than M.#
 [#norm:mstatus_mxr_rdonly0_no_smode]#csr::[mxr] is read-only 0 if S-mode is not supported or if csr:satp[mode] is read-only 0; otherwise, it must be writable.#
 
 [NOTE]

--- a/src/priv/zpm.adoc
+++ b/src/priv/zpm.adoc
@@ -136,7 +136,7 @@ Pointer masking is not applied to `SFENCE.\*`, `HFENCE.*`, `SINVAL.\*`, or `HINV
 
 [NOTE]
 ====
-Note that this includes cases where page-based virtual memory is not in effect; i.e., although MXR has no effect on permissions checks when page-based virtual memory is not in effect, it is still used in determining whether or not pointer masking should be applied.
+Note that this includes cases where page-based virtual memory is not in effect; i.e., although MXR has no effect on permissions checks when page-based virtual memory is not in effect, it is still used in determining whether or not pointer masking should be applied for loads with effective privilege mode less than M.
 ====
 
 [NOTE]


### PR DESCRIPTION
The spec's intent is obvious in that if MXR did affect M-mode pointer masking, then S-mode could control M-mode's addressing behavior by writing MXR, which would be bad.  Nevertheless, this has been a source of confusion.

We don't need the old MXR text that says it is only in effect when paging is enabled, because that's redundant with the text below that says MXR doesn't affect physical memory accesses.

@nadime15 does this look OK?

cc @davidharrishmc 

Resolves #3313 