### PR TITLE
Require illegal-instruction exception on M-mode access to debug-only CSRs

### DIFF
--- a/src/priv/csrs.adoc
+++ b/src/priv/csrs.adoc
@@ -60,7 +60,7 @@ Machine-mode standard read-write CSRs `0x7A0`{endash}``0x7BF`` are reserved for
 use by the debug system. Of these CSRs, `0x7A0`{endash}``0x7AF`` are accessible
 to machine mode, whereas
 [#norm:Zicsr_debug_illegal]#`0x7B0`{endash}``0x7BF`` are only visible to debug mode.
-Implementations should raise illegal-instruction exceptions on
+Implementations must raise illegal-instruction exceptions on
 machine-mode access to the latter set of registers.#
 
 [NOTE]


### PR DESCRIPTION
Change "should" to "must" for the requirement that implementations raise an illegal-instruction exception on machine-mode access to the debug-mode-only CSRs `0x7B0`–`0x7BF`.

The surrounding text already states that these registers are only visible to debug mode, and the sentence is tagged as a normative statement (`norm:Zicsr_debug_illegal`). "Should" leaves it optional, which makes the normative tag unenforceable and the visibility statement untestable; "must" matches the intent and allows architectural tests to check the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)