### PR TITLE
Clarify that debug mode CSRs are inaccessible from machine mode

### DIFF
--- a/src/priv/csrs.adoc
+++ b/src/priv/csrs.adoc
@@ -60,7 +60,7 @@ Machine-mode standard read-write CSRs `0x7A0`{endash}``0x7BF`` are reserved for
 use by the debug system. Of these CSRs, `0x7A0`{endash}``0x7AF`` are accessible
 to machine mode, whereas
 [#norm:Zicsr_debug_illegal]#`0x7B0`{endash}``0x7BF`` are only visible to debug mode.
-Implementations should raise illegal-instruction exceptions on
+Implementations must raise illegal-instruction exceptions on
 machine-mode access to the latter set of registers.#
 
 [NOTE]


### PR DESCRIPTION
@aswaterman 

should -> must, matches apparent intent and normative rule 
per conversation of Allen and Andrew.

