### PR TITLE
Clarify that vsatp.ASID is the same width as satp.ASID

### DIFF
--- a/normative_rule_defs/hypervisor.yaml
+++ b/normative_rule_defs/hypervisor.yaml
@@ -378,6 +378,8 @@ normative_rule_definitions:
     impl-def-category: WARL
   - name: vsatp_mode_unsupported_v1
     tags: ["norm:vsatp_mode_unsupported_v1"]
+  - name: vsatp_asidlen
+    tags: ["norm:vsatp_asidlen"]
   - name: vsatp_v0
     tags: ["norm:vsatp_v0"]
   - name: vs_stage_speculative_a_bit

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -1417,6 +1417,9 @@ ignored as it is for `satp`, or the fields of `vsatp` are treated as *WARL* in
 the normal way.# [#norm:vsatp_mode_unsupported_v1]#However, when V=1, a write to `satp` with an unsupported
 MODE value _is_ ignored and no write to `vsatp` is effected.#
 
+[#norm:vsatp_asidlen]#The ASID field in the `vsatp` register has the same number of implemented bits
+as that of the `satp` register, i.e., it is ASIDLEN bits wide.#
+
 [[norm:vsatp_v0]]
 When V=0, `vsatp` does not directly affect the behavior of the machine,
 unless a virtual-machine load/store (HLV, HLVX, or HSV) or the MPRV


### PR DESCRIPTION
Fixes #3335