### PR TITLE
Restore "or vstimecmp" in norm:menvcfg_stce_op2

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -2221,12 +2221,12 @@ enabled, see <<smcdeleg>>. When CDE=0, the Smcdeleg and Ssccfg extensions appear
 [#norm:menvcfg_stce_op1]#The Sstc extension adds the `STCE` (STimecmp Enable) bit to `menvcfg` CSR.#
 [#norm:menvcfg_stce_rdonly0]#When the Sstc extension is not implemented, `STCE` is read-only zero.#
 [#norm:menvcfg_stce_op2]#The `STCE` bit enables `stimecmp` for S-mode when set to one.
-When this extension is implemented and `STCE` in `menvcfg` is zero, an attempt to access `stimecmp`
-in a mode other than M-mode raises an illegal-instruction exception, `STCE` in
-`henvcfg` is read-only zero, and `STIP` in `mip` and `sip` reverts to its
-defined behavior as if this extension is not implemented. Further, if the H
-extension is implemented, then `hip`.VSTIP also reverts its defined behavior as
-if this extension is not implemented.#
+When this extension is implemented and `STCE` in `menvcfg` is zero, an attempt
+to access `stimecmp` or `vstimecmp` in a mode other than M-mode raises an
+illegal-instruction exception, `STCE` in `henvcfg` is read-only zero, and `STIP`
+in `mip` and `sip` reverts to its defined behavior as if this extension is not
+implemented. Further, if the H extension is implemented, then `hip`.VSTIP also
+reverts its defined behavior as if this extension is not implemented.#
 
 [#norm:menvcfg_cbze_op]#The Zicboz extension adds the `CBZE` (Cache Block Zero instruction enable) field
 to `menvcfg`. When the `CBZE` field is set to 1, it enables execution of the


### PR DESCRIPTION
The rule lost "or vstimecmp" when the Sstc text was moved in #2504.

Fixes #3329