### PR TITLE
Remove misleading zeros from FENCE[.I] encoding diagrams

### DIFF
--- a/src/unpriv/images/wavedrom/mem-order.edn
+++ b/src/unpriv/images/wavedrom/mem-order.edn
@@ -4,9 +4,9 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},
-  {bits: 5,  name: 'rd', attr: ['5', '0']},
+  {bits: 5,  name: 'rd', attr: ['5']},
   {bits: 3,  name: 'funct3', attr: ['3', 'FENCE']},
-  {bits: 5,  name: 'rs1', attr: ['5', '0']},
+  {bits: 5,  name: 'rs1', attr: ['5']},
   {bits: 1,  name: 'SW', attr: 1},
   {bits: 1,  name: 'SR', attr: 1},
   {bits: 1,  name: 'SO', attr: 1},

--- a/src/unpriv/images/wavedrom/zifencei-ff.edn
+++ b/src/unpriv/images/wavedrom/zifencei-ff.edn
@@ -4,9 +4,9 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},
-  {bits: 5,  name: 'rd',    attr: ['5', '0']},
+  {bits: 5,  name: 'rd',    attr: ['5']},
   {bits: 3,  name: 'funct3', attr: ['3', 'FENCE.I']},
-  {bits: 5,  name: 'rs1',   attr: ['5', '0']},
-  {bits: 12, name: 'funct12', attr: ['12', '0']},
+  {bits: 5,  name: 'rs1',   attr: ['5']},
+  {bits: 12, name: 'funct12', attr: ['12']},
 ]}
 ....


### PR DESCRIPTION
Fixes #3336; see that issue for discussion.