### PR TITLE
Clarify that unexpected M-mode traps use RNMI interrupt trap vector

### DIFF
--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -481,7 +481,7 @@ csr:mnstatus[nmie] set to 0 is an _unexpected trap_.#
 [#norm:trap_unexp_hndl_lead-in]#In the event of a _unexpected trap_, the handling is as follows:#
 
 * [#norm:trap_unexp_hndl_rnmi]#When the Smrnmi extension is implemented and csr:mnstatus[nmie] is 1, the hart
-  traps to the RNMI handler. To deliver this trap, the csr:mnepc[] and
+  traps to the RNMI interrupt trap handler. To deliver this trap, the csr:mnepc[] and
   csr:mncause[] registers are written with the values that the _unexpected trap_ would have
   written to the csr:mepc[] and csr:mcause[] registers respectively. The privilege
   mode information fields in the csr:mnstatus[] register are written to indicate


### PR DESCRIPTION
..even though they are caused by exceptions, not interrupts.

This corresponds to the fact that mnepc, mncause, etc. are written, rather than mepc, mcause, etc.  RNMI interrupt trap handlers are written to examine the former, whereas RNMI exception trap handlers are written to examine mnepc, mncause, etc.

cc @ved-rivos @kasanovic 