### PR TITLE
Restore Zve floating-point permutation requirements

### DIFF
--- a/normative_rule_defs/v-st-ext.yaml
+++ b/normative_rule_defs/v-st-ext.yaml
@@ -1221,6 +1221,12 @@ normative_rule_definitions:
   - names: [Zve32f_dependent_F, Zve64f_dependent_F]
     tags: ["norm:Zve32f_Zve64f_dependent_F"]
 
+  - name: Zve32f_instr_perm
+    tags: ["norm:Zve32f_instr_perm"]
+
+  - name: Zve64d_instr_perm
+    tags: ["norm:Zve64d_instr_perm"]
+
   - name: misa_v_op
     tags: ["norm:misa_v_op"]
 

--- a/src/unpriv/zv.adoc
+++ b/src/unpriv/zv.adoc
@@ -15,7 +15,7 @@ and adds support for 64-bit integers.
 The extlink:zve32f[] extension includes the ext:zve32x[] functionality
 and adds single-precision floating-point support.
 The extlink:zve64f[] extension is the union of
-ext:zve64x[] and ext:zve64f[].
+ext:zve64x[] and ext:zve32f[].
 The extlink:zve64d[] extension extends ext:zve64f[] by adding
 double-precision floating-point support.
 

--- a/src/unpriv/zve32f.adoc
+++ b/src/unpriv/zve32f.adoc
@@ -12,4 +12,7 @@ ext:zve32f[] implements all vector floating-point instructions
 Vector single-width floating-point reductions
 (<<sec-vector-float-reduce>>) for EEW=32 are supported.
 
+[#norm:Zve32f_instr_perm]#ext:zve32f[] supports all vector floating-point permutation instructions
+(<<sec-vector-float-permute>>) for floating-point operands with EEW=32.#
+
 //

--- a/src/unpriv/zve64d.adoc
+++ b/src/unpriv/zve64d.adoc
@@ -15,4 +15,7 @@ Vector single-width floating-point reductions
 (<<sec-vector-float-reduce>>) for EEW=32 and EEW=64 are supported as
 well as widening reductions from FP32 to FP64.
 
+[#norm:Zve64d_instr_perm]#ext:zve64d[] supports all vector floating-point permutation instructions
+(<<sec-vector-float-permute>>) for floating-point operands with EEW=32 or EEW=64.#
+
 //


### PR DESCRIPTION
#3031 dropped the Zve floating-point permutation requirements while splitting the vector chapter.

- Restore EEW=32 support for Zve32f and EEW=32/64 for Zve64d.
- Add the corresponding normative-rule definitions.
- Fix the Zve64f union typo.

Zve64f inherits EEW=32 support from Zve32f. No encoding change.