### PR TITLE
Fix malformed and misspelt normative-rule tags

### DIFF
--- a/normative_rule_defs/c-st-ext.yaml
+++ b/normative_rule_defs/c-st-ext.yaml
@@ -35,8 +35,8 @@ normative_rule_definitions:
     tags: ["norm:c-sdsp_op"]
   - name: c-fswsp_op
     tags: ["norm:c-fswsp_op"]
-  - name: c-fsdwsp_op
-    tags: ["norm:c-fsdwsp_op"]
+  - name: c-fsdsp_op
+    tags: ["norm:c-fsdsp_op"]
   - name: c-lw_op
     tags: ["norm:c-lw_op"]
   - name: c-ld_op

--- a/normative_rule_defs/hypervisor.yaml
+++ b/normative_rule_defs/hypervisor.yaml
@@ -339,7 +339,7 @@ normative_rule_definitions:
   - names: [vsscratch_sz, vsscratch_acc, vsscratch_op]
     tags: ["norm:vsscratch_sz_acc_op"]
   - names: [vspec_sz, vspec_acc, vspec_op]
-    tags: ["norm:vspec_sz_acc_op"]
+    tags: ["norm:vsepc_sz_acc_op"]
   - name: VSEPC_WARL
     tags: ["norm:vsepc_warl"]
     impl-def-behavior: true
@@ -462,8 +462,8 @@ normative_rule_definitions:
     kind: extension
     instance: H
     impl-def-category: WARL
-  - name: mtval2_Ssdbltrap
-    tags: ["norm:mtval2_Ssdbltrap"]
+  - name: mtval2_Ssdbltrp
+    tags: ["norm:mtval2_Ssdbltrp"]
   - names: [mtinst_sz, mtinst_acc, mtinst_op]
     tags: ["norm:mtinst_sz_acc_op"]
   - name: mtinst_val

--- a/normative_rule_defs/machine.yaml
+++ b/normative_rule_defs/machine.yaml
@@ -513,8 +513,8 @@ normative_rule_definitions:
     instance: Sm
   - name: medeleg_when_rd0
     tag: "norm:medeleg_when_rd0"
-  - name: medeleg_16_no_rd0
-    tag: "norm:medeleg_16_no_rd0"
+  - name: medeleg_16_rdonly0
+    tag: "norm:medeleg_16_rdonly0"
 
   # CSR mip & mie
   - names: [mip_sz, mip_acc]

--- a/normative_rule_defs/priv-cfi.yaml
+++ b/normative_rule_defs/priv-cfi.yaml
@@ -47,7 +47,7 @@ normative_rule_definitions:
     tags: ["norm:ssmp_ssamoswap"]
   - name: ss_page_exceptions
     tags: ["norm:ssmp_ss_page_access_fault", "norm:ssmp_ss_cache_block_access_fault", "norm:ssmp_ss_implicit_access_fault", "norm:ssmp_ss_load", "norm:ss_fault_exception_code",
-      "norm:ssmp_ss_page_illegeal_access", "norm:ssmp_ss_read_only_page"]
+      "norm:ssmp_ss_page_illegal_access", "norm:ssmp_ss_read_only_page"]
   - name: ssp_xlen_aligned
     tags: ["norm:ssp_xlen_aligned"]
   - name: ssmp_ss_idempotent_memory

--- a/normative_rule_defs/smctr.yaml
+++ b/normative_rule_defs/smctr.yaml
@@ -127,7 +127,7 @@ normative_rule_definitions:
 
   - name: vsctr-s
     summary: Enable transfer recording in VS-mode.
-    tags: ["norm:vsctr-s_op"]
+    tags: ["norm:vsctrctl-s_op"]
 
   - name: vsctrctl-u
     summary: Enable transfer recording in VU-mode.
@@ -284,7 +284,7 @@ normative_rule_definitions:
 
   - name: ctr_behavior
     summary: CTR records transfers if mode enabled, type not inhibited, not frozen, and retired.
-    tags: ["norm:ctr_behavior", "norm:ctr_behavior_criteria0", "norm:ctr_behavior_criteri1", "norm:ctr_behavior_criteria2", "norm:ctr_behavior_criteria3"]
+    tags: ["norm:ctr_behavior", "norm:ctr_behavior_criteria0", "norm:ctr_behavior_criteria1", "norm:ctr_behavior_criteria2", "norm:ctr_behavior_criteria3"]
 
   - name: ctr_stack
     summary: CTR buffer operates as circular stack; overwrites oldest entries when full.

--- a/normative_rule_defs/smstateen.yaml
+++ b/normative_rule_defs/smstateen.yaml
@@ -98,6 +98,9 @@ normative_rule_definitions:
   - name: stateen0_fcsr_op
     tags: ["norm:stateen0_fcsr_op"]
 
+  - name: mstateen0_fcsr_roz
+    tags: ["norm:mstateen0_fcsr_roz"]
+
   - name: stateen0_fcsr0_misa_f0_illegal_fpu_instr
     tags: ["norm:stateen0_fcsr0_misa_f0_illegal_fpu_instr"]
 

--- a/normative_rule_defs/supervisor.yaml
+++ b/normative_rule_defs/supervisor.yaml
@@ -238,8 +238,8 @@ normative_rule_definitions:
   - names: [senvcfg_lpe_Zicfilp_acc, senvcfg_lpe_Zicfilp_op]
     tags: ["norm:senvcfg_lpe_Zicfilp"]
 
-  - names: [senvcfg_sse_Zicfilp_sz, senvcfg_sse_Zicfilp_op]
-    tags: ["norm:senvcfg_sse_Zicfilp"]
+  - names: [senvcfg_sse_Zicfiss_sz, senvcfg_sse_Zicfiss_op]
+    tags: ["norm:senvcfg_sse_Zicfiss"]
 
   - names: [satp_sz, satp_acc, satp_op, satp_mode]
     tags: ["norm:satp"]

--- a/normative_rule_defs/unpriv-cfi.yaml
+++ b/normative_rule_defs/unpriv-cfi.yaml
@@ -14,19 +14,19 @@ normative_rule_definitions:
   - name: cfi_indirect-jump_term
     tags: ["norm:cfi_indirect-jump_term"]
   - name: Zicflip_lpad_enc
-    tags: ["norm:zicflip_lpad_enc", "norm:zicflip_lpad_imm_enc"]
+    tags: ["norm:zicfilp_lpad_enc", "norm:zicfilp_lpad_imm_enc"]
   - name: Zicflip_lpad_expected
-    tags: ["norm:zicflip_lpad_expected"]
+    tags: ["norm:zicfilp_lpad_expected"]
   - name: Zicflip_indirect_branch_lpad
-    tags: ["norm:zicflip_indirect_branch_lpad"]
+    tags: ["norm:zicfilp_indirect_branch_lpad"]
   - name: Zicflip_lpad_label
-    tags: ["norm:zicflip_lpad_label"]
+    tags: ["norm:zicfilp_lpad_label"]
   - name: Zicflip_elp_lpad_expected
-    tags: ["norm:zicflip_elp_lpad_expected"]
+    tags: ["norm:zicfilp_elp_lpad_expected"]
   - name: Zicflip_lpad_enabled_instr_allowed
-    tags: ["norm:zicflip_lpad_enabled_instr_allowed"]
+    tags: ["norm:zicfilp_lpad_enabled_instr_allowed"]
   - name: Zicflip_lpad_exception
-    tags: ["norm:zicflip_lpad_enabled_exception", "norm:zicflip_lpad_alignment_exception", "norm:zicflip_lpad_label_exception", "norm:zicflip_lpad_no_sw_exception"]
+    tags: ["norm:zicfilp_lpad_enabled_exception", "norm:zicfilp_lpad_alignment_exception", "norm:zicfilp_lpad_label_exception", "norm:zicfilp_lpad_no_sw_exception"]
   - name: Zicfiss_link_reg_func
     tags: ["norm:zicfiss_link_reg_func_enter", "norm:zicfiss_link_reg_func_return", "norm:zicfiss_stack_compare"]
   - name: Zicfiss_enc

--- a/normative_rule_defs/v-st-ext.yaml
+++ b/normative_rule_defs/v-st-ext.yaml
@@ -703,7 +703,7 @@ normative_rule_definitions:
     tags: ["norm:vdivu_vdiv_vremu_vrem_op"]
 
   - names: [vwmul_op, vwmulu_op, vwmulsu_op]
-    tags: ["norm:vwmul_wmulu_vwmulsu_op"]
+    tags: ["norm:vwmul_vwmulu_vwmulsu_op"]
 
   - name: vmacc_op
     tags: ["norm:vmacc_vnmsac_vmadd_vnmsub_op", "norm:vmacc_vnmsac_vmadd_vnmsub_op_lowhalf"]
@@ -1285,8 +1285,8 @@ normative_rule_definitions:
   - name: vnclipu_vnclip_rounding
     tags: ["norm:vnclipu_vnclip_rounding"]
 
-  - name: Vf_requrires_Vx
-    tags: ["norm:Vf_requrires_Vx"]
+  - name: Vf_requires_Vx
+    tags: ["norm:Vf_requires_Vx"]
 
   - name: instrgrp_vmask_disregard_vlmul
     tags: ["norm:instrgrp_vmask_disregard_vlmul"]

--- a/normative_rule_defs/vector-crypto.yaml
+++ b/normative_rule_defs/vector-crypto.yaml
@@ -41,7 +41,7 @@ normative_rule_definitions:
     tags: ["norm:veccrypto_vsins_vd"]
 
   - names: [Zvknhb_depZve64x, Zvkn_depZve64x, Zvknc_depZve64x, Zvkng_depZve64x]
-    tags: ["norm:Zvknhb_Zvkn_Zvknc_Zvkng_depZve64x"]
+    tags: ["norm:Zvknhb_Zvkn_Zvknc_Zvkng_Zvksc_depZve64x"]
 
   - names: [Zvkb_depZve32x, Zvkg_depZve32x, Zvkned_depZve32x, Zvknha_depZve32x, Zvksed_depZve32x, Zvksh_depZve32x, Zvks_depZve32x, Zvksc_depZve32x, Zvksg_depZve32x,
       Zvkt_depZve32x]

--- a/normative_rule_defs/vector-crypto.yaml
+++ b/normative_rule_defs/vector-crypto.yaml
@@ -40,7 +40,7 @@ normative_rule_definitions:
   - name: veccrypto_vsins_vd
     tags: ["norm:veccrypto_vsins_vd"]
 
-  - names: [Zvknhb_depZve64x, Zvkn_depZve64x, Zvknc_depZve64x, Zvkng_depZve64x]
+  - names: [Zvknhb_depZve64x, Zvkn_depZve64x, Zvknc_depZve64x, Zvkng_depZve64x, Zvksc_depZve64x]
     tags: ["norm:Zvknhb_Zvkn_Zvknc_Zvkng_Zvksc_depZve64x"]
 
   - names: [Zvkb_depZve32x, Zvkg_depZve32x, Zvkned_depZve32x, Zvknha_depZve32x, Zvksed_depZve32x, Zvksh_depZve32x, Zvks_depZve32x, Zvksc_depZve32x, Zvksg_depZve32x,

--- a/normative_rule_defs/zfa.yaml
+++ b/normative_rule_defs/zfa.yaml
@@ -64,8 +64,8 @@ normative_rule_definitions:
   - name: fcvtmod-w-d_flags
     tags: ["norm:fcvtmod-w-d_flags"]
 
-  - name: fcvtmod-w-d_rsw
-    tags: ["norm:fcvtmod-w-d_rsw"]
+  - name: fcvtmod-w-d_enc
+    tags: ["norm:fcvtmod-w-d_enc"]
 
   - name: fmvh-x-d_op
     tags: ["norm:fmvh-x-d_op"]

--- a/normative_rule_defs/zfinx.yaml
+++ b/normative_rule_defs/zfinx.yaml
@@ -43,8 +43,8 @@ normative_rule_definitions:
   - name: Zhinx_x_regs
     tags: ["norm:Zhinx_x_regs"]
 
-  - name: Zfhinxmin_instrs
-    tags: ["norm:Zfhinxmin_instrs"]
+  - name: Zhinxmin_instrs
+    tags: ["norm:Zhinxmin_instrs"]
 
   - name: Zfinx_mstatus_FS_zero
     tags: ["norm:Zfinx_mstatus_FS_zero"]

--- a/normative_rule_defs/zihintntl.yaml
+++ b/normative_rule_defs/zihintntl.yaml
@@ -99,9 +99,9 @@ normative_rule_definitions:
     tags: ["norm:NTL_range"]
 
   # Prefetch interaction
-  - name: NTL_Zicob_prefetch_outer
+  - name: NTL_Zicbop_prefetch_outer
     summary: When an NTL is applied to a Zicbop prefetch hint, the cache line is prefetched into a cache outer from the level specified by the NTL
-    tags: ["norm:NTL_Zicob_prefetch_outer"]
+    tags: ["norm:NTL_Zicbop_prefetch_outer"]
 
   # Trap behavior
   - name: NTL_TRAP_BEHAVIOR

--- a/src/priv/cfi.adoc
+++ b/src/priv/cfi.adoc
@@ -277,7 +277,7 @@ either a store, an AMO, or a shadow stack instruction.
 ====
 
 Shadow stack instructions are restricted to accessing shadow stack
-(`pte.xwr=0b010`) pages. [#norm:ssmp_ss_page_illegeal_access]#Should a shadow stack instruction access a page that is
+(`pte.xwr=0b010`) pages. [#norm:ssmp_ss_page_illegal_access]#Should a shadow stack instruction access a page that is
 not designated as a shadow stack page and is not marked as read-only
 (`pte.xwr=0b001`), a store/AMO access-fault exception will be invoked.# [#norm:ssmp_ss_read_only_page]#Conversely,
 if the page being accessed by a shadow stack instruction is a read-only page, a

--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -1327,7 +1327,7 @@ include::images/bytefield/vsscratchreg.edn[]
 
 ==== Virtual Supervisor Exception Program Counter (`vsepc`) Register
 
-[[norm:vspec_sz_acc_op]]
+[[norm:vsepc_sz_acc_op]]
 The `vsepc` register is a VSXLEN-bit read/write register that is
 VS-mode’s version of supervisor register `sepc`, formatted as shown in
 <<vsepcreg>>. When V=1, `vsepc` substitutes for the
@@ -1851,7 +1851,7 @@ the instruction as indicated by the virtual address in `mtval`.
 capable of holding only an arbitrary subset of other 2-bit-shifted guest
 physical addresses, if any.
 
-[[norm:mtval2_Ssdbltrap]]
+[[norm:mtval2_Ssdbltrp]]
 The Ssdbltrap extension (See <<ssdbltrp>>) requires the implementation of
 the `mtval2` CSR.
 

--- a/src/priv/machine.adoc
+++ b/src/priv/machine.adoc
@@ -1320,7 +1320,7 @@ interrupt delegation control is located in bit 5).
 corresponding csr:medeleg[] bits should be read-only zero. In particular,
 csr:medeleg[][11] is read-only zero.#
 
-[#norm:medeleg_16_no_rd0]#The csr:medeleg[][16] is read-only zero as double trap is not delegatable.#
+[#norm:medeleg_16_rdonly0]#The csr:medeleg[][16] is read-only zero as double trap is not delegatable.#
 
 ==== Machine Interrupt (csr:mip[] and csr:mie[]) Registers
 

--- a/src/priv/smctr.adoc
+++ b/src/priv/smctr.adoc
@@ -162,7 +162,7 @@ _Because the ROI of CTR is perceived to be low for RV32 implementations, CTR doe
 [width="100%",cols="20%,80%",options="header",]
 |===
 |Field |Description
-|S |[#norm:vsctr-s_op]#Enable transfer recording in VS-mode.#
+|S |[#norm:vsctrctl-s_op]#Enable transfer recording in VS-mode.#
 |U |[#norm:vsctrctl-u_op]#Enable transfer recording in VU-mode.#
 |STE |[#norm:vsctrctl-ste_op]#Enables recording of traps to VS-mode when S=0.#  See <<External Traps>>.
 |BPFRZ |[#norm:vsctrctl-bpfrz_op]#Set `sctrstatus`.FROZEN on a breakpoint exception that traps to VS-mode.# See <<Freeze>>.
@@ -439,7 +439,7 @@ _Implementations that support Smctr/Ssctr but not Smstateen/Ssstateen may observ
 [#norm:ctr_behavior]#CTR records qualified control transfers.  Control transfers are qualified if they meet the following criteria:#
 
 * [#norm:ctr_behavior_criteria0]#The current privilege mode is enabled#
-* [#norm:ctr_behavior_criteri1]#The transfer type is not inhibited#
+* [#norm:ctr_behavior_criteria1]#The transfer type is not inhibited#
 * [#norm:ctr_behavior_criteria2]#`sctrstatus`.FROZEN is not set#
 * [#norm:ctr_behavior_criteria3]#The transfer completes/retires#
 

--- a/src/priv/smstateen.adoc
+++ b/src/priv/smstateen.adoc
@@ -252,7 +252,7 @@ relevant RISC-V standards, or the hardware is not standard-conforming.
 
 [#norm:stateen0_fcsr_op]#The FCSR bit controls access to `fcsr` for the case when floating-point
 instructions operate on `x` registers instead of `f` registers as specified by
-the Zfinx and related extensions (Zdinx, etc.).# [mstateen0_fcsr_roz]#Whenever `misa.F` = 1, FCSR bit
+the Zfinx and related extensions (Zdinx, etc.).# [#norm:mstateen0_fcsr_roz]#Whenever `misa.F` = 1, FCSR bit
 of `mstateen0` is read-only zero (and hence read-only zero in `hstateen0` and
 `sstateen0` too).# [#norm:stateen0_fcsr0_misa_f0_illegal_fpu_instr]#For convenience, when the `stateen` CSRs are implemented and
 `misa.F` = 0, then if the FCSR bit of a controlling `stateen0` CSR is zero, all

--- a/src/priv/sscofpmf.adoc
+++ b/src/priv/sscofpmf.adoc
@@ -88,7 +88,7 @@ associated OF bit.#
 the LCOFIP bit in the `mip`/`sip` registers.#
 The LCOFIP bit is cleared by software before servicing the count overflow
 interrupt resulting from one or more count overflows. The `mideleg` register controls the delegation of this interrupt to S-mode
-versus M-mode.#
+versus M-mode.
 
 [NOTE]
 ====

--- a/src/priv/supervisor.adoc
+++ b/src/priv/supervisor.adoc
@@ -956,7 +956,7 @@ apply to VU/U-mode:
 * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
 * The `LPAD` instruction operates as a no-op.
 
-[[norm:senvcfg_sse_Zicfilp]]
+[[norm:senvcfg_sse_Zicfiss]]
 The Zicfiss extension adds the `SSE` field in `senvcfg`. When the `SSE` field is
 set to 1, the Zicfiss extension is activated in VU/U-mode. When the `SSE` field
 is 0, the Zicfiss extension remains inactive in VU/U-mode, and the following

--- a/src/unpriv/cfi.adoc
+++ b/src/unpriv/cfi.adoc
@@ -74,7 +74,7 @@ specified in <<priv-backward>>.
 To enforce forward-edge CFI, the ext:zicfilp[] extension introduces
 a landing pad (insn:lpad[]) instruction. The insn:lpad[] instruction must be placed at the
 program locations that are valid targets of indirect jumps or calls.
-[#norm:zicflip_lpad_enc]#The insn:lpad[] instruction (See <<LP_INST>>) is
+[#norm:zicfilp_lpad_enc]#The insn:lpad[] instruction (See <<LP_INST>>) is
 encoded using the insn:auipc[] major opcode with _rd_=`x0`.#
 
 Compilers emit a landing pad instruction as the first instruction of an
@@ -165,7 +165,7 @@ indirect call or an indirect jump. The csr::[elp] state can be one of:
 
 The csr::[elp] state is initialized to `NO_LP_EXPECTED` by the hart upon reset.
 
-[[norm:zicflip_lpad_expected]]
+[[norm:zicfilp_lpad_expected]]
 The ext:zicfilp[] extension, when enabled, determines if an indirect call or an
 indirect jump must land on a landing pad, as specified in <<IND_CALL_JMP>>. If
 `is_lp_expected` is 1, then the hart updates the csr::[elp] to `LP_EXPECTED`.
@@ -179,7 +179,7 @@ indirect jump must land on a landing pad, as specified in <<IND_CALL_JMP>>. If
                      (rs1 != x1) && (rs1 != x5) && (rs1 != x7) ) ? 1 : 0;
 ----
 
-[[norm:zicflip_indirect_branch_lpad]]
+[[norm:zicfilp_indirect_branch_lpad]]
 An indirect branch using insn:jalr[], insn:c.jalr[], or insn:c.jr[] with `rs1` as `x7` is
 termed a _software-guarded branch_. Such branches do not need to land on a
 insn:lpad[] instruction and thus do not set csr::[elp] to `LP_EXPECTED`.
@@ -216,17 +216,17 @@ performing bounds checking on the index into the table, etc.).
 ====
 
 The landing pad may be labeled. ext:zicfilp[] extension designates the register `x7`
-for use as the landing pad label register. [#norm:zicflip_lpad_label]#To support labeled landing pads, the
+for use as the landing pad label register. [#norm:zicfilp_lpad_label]#To support labeled landing pads, the
 indirect call/jump sites establish an expected landing pad label (e.g., using
 the insn:lui[] instruction) in the bits 31:12 of the `x7` register.#
-[#norm:zicflip_lpad_imm_enc]#The insn:lpad[] instruction is encoded with a
+[#norm:zicfilp_lpad_imm_enc]#The insn:lpad[] instruction is encoded with a
 20-bit immediate value called the landing-pad-label (`LPL`) that is matched to
 the expected landing pad label. When `LPL` is encoded as zero, the
 insn:lpad[] instruction does not perform the label check and in programs
 built with this single label mode of operation the indirect call/jump sites do
 not need to establish an expected landing pad label value in `x7`.#
 
-[[norm:zicflip_elp_lpad_expected]]
+[[norm:zicfilp_elp_lpad_expected]]
 When csr::[elp] is set to `LP_EXPECTED`, if the next instruction in the instruction
 stream is not 4-byte aligned, or is not insn:lpad[], or if the landing pad label
 encoded in insn:lpad[] is not zero and does not match the expected landing pad label
@@ -261,16 +261,16 @@ the accidental landing pad.
 [[LP_INST]]
 ===== Landing Pad Instruction
 
-[#norm:zicflip_lpad_enabled_instr_allowed]#When ext:zicfilp[] is enabled, insn:lpad[] is the only instruction allowed to execute when
+[#norm:zicfilp_lpad_enabled_instr_allowed]#When ext:zicfilp[] is enabled, insn:lpad[] is the only instruction allowed to execute when
 the csr::[elp] state is `LP_EXPECTED`. If ext:zicfilp[] is not enabled then the instruction
-is a no-op.# [#norm:zicflip_lpad_enabled_exception]#If ext:zicfilp[] is enabled, the insn:lpad[] instruction causes a
+is a no-op.# [#norm:zicfilp_lpad_enabled_exception]#If ext:zicfilp[] is enabled, the insn:lpad[] instruction causes a
 software-check exception with `__x__tval` set to "`landing pad fault (code=2)`"# if
 any of the following conditions are true:
 
-* [#norm:zicflip_lpad_alignment_exception]#The `pc` is not 4-byte aligned and csr::[elp] is `LP_EXPECTED`.#
-* [#norm:zicflip_lpad_label_exception]#The csr::[elp] is `LP_EXPECTED` and the `LPL` is not zero and the `LPL` does not match the expected landing pad label in bits 31:12 of the `x7` register.#
+* [#norm:zicfilp_lpad_alignment_exception]#The `pc` is not 4-byte aligned and csr::[elp] is `LP_EXPECTED`.#
+* [#norm:zicfilp_lpad_label_exception]#The csr::[elp] is `LP_EXPECTED` and the `LPL` is not zero and the `LPL` does not match the expected landing pad label in bits 31:12 of the `x7` register.#
 
-[[norm:zicflip_lpad_no_sw_exception]]
+[[norm:zicfilp_lpad_no_sw_exception]]
 If a software-check exception is not caused then the csr::[elp] is updated to
 `NO_LP_EXPECTED`.
 

--- a/src/unpriv/cmo.adoc
+++ b/src/unpriv/cmo.adoc
@@ -878,7 +878,7 @@ Encoding::
 
 Description::
 
-[#norm:cbo-flush_op]#A insn:cbo.flush[] instruction performs a flush operation on the cache block whose
+[#norm:cbo-flush_op]#A insn:cbo.flush[] instruction performs a flush operation on the cache block
 that contains the address specified in _rs1_.# [#norm:cbo-flush_unaligned]#It is not required that _rs1_ is
 aligned to the size of a cache block.# On faults, the faulting virtual address
 is considered to be the value in rs1, rather than the base address of the cache

--- a/src/unpriv/vector-common.adoc
+++ b/src/unpriv/vector-common.adoc
@@ -2996,7 +2996,7 @@ operation.
 
 ===== Vector Widening Integer Multiply Instructions
 
-[#norm:vwmul_wmulu_vwmulsu_op]#The widening integer multiply instructions return the full 2*SEW-bit
+[#norm:vwmul_vwmulu_vwmulsu_op]#The widening integer multiply instructions return the full 2*SEW-bit
 product from an SEW-bit*SEW-bit multiply.#
 
 ----
@@ -3321,7 +3321,7 @@ values. When 16-bit and 128-bit element widths are added, they will be
 also be treated as IEEE 754-2008-compatible values.  Other
 floating-point formats may be supported in future extensions.
 
-[#norm:Vf_requrires_Vx]#Vector floating-point instructions require the presence of base scalar
+[#norm:Vf_requires_Vx]#Vector floating-point instructions require the presence of base scalar
 floating-point extensions corresponding to the supported vector
 floating-point element widths.#
 
@@ -4879,7 +4879,7 @@ Permutation instructions with scalar floating-point operands are also provided.
 
 The floating-point scalar read/write instructions transfer a single
 value between a scalar `f` register and element 0 of a vector
-register group with EMUL = ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]##The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
+register group with EMUL = ceil(EEW/VLEN).  [#norm:vfmv-f-s_vfmv-s-f_ignoreLMUL]#The instructions ignore LMUL; EMUL is computed as ceil(EEW/VLEN).#
 
 ----
 vfmv.f.s rd, vs2  # f[rd] = vs2[0] (rs1=0)

--- a/src/unpriv/zcd.adoc
+++ b/src/unpriv/zcd.adoc
@@ -19,7 +19,7 @@ register _rd_. It computes its effective address by adding the
 _zero_-extended offset, scaled by 8, to the stack pointer, `x2`. It
 expands to insn:fld[rd,offset(x2)].#
 
-[#norm:c-fsdwsp_op]#insn:c.fsdsp[] is an RV32DC/RV64DC-only instruction that stores a
+[#norm:c-fsdsp_op]#insn:c.fsdsp[] is an RV32DC/RV64DC-only instruction that stores a
 double-precision floating-point value in floating-point register _rs2_
 to memory. It computes an effective address by adding the
 _zero_-extended offset, scaled by 8, to the stack pointer, `x2`. It

--- a/src/unpriv/zfa.adoc
+++ b/src/unpriv/zfa.adoc
@@ -185,7 +185,7 @@ zero.
 Floating-point exception flags are raised the same as they would be for
 insn:fcvt.w.d[] with the same input operand.
 
-This instruction is only provided if the ext:d[] extension is implemented. [#norm:fcvtmod-w-d_rsw]#It
+This instruction is only provided if the ext:d[] extension is implemented. [#norm:fcvtmod-w-d_enc]#It
 is encoded like insn:fcvt.w.d[], but with the rs2 field set to 8 and the _rm_
 field set to 1 (RTZ). Other _rm_ values are _reserved_.#
 

--- a/src/unpriv/zfinx.adoc
+++ b/src/unpriv/zfinx.adoc
@@ -139,7 +139,7 @@ half-precision floating-point instructions that operate on the `x`
 registers. The ext:zhinxmin[] extension depends upon the ext:zfinx[] extension.
 ext:zhinx[] implies ext:zhinxmin[].
 
-[[norm:Zfhinxmin_instrs]]
+[[norm:Zhinxmin_instrs]]
 The ext:zhinxmin[] extension includes the following instructions from the
 ext:zhinx[] extension: insn:fcvt.s.h[] and insn:fcvt.h.s[]. If the ext:zdinx[] extension is
 present, the insn:fcvt.d.h[] and insn:fcvt.h.d[] instructions are also included.

--- a/src/unpriv/zihintntl.adoc
+++ b/src/unpriv/zihintntl.adoc
@@ -137,7 +137,7 @@ explicit cache management
 |Private L1/L2/L3; shared L4/L5  |L1 |L3 |L4 |L5 |P1 |P1 |PALL |ALL
 |===
 
-[#norm:NTL_Zicob_prefetch_outer]#When an insn:ntl[] instruction is applied to a
+[#norm:NTL_Zicbop_prefetch_outer]#When an insn:ntl[] instruction is applied to a
 prefetch hint in the ext:zicbop[] extension, it indicates that a cache line
 should be prefetched into a cache that is _outer_ from the level specified by
 the insn:ntl[].#

--- a/src/unpriv/zvk.adoc
+++ b/src/unpriv/zvk.adoc
@@ -474,7 +474,7 @@ likely be too burdensome for VLEN=64 implementations.
 The section introduces all of the  extensions in the Vector Cryptography
 Instruction Set Extension Specification.
 
-[#norm:Zvknhb_Zvkn_Zvknc_Zvkng_depZve64x]#The extlink:zvknhb[], extlink:zvkn[], extlink:zvknc[], extlink:zvkng[], and extlink:zvksc[] depend on ext:zve64x[].#
+[#norm:Zvknhb_Zvkn_Zvknc_Zvkng_Zvksc_depZve64x]#The extlink:zvknhb[], extlink:zvkn[], extlink:zvknc[], extlink:zvkng[], and extlink:zvksc[] depend on ext:zve64x[].#
 
 [#norm:Zvkb_Zvkg_Zvkned_Zvknha_Zvksed_Zvksh_Zvks_Zvksc_Zvksg_Zvkt_depZve32x]#All of the other Vector Crypto Extensions depend on ext:zve32x[].#
 
@@ -1343,7 +1343,7 @@ Arguments::
 |===
 
 Description::
-[[norm:vaesdf_final]] A final-round AES block cipher decryption is performed.
+[#norm:vaesdf_final]#A final-round AES block cipher decryption is performed.#
 
 [#norm:vaesdf_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from _vd_.#
 [#norm:vaesdf_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
@@ -1444,7 +1444,7 @@ Arguments::
 |===
 
 Description::
-[[norm:vaesdm_mid]] A middle-round AES block cipher decryption is performed.
+[#norm:vaesdm_mid]#A middle-round AES block cipher decryption is performed.#
 
 [#norm:vaesdm_ops]#The InvShiftRows and InvSubBytes steps are applied to each round state element group from _vd_.#
 [#norm:vaesdm_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
@@ -1550,7 +1550,7 @@ Arguments::
 |===
 
 Description::
-[[norm:vaesef_final]] A final-round encryption function of the AES block cipher is performed.
+[#norm:vaesef_final]#A final-round encryption function of the AES block cipher is performed.#
 
 [#norm:vaesef_ops]#The SubBytes and ShiftRows steps are applied to each round state element group from _vd_.#
 [#norm:vaesef_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector
@@ -1656,7 +1656,7 @@ Arguments::
 |===
 
 Description::
-[[norm:vaesem_mid]] A middle-round encryption function of the AES block cipher is performed.
+[#norm:vaesem_mid]#A middle-round encryption function of the AES block cipher is performed.#
 
 [#norm:vaesem_ops]#The SubBytes, ShiftRows, and MixColumns steps are applied to each round state element group from _vd_.#
 [#norm:vaesem_xor_form]#This is then XORed with the round key in either the corresponding element group in _vs2_ (vector-vector


### PR DESCRIPTION
Mechanical clean-up from an audit of the `norm:` tagging across all chapters. Only items with one obvious fix are included: broken anchor markup, tag names that are typos or name the wrong extension/CSR, and two typos in tagged text. Naming-convention changes, retagging, and new rules are deliberately left out.

## Anchor markup
- `smstateen.adoc`: `[mstateen0_fcsr_roz]#…#` lacked the `norm:` prefix, so the FCSR read-only-zero rule was never extracted. Prefix added and a YAML entry created.
- `sscofpmf.adoc`: stray `#` after "versus M-mode" (left over from shortening `LCOFIP_op`) rendered as a literal `#`.
- `vector-common.adoc`: `vfmv-f-s_vfmv-s-f_ignoreLMUL` opened with `##` and closed with `#`.
- `zvk.adoc`: `vaesdf_final`, `vaesdm_mid`, `vaesef_final`, `vaesem_mid` used `[[norm:x]]` on the same line as the text, which is an empty inline anchor. Converted to `[#norm:x]#…#`.

## Tag names (YAML updated to match)
| Old | New | Why |
|---|---|---|
| `zicflip_*` (11 tags) | `zicfilp_*` | extension is Zicfilp |
| `senvcfg_sse_Zicfilp` | `senvcfg_sse_Zicfiss` | SSE belongs to Zicfiss |
| `vspec_sz_acc_op` | `vsepc_sz_acc_op` | typo |
| `mtval2_Ssdbltrap` | `mtval2_Ssdbltrp` | typo |
| `c-fsdwsp_op` | `c-fsdsp_op` | typo |
| `Zfhinxmin_instrs` | `Zhinxmin_instrs` | extension is Zhinxmin |
| `ssmp_ss_page_illegeal_access` | `ssmp_ss_page_illegal_access` | typo |
| `vsctr-s_op` | `vsctrctl-s_op` | siblings are `vsctrctl-*` |
| `ctr_behavior_criteri1` | `ctr_behavior_criteria1` | typo |
| `NTL_Zicob_prefetch_outer` | `NTL_Zicbop_prefetch_outer` | typo |
| `vwmul_wmulu_vwmulsu_op` | `vwmul_vwmulu_vwmulsu_op` | typo |
| `Vf_requrires_Vx` | `Vf_requires_Vx` | typo |
| `Zvknhb_Zvkn_Zvknc_Zvkng_depZve64x` | `Zvknhb_Zvkn_Zvknc_Zvkng_Zvksc_depZve64x` | tagged sentence also lists Zvksc |
| `fcvtmod-w-d_rsw` | `fcvtmod-w-d_enc` | text is the encoding and its reserved `rm` values |
| `medeleg_16_no_rd0` | `medeleg_16_rdonly0` | text says bit 16 is read-only zero |

## Text typo (second commit, separable)
- `cmo.adoc`: "the cache block whose that contains the address".

Verified with `make build-tags build-norm-rules-json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ruxVh9LcncyTivVq1cTun

