### PR TITLE
Correct three normative rule summaries that contradict their text

### DIFF
--- a/normative_rule_defs/ssdbltrp.yaml
+++ b/normative_rule_defs/ssdbltrp.yaml
@@ -10,11 +10,9 @@ chapter_name: Ssdbltrp (S Dbl Trp)
 
 normative_rule_definitions:
   - name: HS_mode_invoke_error
-    summary: HS-mode must invoke a critical error handler in a virtual machine on a double trap in VS-mode
     tags: ["norm:HS_mode_invoke_error"]
 
   - name: M_mode_invoke_error
-    summary: M-mode must invoke a critical error handler in the OS/Hypervisor on a double trap in S/HS-mode
     tags: ["norm:M_mode_invoke_error"]
 
   - name: menvcfg_DTE

--- a/normative_rule_defs/supervisor.yaml
+++ b/normative_rule_defs/supervisor.yaml
@@ -547,7 +547,6 @@ normative_rule_definitions:
 
   # Sstc extension
   - name: stimecmp_stimecmph_sz_acc
-    summary: stimecmp is a 63-bit CSR with 64-bit precision; RV32 accesses split into stimecmp and stimecmph
     tags: ["norm:stimecmp_stimecmph_sz_acc"]
 
   - names: [mip_stip_op]


### PR DESCRIPTION
Three normative rule summaries assert something their tagged text does not.

`stimecmp_stimecmph_sz_acc` calls stimecmp a 63-bit CSR. [supervisor.adoc:1148](https://github.com/riscv/riscv-isa-manual/blob/a5be4cfb5aa9d4d325e43e066ce4aa0713b4a5c7/src/priv/supervisor.adoc#L1148-L1151) says it is a 64-bit register with 64-bit precision.

`HS_mode_invoke_error` and `M_mode_invoke_error` say HS-mode and M-mode "must invoke" a critical error handler. [ssdbltrp.adoc:5-8](https://github.com/riscv/riscv-isa-manual/blob/a5be4cfb5aa9d4d325e43e066ce4aa0713b4a5c7/src/priv/ssdbltrp.adoc#L5-L8) says the extension enables HS-mode and allows M-mode to do so. The summaries turn a permission into a requirement.
