### PR TITLE
Specify `svg` for more asciidoctor diagrams

### DIFF
--- a/src/priv/ssqosid.adoc
+++ b/src/priv/ssqosid.adoc
@@ -55,7 +55,7 @@ is used to identify a counter to monitor resource usage.#
 [[SRMCFG64]]
 .Supervisor Resource Management Configuration (`srmcfg`) register for SXLEN=64
 
-[wavedrom, , ]
+[wavedrom, ,svg]
 ....
 {reg: [
   {bits: 12, name: 'RCID'},
@@ -68,7 +68,7 @@ is used to identify a counter to monitor resource usage.#
 [[SRMCFG32]]
 .Supervisor Resource Management Configuration (`srmcfg`) register for SXLEN=32
 
-[wavedrom, , ]
+[wavedrom, ,svg]
 ....
 {reg: [
   {bits: 12, name: 'RCID'},

--- a/src/unpriv/images/wavedrom/csr-instr.edn
+++ b/src/unpriv/images/wavedrom/csr-instr.edn
@@ -12,7 +12,7 @@
 ]}
 ....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM','SYSTEM','SYSTEM'] },

--- a/src/unpriv/images/wavedrom/double-fl-compute.edn
+++ b/src/unpriv/images/wavedrom/double-fl-compute.edn
@@ -26,7 +26,7 @@
 ]}
 ....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7, name: 'opcode', attr: 'OP-FP'},
@@ -39,7 +39,7 @@
 //]}
 //....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7, name: 'opcode', attr: ['FMADD', 'FNMADD', 'FMSUB', 'FNMSUB']},

--- a/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
+++ b/src/unpriv/images/wavedrom/m-st-ext-for-int-mult.edn
@@ -13,7 +13,7 @@
 ]}
 ....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7,  name: 'opcode', attr: 'OP-32'},

--- a/src/unpriv/images/wavedrom/mem-order.edn
+++ b/src/unpriv/images/wavedrom/mem-order.edn
@@ -1,6 +1,6 @@
 //## 2.7 Memory Ordering Instructions
 
-[wavedrom,mem-order ,]
+[wavedrom,mem-order,svg]
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'MISC-MEM']},

--- a/src/unpriv/images/wavedrom/quad-cnvrt-mv.edn
+++ b/src/unpriv/images/wavedrom/quad-cnvrt-mv.edn
@@ -13,7 +13,7 @@
 ]}
 ....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7, name: 'opcode', attr: 'OP-FP'},

--- a/src/unpriv/images/wavedrom/quad-compute.edn
+++ b/src/unpriv/images/wavedrom/quad-compute.edn
@@ -26,7 +26,7 @@
 ]}
 ....
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7, name: 'opcode', attr: 'OP-FP'},
@@ -40,7 +40,7 @@
 //....
 
 
-//[wavedrom, ,]
+//[wavedrom, ,svg]
 //....
 //{reg: [
 //  {bits: 7, name: 'opcode', attr: ['FMADD', 'FNMADD', 'FMSUB', 'FNMSUB']},


### PR DESCRIPTION
I noticed some rather pixelated diagrams in the PDF manual and thought it might be an easy fix.

Before:
<img width="722" height="180" alt="before" src="https://github.com/user-attachments/assets/69c84724-12c9-4a2a-a11c-71c29ec50166" />

After:
<img width="722" height="180" alt="after" src="https://github.com/user-attachments/assets/a4003178-c833-4b19-895e-eb426bf32a59" />
