### PR TITLE
Default asciidoctor-diagram output format to svg

### DIFF
--- a/src/riscv-spec.adoc
+++ b/src/riscv-spec.adoc
@@ -13,6 +13,9 @@ endif::[]
 :experimental:
 :reproducible:
 :imagesoutdir: {docdir}/../build/images-out
+// Default output format for asciidoctor-diagram blocks (wavedrom, etc.) that do
+// not specify one; without it wavedrom would fall back to PNG.
+:diagram-format: svg
 :bibtex-file: src/resources/riscv-spec.bib
 :bibtex-order: alphabetical
 :bibtex-style: apa


### PR DESCRIPTION
Fixes #3368.

Sets `:diagram-format: svg` in the `src/riscv-spec.adoc` header so diagram blocks that omit an explicit format still render as SVG.

Without it, a plain `[wavedrom]` block silently falls back to PNG: the wavedrom converter declares `supported_formats == [:png, :svg]`, and asciidoctor-diagram picks `supported_formats[0]` when neither the block nor a document attribute specifies a format. `:diagram-format:` is the lowest-precedence rung of that lookup (block attribute → `:<type>-format:` → `:diagram-format:` → converter default), so it never overrides a block that does specify a format.

### Verification

Checked against asciidoctor-diagram 3.1.0, using the real attribute lines from the `riscv-spec.adoc` header plus a bare `[wavedrom]` block, to confirm nothing later in the header overrides the attribute:

| header | generated file |
| --- | --- |
| *(none)* | `diag-wavedrom-….png` |
| `:diagram-format: svg` | `diag-wavedrom-….svg` |
| `:wavedrom-format: svg` | `diag-wavedrom-….svg` |

### Scope

No output changes today. All 369 wavedrom blocks in `src/` already spell out `svg`, and `bytefield` only supports SVG anyway (`supported_formats == [:svg]`), so the 97 bare `[bytefield]` blocks cannot produce anything else. This is purely a safety net so a future plain `[wavedrom]` block does not silently regress to PNG — the class of drift #3364 was cleaning up.

Stripping the now-redundant `,svg` from the 369 existing blocks is intentionally left out; it would be a large mechanical diff and belongs in its own PR if wanted at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)