### PR TITLE
fix: spell Ssdbltrp correctly in the hypervisor chapter

### DIFF
--- a/src/priv/hypervisor.adoc
+++ b/src/priv/hypervisor.adoc
@@ -1852,7 +1852,7 @@ capable of holding only an arbitrary subset of other 2-bit-shifted guest
 physical addresses, if any.
 
 [[norm:mtval2_Ssdbltrp]]
-The Ssdbltrap extension (See <<ssdbltrp>>) requires the implementation of
+The Ssdbltrp extension (See <<ssdbltrp>>) requires the implementation of
 the `mtval2` CSR.
 
 ==== Machine Trap Instruction (`mtinst`) Register


### PR DESCRIPTION
## What this changes

One word. `src/priv/hypervisor.adoc:1855` reads "Ssdbltrap"; the ratified extension is **Ssdbltrp**.

```diff
-The Ssdbltrap extension (See <<ssdbltrp>>) requires the implementation of
+The Ssdbltrp extension (See <<ssdbltrp>>) requires the implementation of
```

## Why

The file already spells it correctly three lines above, in the normative anchor `[[norm:mtval2_Ssdbltrp]]`, and the cross-reference target `<<ssdbltrp>>` on the same line is correct too — only the prose is wrong. So the name currently appears both ways within three lines of each other.

This is the sole occurrence in `src/`; no other file is affected.

I noticed it while reviewing #3298, which carried the same misspelling in the new profile documents. That has been corrected there, and this is the remaining one, already on `main` and in the published manual.
